### PR TITLE
fix(workflow): sanitize BASH_ENV before running workflow steps

### DIFF
--- a/internal/workflow/env.go
+++ b/internal/workflow/env.go
@@ -46,6 +46,19 @@ func isTruthy(value string) bool {
 // tracks env map onto os.Environ().
 func buildEnvSlice(env map[string]string) []string {
 	base := os.Environ()
+
+	// bash evaluates BASH_ENV for non-interactive shells; never inherit or allow
+	// callers to provide it because workflow params and env are untrusted input.
+	const bashEnvKey = "BASH_ENV"
+	sanitized := make([]string, 0, len(base))
+	for _, entry := range base {
+		if strings.HasPrefix(entry, bashEnvKey+"=") {
+			continue
+		}
+		sanitized = append(sanitized, entry)
+	}
+	base = sanitized
+
 	if len(env) == 0 {
 		return base
 	}
@@ -54,9 +67,15 @@ func buildEnvSlice(env map[string]string) []string {
 	// Only track keys that we may override to avoid indexing unrelated env vars.
 	indexByKey := make(map[string]int, len(env))
 	remaining := len(env)
+	if _, hasBashEnvOverride := env[bashEnvKey]; hasBashEnvOverride {
+		remaining--
+	}
 	for i, entry := range base {
 		key, _, ok := strings.Cut(entry, "=")
 		if !ok {
+			continue
+		}
+		if key == bashEnvKey {
 			continue
 		}
 		if _, needsOverride := env[key]; !needsOverride {
@@ -72,6 +91,9 @@ func buildEnvSlice(env map[string]string) []string {
 	}
 
 	for k, v := range env {
+		if k == bashEnvKey {
+			continue
+		}
 		entry := k + "=" + v
 		if i, ok := indexByKey[k]; ok {
 			base[i] = entry

--- a/internal/workflow/env_test.go
+++ b/internal/workflow/env_test.go
@@ -107,6 +107,28 @@ func TestBuildEnvSlice_OverridesExisting(t *testing.T) {
 	}
 }
 
+func TestBuildEnvSlice_StripsInheritedBashEnv(t *testing.T) {
+	t.Setenv("BASH_ENV", "/tmp/workflow-test-bashenv")
+
+	slice := buildEnvSlice(nil)
+	for _, entry := range slice {
+		if strings.HasPrefix(entry, "BASH_ENV=") {
+			t.Fatalf("expected BASH_ENV to be stripped, got %q", entry)
+		}
+	}
+}
+
+func TestBuildEnvSlice_IgnoresProvidedBashEnvOverride(t *testing.T) {
+	t.Setenv("BASH_ENV", "/tmp/workflow-test-bashenv")
+
+	slice := buildEnvSlice(map[string]string{"BASH_ENV": "/tmp/workflow-param-bashenv"})
+	for _, entry := range slice {
+		if strings.HasPrefix(entry, "BASH_ENV=") {
+			t.Fatalf("expected BASH_ENV to be ignored, got %q", entry)
+		}
+	}
+}
+
 func TestParseParams_ColonSeparator(t *testing.T) {
 	params, err := ParseParams([]string{"KEY:value", "ANOTHER:val2"})
 	if err != nil {


### PR DESCRIPTION
### Motivation
- Running steps via `bash -o pipefail -c` causes Bash to evaluate `BASH_ENV` for non-interactive shells, and workflow runtime previously merged caller-provided params into the step environment allowing untrusted `BASH_ENV` to execute before each step. 
- This introduces an RCE vector when `BASH_ENV` is inherited from the process or provided as a workflow/CLI parameter. 

### Description
- Update `buildEnvSlice` to remove any inherited `BASH_ENV` entries from `os.Environ()` before building the final environment. 
- Ignore any `BASH_ENV` keys present in the caller-provided `env` map so workflow params cannot inject or override `BASH_ENV`. 
- Add focused unit tests in `internal/workflow/env_test.go` to assert that inherited `BASH_ENV` is stripped and that provided `BASH_ENV` overrides are ignored. 

### Testing
- Ran focused tests with `ASC_BYPASS_KEYCHAIN=1 go test ./internal/workflow -run 'TestBuildEnvSlice_(StripsInheritedBashEnv|IgnoresProvidedBashEnvOverride)'` and they passed. 
- Ran the whole workflow package tests with `ASC_BYPASS_KEYCHAIN=1 go test ./internal/workflow` and they passed. 
- Ran the repository test suite with `ASC_BYPASS_KEYCHAIN=1 make test` and `ASC_BYPASS_KEYCHAIN=1 go test ./...` which completed successfully in this environment. 
- `make format` failed here due to missing `gofumpt` in the environment and `make lint` failed due to a local `golangci-lint` config/version mismatch, both of which are environment/tooling issues and not regressions in the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0606100848331a6e862ec5b33916c)