### PR TITLE
xcode-cloud: return usage exit for invalid build-runs flags and add tests

### DIFF
--- a/internal/cli/cmdtest/exit_codes_test.go
+++ b/internal/cli/cmdtest/exit_codes_test.go
@@ -234,6 +234,16 @@ func TestRun_UsageValidationErrorsReturnExitUsage(t *testing.T) {
 			wantErr: "--sort must be one of",
 		},
 		{
+			name:    "xcode-cloud build-runs invalid limit",
+			args:    []string{"xcode-cloud", "build-runs", "--workflow-id", "WF_ID", "--limit", "201"},
+			wantErr: "--limit must be between 1 and 200",
+		},
+		{
+			name:    "xcode-cloud build-runs invalid next",
+			args:    []string{"xcode-cloud", "build-runs", "--next", "http://example.com/not-asc"},
+			wantErr: "--next must be an App Store Connect URL",
+		},
+		{
 			name:    "publish appstore invalid timeout",
 			args:    []string{"publish", "appstore", "--app", "APP_123", "--ipa", "app.ipa", "--version", "1.0.0", "--timeout", "-1s"},
 			wantErr: "--timeout must be greater than 0",

--- a/internal/cli/cmdtest/xcode_cloud_next_validation_test.go
+++ b/internal/cli/cmdtest/xcode_cloud_next_validation_test.go
@@ -2,6 +2,8 @@ package cmdtest
 
 import (
 	"context"
+	"errors"
+	"flag"
 	"io"
 	"net/http"
 	"path/filepath"
@@ -51,14 +53,20 @@ func runXcodeCloudInvalidNextURLCases(
 			if runErr == nil {
 				t.Fatal("expected error, got nil")
 			}
-			if !strings.Contains(runErr.Error(), test.wantErr) {
-				t.Fatalf("expected error %q, got %v", test.wantErr, runErr)
+			if errors.Is(runErr, flag.ErrHelp) {
+				if !strings.Contains(stderr, test.wantErr) {
+					t.Fatalf("expected stderr %q, got %q", test.wantErr, stderr)
+				}
+			} else {
+				if !strings.Contains(runErr.Error(), test.wantErr) {
+					t.Fatalf("expected error %q, got %v", test.wantErr, runErr)
+				}
+				if stderr != "" {
+					t.Fatalf("expected empty stderr, got %q", stderr)
+				}
 			}
 			if stdout != "" {
 				t.Fatalf("expected empty stdout, got %q", stdout)
-			}
-			if stderr != "" {
-				t.Fatalf("expected empty stderr, got %q", stderr)
 			}
 		})
 	}

--- a/internal/cli/xcodecloud/xcode_cloud_list_helpers.go
+++ b/internal/cli/xcodecloud/xcode_cloud_list_helpers.go
@@ -23,12 +23,12 @@ func runXcodeCloudPaginatedList(
 	fetchNextPage func(context.Context, *asc.Client, string) (asc.PaginatedResponse, error),
 ) error {
 	if limit != 0 && (limit < 1 || limit > 200) {
-		return fmt.Errorf("%s: --limit must be between 1 and 200", errorPrefix)
+		return shared.UsageError(fmt.Sprintf("%s: --limit must be between 1 and 200", errorPrefix))
 	}
 
 	nextURL := strings.TrimSpace(next)
 	if err := shared.ValidateNextURL(nextURL); err != nil {
-		return fmt.Errorf("%s: %w", errorPrefix, err)
+		return shared.UsageError(fmt.Sprintf("%s: %s", errorPrefix, err.Error()))
 	}
 
 	client, err := shared.GetASCClient()


### PR DESCRIPTION
### Motivation

- Invalid user flags for Xcode Cloud list endpoints (`--limit`, `--next`) were producing generic errors instead of usage errors, so user input validation did not map to the CLI usage exit code (`2`).
- Add regression coverage to ensure `xcode-cloud build-runs` invalid `--limit` and invalid `--next` scenarios remain classified as usage errors.

### Description

- Return `shared.UsageError(...)` from `runXcodeCloudPaginatedList` for invalid `--limit` to map that failure to the usage exit path instead of a generic error.
- Return `shared.UsageError(...)` from `runXcodeCloudPaginatedList` when `shared.ValidateNextURL(next)` fails so invalid `--next` values are treated as usage errors with a clear message.
- Add two usage-regression tests in `internal/cli/cmdtest/exit_codes_test.go` covering `xcode-cloud build-runs` with an out-of-range `--limit` and with an invalid `--next` value, asserting the expected usage error messages.

### Testing

- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run TestRun_UsageValidationErrorsReturnExitUsage -v` ran and passed, covering the new cases. 
- `make check-command-docs` ran and passed, verifying command docs remain in sync.
- `make format` failed in this environment because `gofumpt` is not available and `make tools` cannot fetch it (network/proxy restriction), so formatting could not be validated here.
- `make lint` failed in this environment due to a `golangci-lint` configuration/binary mismatch, so full linting could not be completed here; broader `ASC_BYPASS_KEYCHAIN=1 make test` started and executed many packages (with many tests passing) but was interrupted by the environment before full completion.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5a716bdbc832ea60cd92ccde5a1ad)