### PR TITLE
perf: move skills check off command path

### DIFF
--- a/cmd/exit_codes_test.go
+++ b/cmd/exit_codes_test.go
@@ -819,6 +819,19 @@ func TestSkillsAutoCheckDoesNotDelayForegroundCommand(t *testing.T) {
 	}
 	markerPath := filepath.Join(tmpDir, "skills-check-ran")
 	sleepPIDPath := filepath.Join(tmpDir, "skills-check-sleep-pid")
+	t.Cleanup(func() {
+		pidBytes, err := os.ReadFile(sleepPIDPath)
+		if err != nil {
+			return
+		}
+		pid, err := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
+		if err != nil {
+			return
+		}
+		if process, err := os.FindProcess(pid); err == nil {
+			_ = process.Kill()
+		}
+	})
 	scriptPath := filepath.Join(scriptDir, "skills")
 	script := "#!/bin/sh\n" +
 		"printf 'ran' > \"$SKILLS_MARKER\"\n" +
@@ -920,6 +933,7 @@ func TestSkillsAutoCheckDoesNotDelayForegroundCommand(t *testing.T) {
 				t.Fatalf("find checker sleep process: %v", findErr)
 			}
 			_ = process.Kill()
+			_ = os.Remove(sleepPIDPath)
 			break
 		}
 		if !os.IsNotExist(readErr) {

--- a/cmd/exit_codes_test.go
+++ b/cmd/exit_codes_test.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -796,6 +798,137 @@ func TestWebAuthLoginPromptInterruptSkipsSkillsAutoCheck(t *testing.T) {
 
 	if strings.Contains(output.String(), "skills updates may be available") {
 		t.Fatalf("expected no skills update notice after interrupt, got %q", output.String())
+	}
+}
+
+func TestSkillsAutoCheckDoesNotDelayForegroundCommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PTY timing regression requires a Unix shell")
+	}
+
+	tmpDir := t.TempDir()
+	binaryPath := buildASCBlackboxBinary(t)
+	configPath := filepath.Join(tmpDir, "config.json")
+	if err := os.WriteFile(configPath, []byte(`{"skills_checked_at":"2000-01-01T00:00:00Z"}`), 0o600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	scriptDir := filepath.Join(tmpDir, "bin")
+	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+		t.Fatalf("failed to create fake skills dir: %v", err)
+	}
+	markerPath := filepath.Join(tmpDir, "skills-check-ran")
+	sleepPIDPath := filepath.Join(tmpDir, "skills-check-sleep-pid")
+	scriptPath := filepath.Join(scriptDir, "skills")
+	script := "#!/bin/sh\n" +
+		"printf 'ran' > \"$SKILLS_MARKER\"\n" +
+		"sleep 10 &\n" +
+		"printf '%s' \"$!\" > \"$SKILLS_SLEEP_PID\"\n" +
+		"printf '2 updates available\\n'\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("failed to write fake skills command: %v", err)
+	}
+
+	runCmd := exec.Command(binaryPath, "completion", "--shell", "bash")
+	runCmd.Env = append(
+		isolatedCLITestEnv(configPath),
+		"ASC_SKILLS_AUTO_CHECK=1",
+		"CI=",
+		"SKILLS_MARKER="+markerPath,
+		"SKILLS_SLEEP_PID="+sleepPIDPath,
+		"PATH="+scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+
+	startedAt := time.Now()
+	ptmx, err := pty.Start(runCmd)
+	if err != nil {
+		t.Fatalf("failed to start PTY command: %v", err)
+	}
+	defer func() { _ = ptmx.Close() }()
+	output, _, readDone := startPTYCapture(ptmx, "")
+
+	waitDone := make(chan error, 1)
+	go func() {
+		waitDone <- runCmd.Wait()
+	}()
+
+	select {
+	case err = <-waitDone:
+	case <-time.After(2 * time.Second):
+		_ = runCmd.Process.Kill()
+		_ = ptmx.Close()
+		<-waitDone
+		t.Fatalf("foreground command waited for 10-second checker descendant\noutput:\n%s", output.String())
+	}
+	if err != nil {
+		t.Fatalf("foreground command failed: %v\noutput:\n%s", err, output.String())
+	}
+	if elapsed := time.Since(startedAt); elapsed >= 2*time.Second {
+		t.Fatalf("foreground command took %s, want under 2s", elapsed)
+	}
+
+	select {
+	case <-readDone:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("PTY stayed open after foreground exit\noutput:\n%s", output.String())
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, statErr := os.Stat(markerPath); statErr == nil {
+			break
+		} else if !os.IsNotExist(statErr) {
+			t.Fatalf("failed to stat skills marker: %v", statErr)
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("detached skills checker did not start")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	cachePath := filepath.Join(tmpDir, "skills-check.json")
+	lockPath := filepath.Join(tmpDir, "skills-check.lock")
+	deadline = time.Now().Add(3 * time.Second)
+	for {
+		_, cacheErr := os.Stat(cachePath)
+		_, lockErr := os.Stat(lockPath)
+		if cacheErr == nil && os.IsNotExist(lockErr) {
+			break
+		}
+		if cacheErr != nil && !os.IsNotExist(cacheErr) {
+			t.Fatalf("stat skills cache: %v", cacheErr)
+		}
+		if lockErr != nil && !os.IsNotExist(lockErr) {
+			t.Fatalf("stat skills worker lock: %v", lockErr)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("detached worker did not finish cache publication (cache: %v, lock: %v)", cacheErr, lockErr)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	deadline = time.Now().Add(2 * time.Second)
+	for {
+		pidBytes, readErr := os.ReadFile(sleepPIDPath)
+		if readErr == nil {
+			pid, parseErr := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
+			if parseErr != nil {
+				t.Fatalf("parse checker sleep PID: %v", parseErr)
+			}
+			process, findErr := os.FindProcess(pid)
+			if findErr != nil {
+				t.Fatalf("find checker sleep process: %v", findErr)
+			}
+			_ = process.Kill()
+			break
+		}
+		if !os.IsNotExist(readErr) {
+			t.Fatalf("read checker sleep PID: %v", readErr)
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("checker did not record descendant PID")
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -21,13 +21,16 @@ import (
 )
 
 var (
-	maybeCheckForSkillUpdates = install.MaybeCheckForSkillUpdates
-	emitTelemetry             = telemetry.EmitWithContext
+	maybeScheduleSkillsUpdateCheck = install.MaybeScheduleSkillsUpdateCheck
+	emitTelemetry                  = telemetry.EmitWithContext
 )
 
 // Run executes the CLI using the provided args (not including argv[0]) and version string.
 // It returns the intended process exit code.
 func Run(args []string, versionInfo string) int {
+	if install.RunSkillsCheckWorkerIfRequested() {
+		return ExitSuccess
+	}
 	defer shared.CleanupTempPrivateKeys()
 
 	// Fast path for the most common version check invocation. This avoids
@@ -120,7 +123,7 @@ func Run(args []string, versionInfo string) int {
 	}
 
 	if !renderGroupHelp && shouldRunSkillsUpdateCheck(commandName, runCtx, runErr) {
-		maybeCheckForSkillUpdates(runCtx)
+		maybeScheduleSkillsUpdateCheck()
 	}
 
 	// Write JUnit report if requested
@@ -247,7 +250,7 @@ func shouldCancelRunContextAfterError(err error) bool {
 }
 
 func shouldRunSkillsUpdateCheck(commandName string, runCtx context.Context, runErr error) bool {
-	if commandName == "asc" || commandName == "asc install-skills" {
+	if commandName == "asc" || commandName == "asc install-skills" || commandName == "asc version" {
 		return false
 	}
 	if runCtx != nil && runCtx.Err() != nil {

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -555,11 +555,11 @@ func TestRun_NoArgsShowsHelpReturnsSuccess(t *testing.T) {
 func TestRun_InvokesSkillsUpdateCheckForSubcommand(t *testing.T) {
 	resetReportFlags(t)
 
-	origCheck := maybeCheckForSkillUpdates
-	t.Cleanup(func() { maybeCheckForSkillUpdates = origCheck })
+	origCheck := maybeScheduleSkillsUpdateCheck
+	t.Cleanup(func() { maybeScheduleSkillsUpdateCheck = origCheck })
 
 	called := make(chan struct{}, 1)
-	maybeCheckForSkillUpdates = func(ctx context.Context) {
+	maybeScheduleSkillsUpdateCheck = func() {
 		select {
 		case called <- struct{}{}:
 		default:
@@ -583,11 +583,11 @@ func TestRun_InvokesSkillsUpdateCheckForSubcommand(t *testing.T) {
 func TestRun_SkipsSkillsUpdateCheckForRootInvocation(t *testing.T) {
 	resetReportFlags(t)
 
-	origCheck := maybeCheckForSkillUpdates
-	t.Cleanup(func() { maybeCheckForSkillUpdates = origCheck })
+	origCheck := maybeScheduleSkillsUpdateCheck
+	t.Cleanup(func() { maybeScheduleSkillsUpdateCheck = origCheck })
 
 	called := false
-	maybeCheckForSkillUpdates = func(ctx context.Context) {
+	maybeScheduleSkillsUpdateCheck = func() {
 		called = true
 	}
 
@@ -600,6 +600,40 @@ func TestRun_SkipsSkillsUpdateCheckForRootInvocation(t *testing.T) {
 
 	if called {
 		t.Fatal("expected skills update check to be skipped for root invocation")
+	}
+}
+
+func TestRun_SkipsSkillsUpdateCheckForHelpAndVersionInvocations(t *testing.T) {
+	origCheck := maybeScheduleSkillsUpdateCheck
+	t.Cleanup(func() { maybeScheduleSkillsUpdateCheck = origCheck })
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "root help", args: []string{"--help"}},
+		{name: "subcommand help", args: []string{"completion", "--help"}},
+		{name: "version flag", args: []string{"--version"}},
+		{name: "version command", args: []string{"version"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetReportFlags(t)
+			called := false
+			maybeScheduleSkillsUpdateCheck = func() {
+				called = true
+			}
+
+			_, _ = captureCommandOutput(t, func() {
+				if code := Run(tt.args, "1.0.0"); code != ExitSuccess {
+					t.Fatalf("Run() exit code = %d, want %d", code, ExitSuccess)
+				}
+			})
+			if called {
+				t.Fatalf("skills update check scheduled for %v", tt.args)
+			}
+		})
 	}
 }
 
@@ -661,6 +695,12 @@ func TestShouldRunSkillsUpdateCheck(t *testing.T) {
 	t.Run("skips for install-skills command", func(t *testing.T) {
 		if shouldRunSkillsUpdateCheck("asc install-skills", context.Background(), nil) {
 			t.Fatal("expected skills update check to be skipped for install-skills command")
+		}
+	})
+
+	t.Run("skips for version command", func(t *testing.T) {
+		if shouldRunSkillsUpdateCheck("asc version", context.Background(), nil) {
+			t.Fatal("expected skills update check to be skipped for version command")
 		}
 	})
 

--- a/internal/cli/install/skills_check.go
+++ b/internal/cli/install/skills_check.go
@@ -39,9 +39,10 @@ const (
 )
 
 var (
-	lookupSkillsCheckCLI      = exec.LookPath
-	errSkillsCheckUnavailable = errors.New("skills check command unavailable")
-	skillsCheckClaimMu        sync.Mutex
+	lookupSkillsCheckCLI           = exec.LookPath
+	errSkillsCheckUnavailable      = errors.New("skills check command unavailable")
+	releaseSkillsCheckClaimGuardFn = releaseSkillsCheckClaimGuard
+	skillsCheckClaimMu             sync.Mutex
 )
 
 type skillsCheckCache struct {
@@ -297,14 +298,17 @@ func defaultClaimSkillsCheckWorker(path string, now time.Time) (string, bool, er
 	}
 
 	token, claimed, claimErr := claimSkillsCheckWorkerUnderGuard(path, now)
-	guardErr := releaseSkillsCheckClaimGuard(guard)
+	guardErr := releaseSkillsCheckClaimGuardFn(guard)
 	if claimErr != nil {
 		return "", false, claimErr
+	}
+	if claimed {
+		return token, true, nil
 	}
 	if guardErr != nil {
 		return "", false, guardErr
 	}
-	return token, claimed, nil
+	return "", false, nil
 }
 
 func claimSkillsCheckWorkerUnderGuard(path string, now time.Time) (string, bool, error) {

--- a/internal/cli/install/skills_check.go
+++ b/internal/cli/install/skills_check.go
@@ -3,13 +3,15 @@ package install
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
 	"strings"
 	"time"
 
@@ -18,71 +20,375 @@ import (
 )
 
 const (
-	skillsAutoCheckEnvVar  = "ASC_SKILLS_AUTO_CHECK"
-	skillsCheckInterval    = 24 * time.Hour
-	skillsCheckTimeout     = 8 * time.Second
-	skillsCheckedAtLayout  = time.RFC3339
-	skillsUpdateMessageFmt = "skills updates may be available. Run 'npx skills update' to refresh installed skills."
+	skillsAutoCheckEnvVar     = "ASC_SKILLS_AUTO_CHECK"
+	skillsWorkerEnvVar        = "ASC_INTERNAL_SKILLS_CHECK_WORKER"
+	skillsWorkerCacheEnvVar   = "ASC_INTERNAL_SKILLS_CHECK_CACHE"
+	skillsWorkerLockEnvVar    = "ASC_INTERNAL_SKILLS_CHECK_LOCK"
+	skillsWorkerTokenEnvVar   = "ASC_INTERNAL_SKILLS_CHECK_TOKEN"
+	skillsCheckCacheFilename  = "skills-check.json"
+	skillsCheckLockFilename   = "skills-check.lock"
+	skillsCheckInterval       = 24 * time.Hour
+	skillsCheckTimeout        = 8 * time.Second
+	skillsCheckPipeWaitDelay  = 250 * time.Millisecond
+	skillsWorkerRetryDelay    = 10 * time.Minute
+	skillsCheckedAtLayout     = time.RFC3339
+	skillsUpdateMessageFmt    = "skills updates may be available. Run 'npx skills update' to refresh installed skills."
+	maxSkillsCheckOutputBytes = 1 << 20
 )
 
 var (
-	loadConfigForSkillsCheck       = config.Load
-	persistSkillsCheckedAtForCheck = defaultPersistSkillsCheckedAt
-	nowForSkillsCheck              = time.Now
-	runSkillsCheckCommand          = defaultRunSkillsCheckCommand
-	progressEnabledForCheck        = shared.ProgressEnabled
-	lookupSkillsCheckCLI           = exec.LookPath
-	errSkillsCheckUnavailable      = errors.New("skills check command unavailable")
+	lookupSkillsCheckCLI      = exec.LookPath
+	errSkillsCheckUnavailable = errors.New("skills check command unavailable")
 )
 
-// MaybeCheckForSkillUpdates checks for skill updates once per interval and prints
-// a non-blocking stderr notice when updates appear available.
-func MaybeCheckForSkillUpdates(ctx context.Context) {
-	if !skillsAutoCheckEnabled(strings.TrimSpace(os.Getenv(skillsAutoCheckEnvVar))) {
+type skillsCheckCache struct {
+	CheckedAt       string `json:"checked_at"`
+	UpdateAvailable bool   `json:"update_available"`
+}
+
+type skillsCheckStatePaths struct {
+	cache string
+	lock  string
+}
+
+type skillsCheckWorkerSpec struct {
+	cachePath string
+	lockPath  string
+	token     string
+}
+
+type skillsCheckLock struct {
+	Token     string `json:"token"`
+	StartedAt string `json:"started_at"`
+}
+
+type skillsCheckScheduler struct {
+	getenv          func(string) string
+	progressEnabled func() bool
+	loadConfig      func() (*config.Config, error)
+	statePaths      func() (skillsCheckStatePaths, error)
+	loadCache       func(string) (skillsCheckCache, error)
+	storeCache      func(string, skillsCheckCache) error
+	claimWorker     func(string, time.Time) (string, bool, error)
+	releaseWorker   func(string, string) error
+	startWorker     func(skillsCheckWorkerSpec) error
+	now             func() time.Time
+	stderr          io.Writer
+}
+
+type skillsCheckWorker struct {
+	runCheck      func(context.Context) (string, error)
+	storeCache    func(string, skillsCheckCache) error
+	releaseWorker func(string, string) error
+	now           func() time.Time
+	timeout       time.Duration
+}
+
+// MaybeScheduleSkillsUpdateCheck performs only bounded local work in the
+// foreground. The actual checker runs in a detached maintenance process.
+func MaybeScheduleSkillsUpdateCheck() {
+	defaultSkillsCheckScheduler().run()
+}
+
+// RunSkillsCheckWorkerIfRequested handles the private detached-worker entry
+// point before the public command tree is constructed.
+func RunSkillsCheckWorkerIfRequested() bool {
+	if strings.TrimSpace(os.Getenv(skillsWorkerEnvVar)) != "1" {
+		return false
+	}
+
+	spec, err := skillsCheckWorkerSpecFromEnvironment()
+	if err == nil {
+		_ = defaultSkillsCheckWorker().run(context.Background(), spec)
+	}
+	return true
+}
+
+func defaultSkillsCheckScheduler() skillsCheckScheduler {
+	return skillsCheckScheduler{
+		getenv:          os.Getenv,
+		progressEnabled: shared.ProgressEnabled,
+		loadConfig:      config.Load,
+		statePaths:      defaultSkillsCheckStatePaths,
+		loadCache:       defaultLoadSkillsCheckCache,
+		storeCache:      defaultStoreSkillsCheckCache,
+		claimWorker:     defaultClaimSkillsCheckWorker,
+		releaseWorker:   defaultReleaseSkillsCheckWorker,
+		startWorker:     defaultStartSkillsCheckWorker,
+		now:             time.Now,
+		stderr:          os.Stderr,
+	}
+}
+
+func defaultSkillsCheckWorker() skillsCheckWorker {
+	return skillsCheckWorker{
+		runCheck:      defaultRunSkillsCheckCommand,
+		storeCache:    defaultStoreSkillsCheckCache,
+		releaseWorker: defaultReleaseSkillsCheckWorker,
+		now:           time.Now,
+		timeout:       skillsCheckTimeout,
+	}
+}
+
+func (s skillsCheckScheduler) run() {
+	if !skillsAutoCheckEnabled(strings.TrimSpace(s.getenv(skillsAutoCheckEnvVar))) {
 		return
 	}
-	if os.Getenv("CI") != "" {
-		return
-	}
-	if !progressEnabledForCheck() {
+	if s.getenv("CI") != "" || !s.progressEnabled() {
 		return
 	}
 
-	cfg, err := loadConfigForSkillsCheck()
+	cfg, err := s.loadConfig()
+	if err != nil || cfg == nil {
+		return
+	}
+	paths, err := s.statePaths()
 	if err != nil {
-		// Keep command execution unaffected when config is absent or unreadable.
-		return
-	}
-	if cfg == nil {
 		return
 	}
 
-	now := nowForSkillsCheck().UTC()
-	if !shouldRunSkillsCheck(now, cfg.SkillsCheckedAt) {
+	cache, err := s.loadCache(paths.cache)
+	if errors.Is(err, os.ErrNotExist) {
+		cache.CheckedAt = cfg.SkillsCheckedAt
+	} else if err != nil {
+		// A malformed or unreadable cache must not turn every command into a
+		// worker launch attempt.
 		return
 	}
 
-	checkCtx, cancel := context.WithTimeout(ctx, skillsCheckTimeout)
+	if cache.UpdateAvailable {
+		cache.UpdateAvailable = false
+		if err := s.storeCache(paths.cache, cache); err != nil {
+			return
+		}
+		fmt.Fprintln(s.stderr, skillsUpdateMessageFmt)
+	}
+
+	now := s.now().UTC()
+	if !shouldRunSkillsCheck(now, cache.CheckedAt) {
+		return
+	}
+
+	token, claimed, err := s.claimWorker(paths.lock, now)
+	if err != nil || !claimed {
+		return
+	}
+
+	spec := skillsCheckWorkerSpec{
+		cachePath: paths.cache,
+		lockPath:  paths.lock,
+		token:     token,
+	}
+	if err := s.startWorker(spec); err != nil {
+		_ = s.releaseWorker(paths.lock, token)
+	}
+}
+
+func (w skillsCheckWorker) run(ctx context.Context, spec skillsCheckWorkerSpec) error {
+	if err := validateSkillsCheckWorkerSpec(spec); err != nil {
+		return err
+	}
+
+	checkCtx, cancel := context.WithTimeout(ctx, w.timeout)
 	defer cancel()
 
-	output, runErr := runSkillsCheckCommand(checkCtx)
-	if runErr != nil {
-		// Avoid suppressing future checks when the command never actually ran due
-		// to cancellation or timeout in the parent context.
-		if !errors.Is(runErr, context.Canceled) &&
-			!errors.Is(runErr, context.DeadlineExceeded) &&
-			!errors.Is(runErr, errSkillsCheckUnavailable) {
-			_ = persistSkillsCheckedAtForCheck(now.Format(skillsCheckedAtLayout))
+	now := w.now().UTC()
+	output, runErr := w.runCheck(checkCtx)
+	if errors.Is(runErr, context.Canceled) ||
+		errors.Is(runErr, context.DeadlineExceeded) ||
+		errors.Is(runErr, errSkillsCheckUnavailable) {
+		// Keep the lease as a short retry cooldown. It becomes reclaimable if
+		// the worker is canceled, crashes, or cannot find the checker.
+		return runErr
+	}
+
+	cache := skillsCheckCache{
+		CheckedAt:       now.Format(skillsCheckedAtLayout),
+		UpdateAvailable: runErr == nil && skillsOutputHasUpdates(output),
+	}
+	if err := w.storeCache(spec.cachePath, cache); err != nil {
+		// Preserve the lease on cache failure to avoid a worker storm.
+		return err
+	}
+	if err := w.releaseWorker(spec.lockPath, spec.token); err != nil {
+		return err
+	}
+	return runErr
+}
+
+func skillsCheckWorkerSpecFromEnvironment() (skillsCheckWorkerSpec, error) {
+	spec := skillsCheckWorkerSpec{
+		cachePath: strings.TrimSpace(os.Getenv(skillsWorkerCacheEnvVar)),
+		lockPath:  strings.TrimSpace(os.Getenv(skillsWorkerLockEnvVar)),
+		token:     strings.TrimSpace(os.Getenv(skillsWorkerTokenEnvVar)),
+	}
+	return spec, validateSkillsCheckWorkerSpec(spec)
+}
+
+func validateSkillsCheckWorkerSpec(spec skillsCheckWorkerSpec) error {
+	if spec.cachePath == "" || !filepath.IsAbs(spec.cachePath) {
+		return fmt.Errorf("invalid skills check cache path")
+	}
+	if spec.lockPath == "" || !filepath.IsAbs(spec.lockPath) {
+		return fmt.Errorf("invalid skills check lock path")
+	}
+	if spec.token == "" {
+		return fmt.Errorf("invalid skills check worker token")
+	}
+	return nil
+}
+
+func defaultSkillsCheckStatePaths() (skillsCheckStatePaths, error) {
+	configPath, err := config.Path()
+	if err != nil {
+		return skillsCheckStatePaths{}, err
+	}
+	dir := filepath.Dir(configPath)
+	return skillsCheckStatePaths{
+		cache: filepath.Join(dir, skillsCheckCacheFilename),
+		lock:  filepath.Join(dir, skillsCheckLockFilename),
+	}, nil
+}
+
+func defaultLoadSkillsCheckCache(path string) (skillsCheckCache, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return skillsCheckCache{}, err
+	}
+
+	var cache skillsCheckCache
+	if err := json.Unmarshal(data, &cache); err != nil {
+		return skillsCheckCache{}, err
+	}
+	return cache, nil
+}
+
+func defaultStoreSkillsCheckCache(path string, cache skillsCheckCache) error {
+	data, err := json.MarshalIndent(cache, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+
+	_, err = shared.WriteFileNoSymlinkOverwrite(
+		path,
+		bytes.NewReader(data),
+		0o600,
+		".skills-check-*.tmp",
+		".skills-check-*.bak",
+	)
+	return err
+}
+
+func defaultClaimSkillsCheckWorker(path string, now time.Time) (string, bool, error) {
+	token, err := newSkillsCheckWorkerToken()
+	if err != nil {
+		return "", false, err
+	}
+
+	for attempt := 0; attempt < 2; attempt++ {
+		if err := createSkillsCheckLock(path, token, now); err == nil {
+			return token, true, nil
+		} else if !errors.Is(err, os.ErrExist) {
+			return "", false, err
 		}
-		return
+
+		stale, err := skillsCheckLockIsStale(path, now)
+		if err != nil || !stale {
+			return "", false, err
+		}
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return "", false, err
+		}
 	}
 
-	_ = persistSkillsCheckedAtForCheck(now.Format(skillsCheckedAtLayout))
-	if !skillsOutputHasUpdates(output) {
-		return
+	return "", false, nil
+}
+
+func createSkillsCheckLock(path, token string, now time.Time) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
 	}
 
-	fmt.Fprintln(os.Stderr, skillsUpdateMessageFmt)
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return err
+	}
+	removeOnFailure := true
+	defer func() {
+		_ = file.Close()
+		if removeOnFailure {
+			_ = os.Remove(path)
+		}
+	}()
+
+	lock := skillsCheckLock{
+		Token:     token,
+		StartedAt: now.UTC().Format(skillsCheckedAtLayout),
+	}
+	if err := json.NewEncoder(file).Encode(lock); err != nil {
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+
+	removeOnFailure = false
+	return nil
+}
+
+func skillsCheckLockIsStale(path string, now time.Time) (bool, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return false, err
+	}
+	if !info.Mode().IsRegular() {
+		return false, nil
+	}
+
+	startedAt := info.ModTime().UTC()
+	if data, readErr := os.ReadFile(path); readErr == nil {
+		var lock skillsCheckLock
+		if json.Unmarshal(data, &lock) == nil {
+			if parsed, parseErr := time.Parse(skillsCheckedAtLayout, lock.StartedAt); parseErr == nil {
+				startedAt = parsed.UTC()
+			}
+		}
+	}
+	return now.UTC().Sub(startedAt) >= skillsWorkerRetryDelay, nil
+}
+
+func defaultReleaseSkillsCheckWorker(path, token string) error {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	var lock skillsCheckLock
+	if err := json.Unmarshal(data, &lock); err != nil {
+		return err
+	}
+	if lock.Token != token {
+		return nil
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+func newSkillsCheckWorkerToken() (string, error) {
+	var value [16]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(value[:]), nil
 }
 
 func shouldRunSkillsCheck(now time.Time, lastCheckedAt string) bool {
@@ -136,17 +442,7 @@ func skillsOutputHasUpdates(output string) bool {
 func defaultRunSkillsCheckCommand(ctx context.Context) (string, error) {
 	skillsPath, err := lookupSkillsCheckCLI("skills")
 	if err == nil && !shouldSkipProjectLocalSkillsBinary(skillsPath) {
-		cmd := exec.CommandContext(ctx, skillsPath, "check")
-		// Avoid resolving project-local node_modules in the current repository.
-		cmd.Dir = skillsCheckWorkingDirectory()
-		var combined bytes.Buffer
-		cmd.Stdout = &combined
-		cmd.Stderr = &combined
-
-		if err := cmd.Run(); err != nil {
-			return combined.String(), err
-		}
-		return combined.String(), nil
+		return runSkillsCheckProcess(ctx, skillsPath, []string{"check"}, nil)
 	}
 
 	npxPath, err := lookupNpx("npx")
@@ -154,23 +450,42 @@ func defaultRunSkillsCheckCommand(ctx context.Context) (string, error) {
 		return "", errSkillsCheckUnavailable
 	}
 
-	// Fall back to the install-skills execution path while forcing offline mode.
-	cmd := exec.CommandContext(ctx, npxPath, "--offline", "--yes", "skills", "check")
-	// Avoid resolving project-local node_modules in the current repository.
+	output, runErr := runSkillsCheckProcess(
+		ctx,
+		npxPath,
+		[]string{"--offline", "--yes", "skills", "check"},
+		append(os.Environ(), "npm_config_offline=true"),
+	)
+	if runErr != nil && isUnavailableSkillsCheckOutput(output) {
+		return output, errSkillsCheckUnavailable
+	}
+	return output, runErr
+}
+
+func runSkillsCheckProcess(ctx context.Context, name string, args []string, env []string) (string, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Dir = skillsCheckWorkingDirectory()
-	// Avoid contacting npm registries during passive background checks.
-	cmd.Env = append(os.Environ(), "npm_config_offline=true")
+	if env != nil {
+		cmd.Env = env
+	}
+	cmd.WaitDelay = skillsCheckPipeWaitDelay
+
 	var combined bytes.Buffer
 	cmd.Stdout = &combined
 	cmd.Stderr = &combined
-
-	if err := cmd.Run(); err != nil {
-		if isUnavailableSkillsCheckOutput(combined.String()) {
-			return combined.String(), errSkillsCheckUnavailable
-		}
-		return combined.String(), err
+	err := cmd.Run()
+	if errors.Is(err, exec.ErrWaitDelay) && cmd.ProcessState != nil && cmd.ProcessState.Success() {
+		err = nil
 	}
-	return combined.String(), nil
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		err = ctxErr
+	}
+
+	output := combined.Bytes()
+	if len(output) > maxSkillsCheckOutputBytes {
+		output = output[:maxSkillsCheckOutputBytes]
+	}
+	return string(output), err
 }
 
 func isUnavailableSkillsCheckOutput(output string) bool {
@@ -235,158 +550,4 @@ func isPathWithin(path, root string) bool {
 		return false
 	}
 	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)))
-}
-
-func defaultPersistSkillsCheckedAt(timestamp string) error {
-	path, err := config.Path()
-	if err != nil {
-		return err
-	}
-
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return err
-	}
-
-	order, doc, err := decodeConfigObjectPreservingOrder(data)
-	if err != nil {
-		return err
-	}
-	if doc == nil {
-		doc = map[string]json.RawMessage{}
-	}
-
-	encoded, err := json.Marshal(strings.TrimSpace(timestamp))
-	if err != nil {
-		return err
-	}
-	doc["skills_checked_at"] = encoded
-	if !containsKey(order, "skills_checked_at") {
-		order = append(order, "skills_checked_at")
-	}
-
-	updated, err := marshalConfigObjectPreservingOrder(order, doc)
-	if err != nil {
-		return err
-	}
-
-	return os.WriteFile(path, updated, 0o600)
-}
-
-func decodeConfigObjectPreservingOrder(data []byte) ([]string, map[string]json.RawMessage, error) {
-	trimmed := bytes.TrimSpace(data)
-	if bytes.Equal(trimmed, []byte("null")) {
-		return []string{}, map[string]json.RawMessage{}, nil
-	}
-
-	decoder := json.NewDecoder(bytes.NewReader(trimmed))
-	firstToken, err := decoder.Token()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	delim, ok := firstToken.(json.Delim)
-	if !ok || delim != '{' {
-		return nil, nil, fmt.Errorf("config must be a JSON object")
-	}
-
-	order := make([]string, 0)
-	fields := make(map[string]json.RawMessage)
-	seen := make(map[string]struct{})
-	for decoder.More() {
-		keyToken, err := decoder.Token()
-		if err != nil {
-			return nil, nil, err
-		}
-		key, ok := keyToken.(string)
-		if !ok {
-			return nil, nil, fmt.Errorf("config key must be a string")
-		}
-
-		var rawValue json.RawMessage
-		if err := decoder.Decode(&rawValue); err != nil {
-			return nil, nil, err
-		}
-
-		if _, alreadySeen := seen[key]; !alreadySeen {
-			order = append(order, key)
-			seen[key] = struct{}{}
-		}
-		fields[key] = append(json.RawMessage(nil), rawValue...)
-	}
-
-	endToken, err := decoder.Token()
-	if err != nil {
-		return nil, nil, err
-	}
-	endDelim, ok := endToken.(json.Delim)
-	if !ok || endDelim != '}' {
-		return nil, nil, fmt.Errorf("config must end with object delimiter")
-	}
-
-	return order, fields, nil
-}
-
-func marshalConfigObjectPreservingOrder(order []string, fields map[string]json.RawMessage) ([]byte, error) {
-	if fields == nil {
-		fields = map[string]json.RawMessage{}
-	}
-
-	keys := make([]string, 0, len(fields))
-	seen := make(map[string]struct{}, len(fields))
-	for _, key := range order {
-		if _, ok := fields[key]; ok {
-			keys = append(keys, key)
-			seen[key] = struct{}{}
-		}
-	}
-
-	extraKeys := make([]string, 0)
-	for key := range fields {
-		if _, ok := seen[key]; !ok {
-			extraKeys = append(extraKeys, key)
-		}
-	}
-	sort.Strings(extraKeys)
-	keys = append(keys, extraKeys...)
-
-	var buffer bytes.Buffer
-	buffer.WriteString("{")
-	if len(keys) > 0 {
-		buffer.WriteString("\n")
-	}
-
-	for index, key := range keys {
-		keyJSON, err := json.Marshal(key)
-		if err != nil {
-			return nil, err
-		}
-
-		buffer.WriteString("  ")
-		buffer.Write(keyJSON)
-		buffer.WriteString(": ")
-
-		value := fields[key]
-		if len(value) == 0 {
-			value = []byte("null")
-		}
-		buffer.Write(value)
-
-		if index < len(keys)-1 {
-			buffer.WriteString(",")
-		}
-		buffer.WriteString("\n")
-	}
-
-	buffer.WriteString("}")
-	return buffer.Bytes(), nil
-}
-
-func containsKey(values []string, want string) bool {
-	for _, value := range values {
-		if value == want {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/cli/install/skills_check.go
+++ b/internal/cli/install/skills_check.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
@@ -27,6 +28,7 @@ const (
 	skillsWorkerTokenEnvVar   = "ASC_INTERNAL_SKILLS_CHECK_TOKEN"
 	skillsCheckCacheFilename  = "skills-check.json"
 	skillsCheckLockFilename   = "skills-check.lock"
+	skillsCheckClaimSuffix    = ".claim"
 	skillsCheckInterval       = 24 * time.Hour
 	skillsCheckTimeout        = 8 * time.Second
 	skillsCheckPipeWaitDelay  = 250 * time.Millisecond
@@ -39,6 +41,7 @@ const (
 var (
 	lookupSkillsCheckCLI      = exec.LookPath
 	errSkillsCheckUnavailable = errors.New("skills check command unavailable")
+	skillsCheckClaimMu        sync.Mutex
 )
 
 type skillsCheckCache struct {
@@ -60,6 +63,10 @@ type skillsCheckWorkerSpec struct {
 type skillsCheckLock struct {
 	Token     string `json:"token"`
 	StartedAt string `json:"started_at"`
+}
+
+type cappedSkillsCheckOutput struct {
+	data []byte
 }
 
 type skillsCheckScheduler struct {
@@ -281,6 +288,26 @@ func defaultStoreSkillsCheckCache(path string, cache skillsCheckCache) error {
 }
 
 func defaultClaimSkillsCheckWorker(path string, now time.Time) (string, bool, error) {
+	skillsCheckClaimMu.Lock()
+	defer skillsCheckClaimMu.Unlock()
+
+	guard, acquired, err := acquireSkillsCheckClaimGuard(path+skillsCheckClaimSuffix, false)
+	if err != nil || !acquired {
+		return "", false, err
+	}
+
+	token, claimed, claimErr := claimSkillsCheckWorkerUnderGuard(path, now)
+	guardErr := releaseSkillsCheckClaimGuard(guard)
+	if claimErr != nil {
+		return "", false, claimErr
+	}
+	if guardErr != nil {
+		return "", false, guardErr
+	}
+	return token, claimed, nil
+}
+
+func claimSkillsCheckWorkerUnderGuard(path string, now time.Time) (string, bool, error) {
 	token, err := newSkillsCheckWorkerToken()
 	if err != nil {
 		return "", false, err
@@ -293,16 +320,35 @@ func defaultClaimSkillsCheckWorker(path string, now time.Time) (string, bool, er
 			return "", false, err
 		}
 
-		stale, err := skillsCheckLockIsStale(path, now)
-		if err != nil || !stale {
-			return "", false, err
-		}
-		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		reclaimed, err := quarantineStaleSkillsCheckLock(path, token, now)
+		if err != nil || !reclaimed {
 			return "", false, err
 		}
 	}
 
 	return "", false, nil
+}
+
+func quarantineStaleSkillsCheckLock(path, token string, now time.Time) (bool, error) {
+	stale, err := skillsCheckLockIsStale(path, now)
+	if errors.Is(err, os.ErrNotExist) {
+		return true, nil
+	}
+	if err != nil || !stale {
+		return false, err
+	}
+
+	quarantinePath := path + ".stale-" + token
+	if err := os.Rename(path, quarantinePath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return true, nil
+		}
+		return false, err
+	}
+	if err := os.Remove(quarantinePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return false, err
+	}
+	return true, nil
 }
 
 func createSkillsCheckLock(path, token string, now time.Time) error {
@@ -362,6 +408,26 @@ func skillsCheckLockIsStale(path string, now time.Time) (bool, error) {
 }
 
 func defaultReleaseSkillsCheckWorker(path, token string) error {
+	skillsCheckClaimMu.Lock()
+	defer skillsCheckClaimMu.Unlock()
+
+	guard, acquired, err := acquireSkillsCheckClaimGuard(path+skillsCheckClaimSuffix, true)
+	if err != nil {
+		return err
+	}
+	if !acquired {
+		return nil
+	}
+
+	releaseErr := releaseSkillsCheckWorkerUnderGuard(path, token)
+	guardErr := releaseSkillsCheckClaimGuard(guard)
+	if releaseErr != nil {
+		return releaseErr
+	}
+	return guardErr
+}
+
+func releaseSkillsCheckWorkerUnderGuard(path, token string) error {
 	data, err := os.ReadFile(path)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
@@ -381,6 +447,78 @@ func defaultReleaseSkillsCheckWorker(path, token string) error {
 		return err
 	}
 	return nil
+}
+
+func acquireSkillsCheckClaimGuard(path string, wait bool) (*os.File, bool, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, false, err
+	}
+
+	created, err := shared.OpenNewFileNoFollow(path, 0o600)
+	if err == nil {
+		err = created.Close()
+	} else if errors.Is(err, os.ErrExist) {
+		err = nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+
+	file, err := openSkillsCheckClaimGuard(path)
+	if err != nil {
+		return nil, false, err
+	}
+	acquired, err := lockSkillsCheckClaimFile(file, wait)
+	if err != nil || !acquired {
+		_ = file.Close()
+		return nil, false, err
+	}
+	return file, true, nil
+}
+
+func openSkillsCheckClaimGuard(path string) (*os.File, error) {
+	before, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !before.Mode().IsRegular() {
+		return nil, fmt.Errorf("skills check claim guard must be a regular file")
+	}
+
+	file, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		return nil, err
+	}
+	closeOnFailure := true
+	defer func() {
+		if closeOnFailure {
+			_ = file.Close()
+		}
+	}()
+
+	opened, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	after, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !after.Mode().IsRegular() || !os.SameFile(before, after) || !os.SameFile(opened, after) {
+		return nil, fmt.Errorf("skills check claim guard changed while opening")
+	}
+
+	closeOnFailure = false
+	return file, nil
+}
+
+func releaseSkillsCheckClaimGuard(file *os.File) error {
+	unlockErr := unlockSkillsCheckClaimFile(file)
+	closeErr := file.Close()
+	if unlockErr != nil {
+		return unlockErr
+	}
+	return closeErr
 }
 
 func newSkillsCheckWorkerToken() (string, error) {
@@ -470,7 +608,7 @@ func runSkillsCheckProcess(ctx context.Context, name string, args []string, env 
 	}
 	cmd.WaitDelay = skillsCheckPipeWaitDelay
 
-	var combined bytes.Buffer
+	var combined cappedSkillsCheckOutput
 	cmd.Stdout = &combined
 	cmd.Stderr = &combined
 	err := cmd.Run()
@@ -481,11 +619,22 @@ func runSkillsCheckProcess(ctx context.Context, name string, args []string, env 
 		err = ctxErr
 	}
 
-	output := combined.Bytes()
-	if len(output) > maxSkillsCheckOutputBytes {
-		output = output[:maxSkillsCheckOutputBytes]
+	return combined.String(), err
+}
+
+func (output *cappedSkillsCheckOutput) Write(p []byte) (int, error) {
+	remaining := maxSkillsCheckOutputBytes - len(output.data)
+	if remaining > 0 {
+		if len(p) < remaining {
+			remaining = len(p)
+		}
+		output.data = append(output.data, p[:remaining]...)
 	}
-	return string(output), err
+	return len(p), nil
+}
+
+func (output *cappedSkillsCheckOutput) String() string {
+	return string(output.data)
 }
 
 func isUnavailableSkillsCheckOutput(output string) bool {

--- a/internal/cli/install/skills_check_lock_unix.go
+++ b/internal/cli/install/skills_check_lock_unix.go
@@ -1,0 +1,40 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package install
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func lockSkillsCheckClaimFile(file *os.File, wait bool) (bool, error) {
+	command := unix.F_SETLK
+	if wait {
+		command = unix.F_SETLKW
+	}
+	lock := unix.Flock_t{
+		Type:   unix.F_WRLCK,
+		Whence: 0,
+		Start:  0,
+		Len:    1,
+	}
+	if err := unix.FcntlFlock(file.Fd(), command, &lock); err != nil {
+		if !wait && (errors.Is(err, unix.EACCES) || errors.Is(err, unix.EAGAIN)) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func unlockSkillsCheckClaimFile(file *os.File) error {
+	lock := unix.Flock_t{
+		Type:   unix.F_UNLCK,
+		Whence: 0,
+		Start:  0,
+		Len:    1,
+	}
+	return unix.FcntlFlock(file.Fd(), unix.F_SETLK, &lock)
+}

--- a/internal/cli/install/skills_check_lock_unix.go
+++ b/internal/cli/install/skills_check_lock_unix.go
@@ -9,6 +9,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+var fcntlSkillsCheckClaim = unix.FcntlFlock
+
 func lockSkillsCheckClaimFile(file *os.File, wait bool) (bool, error) {
 	command := unix.F_SETLK
 	if wait {
@@ -20,7 +22,7 @@ func lockSkillsCheckClaimFile(file *os.File, wait bool) (bool, error) {
 		Start:  0,
 		Len:    1,
 	}
-	if err := unix.FcntlFlock(file.Fd(), command, &lock); err != nil {
+	if err := retrySkillsCheckFcntl(file.Fd(), command, &lock); err != nil {
 		if !wait && (errors.Is(err, unix.EACCES) || errors.Is(err, unix.EAGAIN)) {
 			return false, nil
 		}
@@ -36,5 +38,14 @@ func unlockSkillsCheckClaimFile(file *os.File) error {
 		Start:  0,
 		Len:    1,
 	}
-	return unix.FcntlFlock(file.Fd(), unix.F_SETLK, &lock)
+	return retrySkillsCheckFcntl(file.Fd(), unix.F_SETLK, &lock)
+}
+
+func retrySkillsCheckFcntl(fd uintptr, command int, lock *unix.Flock_t) error {
+	for {
+		err := fcntlSkillsCheckClaim(fd, command, lock)
+		if !errors.Is(err, unix.EINTR) {
+			return err
+		}
+	}
 }

--- a/internal/cli/install/skills_check_lock_unix_test.go
+++ b/internal/cli/install/skills_check_lock_unix_test.go
@@ -1,0 +1,45 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package install
+
+import (
+	"errors"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestRetrySkillsCheckFcntlRetriesInterruptedCalls(t *testing.T) {
+	original := fcntlSkillsCheckClaim
+	t.Cleanup(func() { fcntlSkillsCheckClaim = original })
+
+	calls := 0
+	fcntlSkillsCheckClaim = func(_ uintptr, _ int, _ *unix.Flock_t) error {
+		calls++
+		if calls < 3 {
+			return unix.EINTR
+		}
+		return nil
+	}
+
+	if err := retrySkillsCheckFcntl(0, unix.F_SETLKW, &unix.Flock_t{}); err != nil {
+		t.Fatalf("retrySkillsCheckFcntl() error: %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("fcntl calls = %d, want 3", calls)
+	}
+}
+
+func TestRetrySkillsCheckFcntlReturnsNonInterruptedError(t *testing.T) {
+	original := fcntlSkillsCheckClaim
+	t.Cleanup(func() { fcntlSkillsCheckClaim = original })
+
+	want := errors.New("lock failed")
+	fcntlSkillsCheckClaim = func(_ uintptr, _ int, _ *unix.Flock_t) error {
+		return want
+	}
+
+	if err := retrySkillsCheckFcntl(0, unix.F_SETLK, &unix.Flock_t{}); !errors.Is(err, want) {
+		t.Fatalf("retrySkillsCheckFcntl() error = %v, want %v", err, want)
+	}
+}

--- a/internal/cli/install/skills_check_lock_windows.go
+++ b/internal/cli/install/skills_check_lock_windows.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+package install
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockSkillsCheckClaimFile(file *os.File, wait bool) (bool, error) {
+	flags := uint32(windows.LOCKFILE_EXCLUSIVE_LOCK)
+	if !wait {
+		flags |= windows.LOCKFILE_FAIL_IMMEDIATELY
+	}
+	var overlapped windows.Overlapped
+	err := windows.LockFileEx(windows.Handle(file.Fd()), flags, 0, 1, 0, &overlapped)
+	if err == nil {
+		return true, nil
+	}
+	if !wait && (errors.Is(err, windows.ERROR_LOCK_VIOLATION) || errors.Is(err, windows.ERROR_IO_PENDING)) {
+		return false, nil
+	}
+	return false, err
+}
+
+func unlockSkillsCheckClaimFile(file *os.File) error {
+	var overlapped windows.Overlapped
+	return windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, &overlapped)
+}

--- a/internal/cli/install/skills_check_process.go
+++ b/internal/cli/install/skills_check_process.go
@@ -1,0 +1,65 @@
+package install
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func defaultStartSkillsCheckWorker(spec skillsCheckWorkerSpec) error {
+	executable, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	return startDetachedSkillsCheckProcess(
+		executable,
+		nil,
+		skillsCheckWorkerEnvironment(os.Environ(), spec),
+	)
+}
+
+func startDetachedSkillsCheckProcess(executable string, args, env []string) error {
+	devNull, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
+	if err != nil {
+		return err
+	}
+	defer devNull.Close()
+
+	cmd := exec.Command(executable, args...)
+	cmd.Env = env
+	cmd.Stdin = devNull
+	cmd.Stdout = devNull
+	cmd.Stderr = devNull
+	configureDetachedSkillsCheckProcess(cmd)
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	// The worker owns its lifecycle after Start. Release prevents the foreground
+	// process from retaining a wait obligation or zombie bookkeeping.
+	_ = cmd.Process.Release()
+	return nil
+}
+
+func skillsCheckWorkerEnvironment(base []string, spec skillsCheckWorkerSpec) []string {
+	workerKeys := map[string]struct{}{
+		skillsWorkerEnvVar:      {},
+		skillsWorkerCacheEnvVar: {},
+		skillsWorkerLockEnvVar:  {},
+		skillsWorkerTokenEnvVar: {},
+	}
+	env := make([]string, 0, len(base)+len(workerKeys))
+	for _, entry := range base {
+		key, _, _ := strings.Cut(entry, "=")
+		if _, isWorkerKey := workerKeys[key]; !isWorkerKey {
+			env = append(env, entry)
+		}
+	}
+	return append(
+		env,
+		skillsWorkerEnvVar+"=1",
+		skillsWorkerCacheEnvVar+"="+spec.cachePath,
+		skillsWorkerLockEnvVar+"="+spec.lockPath,
+		skillsWorkerTokenEnvVar+"="+spec.token,
+	)
+}

--- a/internal/cli/install/skills_check_process_test.go
+++ b/internal/cli/install/skills_check_process_test.go
@@ -1,0 +1,118 @@
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	detachedProcessHelperEnv      = "ASC_TEST_SKILLS_DETACHED_HELPER"
+	detachedProcessStartedPathEnv = "ASC_TEST_SKILLS_DETACHED_STARTED"
+	detachedProcessDonePathEnv    = "ASC_TEST_SKILLS_DETACHED_DONE"
+)
+
+func TestStartDetachedSkillsCheckProcessReturnsWithoutWaiting(t *testing.T) {
+	if os.Getenv(detachedProcessHelperEnv) == "1" {
+		startedPath := os.Getenv(detachedProcessStartedPathEnv)
+		donePath := os.Getenv(detachedProcessDonePathEnv)
+		if err := os.WriteFile(startedPath, []byte("started"), 0o600); err != nil {
+			os.Exit(2)
+		}
+		time.Sleep(time.Second)
+		if err := os.WriteFile(donePath, []byte("done"), 0o600); err != nil {
+			os.Exit(3)
+		}
+		return
+	}
+
+	tmpDir := t.TempDir()
+	startedPath := filepath.Join(tmpDir, "started")
+	donePath := filepath.Join(tmpDir, "done")
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable() error: %v", err)
+	}
+	env := append(
+		os.Environ(),
+		detachedProcessHelperEnv+"=1",
+		detachedProcessStartedPathEnv+"="+startedPath,
+		detachedProcessDonePathEnv+"="+donePath,
+	)
+
+	startedAt := time.Now()
+	err = startDetachedSkillsCheckProcess(
+		executable,
+		[]string{"-test.run=^TestStartDetachedSkillsCheckProcessReturnsWithoutWaiting$"},
+		env,
+	)
+	if err != nil {
+		t.Fatalf("startDetachedSkillsCheckProcess() error: %v", err)
+	}
+	if elapsed := time.Since(startedAt); elapsed >= 500*time.Millisecond {
+		t.Fatalf("detached launcher waited %s, want under 500ms", elapsed)
+	}
+
+	waitForTestFile(t, startedPath, 5*time.Second)
+	if _, err := os.Stat(donePath); err == nil {
+		t.Fatal("helper completed before detached launcher returned")
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("stat helper completion marker: %v", err)
+	}
+	waitForTestFile(t, donePath, 5*time.Second)
+}
+
+func TestSkillsCheckWorkerEnvironmentReplacesPrivateValues(t *testing.T) {
+	spec := skillsCheckWorkerSpec{
+		cachePath: "/new/cache",
+		lockPath:  "/new/lock",
+		token:     "new-token",
+	}
+	env := skillsCheckWorkerEnvironment([]string{
+		"PATH=/bin",
+		skillsWorkerEnvVar + "=old",
+		skillsWorkerCacheEnvVar + "=/old/cache",
+		skillsWorkerLockEnvVar + "=/old/lock",
+		skillsWorkerTokenEnvVar + "=old-token",
+	}, spec)
+
+	want := map[string]string{
+		skillsWorkerEnvVar:      "1",
+		skillsWorkerCacheEnvVar: spec.cachePath,
+		skillsWorkerLockEnvVar:  spec.lockPath,
+		skillsWorkerTokenEnvVar: spec.token,
+	}
+	counts := make(map[string]int)
+	for _, entry := range env {
+		key, value, _ := strings.Cut(entry, "=")
+		if wantValue, ok := want[key]; ok {
+			counts[key]++
+			if value != wantValue {
+				t.Fatalf("%s = %q, want %q", key, value, wantValue)
+			}
+		}
+	}
+	for key := range want {
+		if counts[key] != 1 {
+			t.Fatalf("%s occurrences = %d, want 1", key, counts[key])
+		}
+	}
+}
+
+func waitForTestFile(t *testing.T, path string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		if _, err := os.Stat(path); err == nil {
+			return
+		} else if !os.IsNotExist(err) {
+			t.Fatalf("stat %s: %v", path, err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s", path)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/internal/cli/install/skills_check_process_test.go
+++ b/internal/cli/install/skills_check_process_test.go
@@ -2,6 +2,7 @@ package install
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -12,6 +13,10 @@ const (
 	detachedProcessHelperEnv      = "ASC_TEST_SKILLS_DETACHED_HELPER"
 	detachedProcessStartedPathEnv = "ASC_TEST_SKILLS_DETACHED_STARTED"
 	detachedProcessDonePathEnv    = "ASC_TEST_SKILLS_DETACHED_DONE"
+	claimGuardHelperEnv           = "ASC_TEST_SKILLS_CLAIM_GUARD_HELPER"
+	claimGuardLockPathEnv         = "ASC_TEST_SKILLS_CLAIM_GUARD_LOCK"
+	claimGuardStartedPathEnv      = "ASC_TEST_SKILLS_CLAIM_GUARD_STARTED"
+	claimGuardReleasePathEnv      = "ASC_TEST_SKILLS_CLAIM_GUARD_RELEASE"
 )
 
 func TestStartDetachedSkillsCheckProcessReturnsWithoutWaiting(t *testing.T) {
@@ -55,13 +60,13 @@ func TestStartDetachedSkillsCheckProcessReturnsWithoutWaiting(t *testing.T) {
 		t.Fatalf("detached launcher waited %s, want under 500ms", elapsed)
 	}
 
-	waitForTestFile(t, startedPath, 5*time.Second)
+	waitForTestFile(t, startedPath)
 	if _, err := os.Stat(donePath); err == nil {
 		t.Fatal("helper completed before detached launcher returned")
 	} else if !os.IsNotExist(err) {
 		t.Fatalf("stat helper completion marker: %v", err)
 	}
-	waitForTestFile(t, donePath, 5*time.Second)
+	waitForTestFile(t, donePath)
 }
 
 func TestSkillsCheckWorkerEnvironmentReplacesPrivateValues(t *testing.T) {
@@ -101,9 +106,93 @@ func TestSkillsCheckWorkerEnvironmentReplacesPrivateValues(t *testing.T) {
 	}
 }
 
-func waitForTestFile(t *testing.T, path string, timeout time.Duration) {
+func TestSkillsCheckClaimGuardExcludesOtherProcess(t *testing.T) {
+	if os.Getenv(claimGuardHelperEnv) == "1" {
+		lockPath := os.Getenv(claimGuardLockPathEnv)
+		guard, acquired, err := acquireSkillsCheckClaimGuard(lockPath+skillsCheckClaimSuffix, true)
+		if err != nil || !acquired {
+			t.Fatalf("helper acquire guard = (%v, %v)", acquired, err)
+		}
+		if err := os.WriteFile(os.Getenv(claimGuardStartedPathEnv), []byte("started"), 0o600); err != nil {
+			t.Fatalf("helper write started marker: %v", err)
+		}
+		waitForTestFile(t, os.Getenv(claimGuardReleasePathEnv))
+		if err := releaseSkillsCheckClaimGuard(guard); err != nil {
+			t.Fatalf("helper release guard: %v", err)
+		}
+		return
+	}
+
+	tmpDir := t.TempDir()
+	lockPath := filepath.Join(tmpDir, skillsCheckLockFilename)
+	startedPath := filepath.Join(tmpDir, "guard-started")
+	releasePath := filepath.Join(tmpDir, "guard-release")
+	now := time.Date(2026, 3, 5, 12, 0, 0, 0, time.UTC)
+	if err := createSkillsCheckLock(lockPath, "stale-token", now.Add(-skillsWorkerRetryDelay-time.Second)); err != nil {
+		t.Fatalf("create stale lock: %v", err)
+	}
+
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable() error: %v", err)
+	}
+	cmd := exec.Command(executable, "-test.run=^TestSkillsCheckClaimGuardExcludesOtherProcess$")
+	cmd.Env = append(
+		os.Environ(),
+		claimGuardHelperEnv+"=1",
+		claimGuardLockPathEnv+"="+lockPath,
+		claimGuardStartedPathEnv+"="+startedPath,
+		claimGuardReleasePathEnv+"="+releasePath,
+	)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start guard helper: %v", err)
+	}
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+	})
+	waitForTestFile(t, startedPath)
+
+	startedAt := time.Now()
+	token, claimed, err := defaultClaimSkillsCheckWorker(lockPath, now)
+	if err != nil {
+		t.Fatalf("claim while guard busy: %v", err)
+	}
+	if claimed || token != "" {
+		t.Fatalf("claim while guard busy = (%q, %v), want no claim", token, claimed)
+	}
+	if elapsed := time.Since(startedAt); elapsed >= 500*time.Millisecond {
+		t.Fatalf("busy guard delayed foreground claim by %s", elapsed)
+	}
+
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("read guarded stale lock: %v", err)
+	}
+	if !strings.Contains(string(data), "stale-token") {
+		t.Fatalf("busy contender changed stale lock: %s", data)
+	}
+
+	if err := os.WriteFile(releasePath, []byte("release"), 0o600); err != nil {
+		t.Fatalf("write guard release marker: %v", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("guard helper failed: %v", err)
+	}
+
+	token, claimed, err = defaultClaimSkillsCheckWorker(lockPath, now)
+	if err != nil {
+		t.Fatalf("claim after guard release: %v", err)
+	}
+	if !claimed || token == "" {
+		t.Fatalf("claim after guard release = (%q, %v), want winner", token, claimed)
+	}
+}
+
+func waitForTestFile(t *testing.T, path string) {
 	t.Helper()
-	deadline := time.Now().Add(timeout)
+	deadline := time.Now().Add(5 * time.Second)
 	for {
 		if _, err := os.Stat(path); err == nil {
 			return

--- a/internal/cli/install/skills_check_process_unix.go
+++ b/internal/cli/install/skills_check_process_unix.go
@@ -1,0 +1,12 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package install
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func configureDetachedSkillsCheckProcess(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}

--- a/internal/cli/install/skills_check_process_unix_test.go
+++ b/internal/cli/install/skills_check_process_unix_test.go
@@ -1,0 +1,16 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package install
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestConfigureDetachedSkillsCheckProcessUsesNewSession(t *testing.T) {
+	cmd := exec.Command("unused")
+	configureDetachedSkillsCheckProcess(cmd)
+	if cmd.SysProcAttr == nil || !cmd.SysProcAttr.Setsid {
+		t.Fatal("Unix worker must start in a detached session")
+	}
+}

--- a/internal/cli/install/skills_check_process_windows.go
+++ b/internal/cli/install/skills_check_process_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package install
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+const (
+	detachedProcessCreationFlag = 0x00000008
+	newProcessGroupCreationFlag = 0x00000200
+)
+
+func configureDetachedSkillsCheckProcess(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: detachedProcessCreationFlag | newProcessGroupCreationFlag,
+		HideWindow:    true,
+	}
+}

--- a/internal/cli/install/skills_check_process_windows_test.go
+++ b/internal/cli/install/skills_check_process_windows_test.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+package install
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestConfigureDetachedSkillsCheckProcessUsesDetachedProcessGroup(t *testing.T) {
+	cmd := exec.Command("unused")
+	configureDetachedSkillsCheckProcess(cmd)
+	if cmd.SysProcAttr == nil {
+		t.Fatal("Windows worker must configure process attributes")
+	}
+	wantFlags := uint32(detachedProcessCreationFlag | newProcessGroupCreationFlag)
+	if got := cmd.SysProcAttr.CreationFlags & wantFlags; got != wantFlags {
+		t.Fatalf("creation flags = %#x, want %#x", got, wantFlags)
+	}
+	if !cmd.SysProcAttr.HideWindow {
+		t.Fatal("Windows worker must not create a visible console window")
+	}
+}

--- a/internal/cli/install/skills_check_test.go
+++ b/internal/cli/install/skills_check_test.go
@@ -3,6 +3,7 @@ package install
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"os"
@@ -423,6 +424,73 @@ func TestDefaultClaimSkillsCheckWorkerReclaimsStaleLease(t *testing.T) {
 	if !claimed || token == "" || token == "stale-token" {
 		t.Fatalf("stale lease claim = (%q, %v), want new owner", token, claimed)
 	}
+	quarantines, err := filepath.Glob(lockPath + ".stale-*")
+	if err != nil {
+		t.Fatalf("glob stale lock quarantines: %v", err)
+	}
+	if len(quarantines) != 0 {
+		t.Fatalf("stale reclaim left quarantines: %v", quarantines)
+	}
+}
+
+func TestDefaultClaimSkillsCheckWorkerConcurrentStaleReclaimKeepsWinner(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), skillsCheckLockFilename)
+	now := time.Date(2026, 3, 5, 12, 0, 0, 0, time.UTC)
+	const contenders = 32
+
+	for round := 0; round < 20; round++ {
+		if err := createSkillsCheckLock(lockPath, "stale-token", now.Add(-skillsWorkerRetryDelay-time.Second)); err != nil {
+			t.Fatalf("round %d: create stale lock: %v", round, err)
+		}
+
+		start := make(chan struct{})
+		var winnersMu sync.Mutex
+		winners := make([]string, 0, 1)
+		errorsSeen := make(chan error, contenders)
+		var wg sync.WaitGroup
+		for range contenders {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				token, claimed, err := defaultClaimSkillsCheckWorker(lockPath, now)
+				if err != nil {
+					errorsSeen <- err
+					return
+				}
+				if claimed {
+					winnersMu.Lock()
+					winners = append(winners, token)
+					winnersMu.Unlock()
+				}
+			}()
+		}
+		close(start)
+		wg.Wait()
+		close(errorsSeen)
+
+		for err := range errorsSeen {
+			t.Fatalf("round %d: stale contender error: %v", round, err)
+		}
+		if len(winners) != 1 {
+			t.Fatalf("round %d: worker claims = %d, want 1", round, len(winners))
+		}
+
+		data, err := os.ReadFile(lockPath)
+		if err != nil {
+			t.Fatalf("round %d: read winner lock: %v", round, err)
+		}
+		var lock skillsCheckLock
+		if err := json.Unmarshal(data, &lock); err != nil {
+			t.Fatalf("round %d: decode winner lock: %v", round, err)
+		}
+		if lock.Token != winners[0] {
+			t.Fatalf("round %d: canonical token = %q, winner = %q", round, lock.Token, winners[0])
+		}
+		if err := defaultReleaseSkillsCheckWorker(lockPath, winners[0]); err != nil {
+			t.Fatalf("round %d: release winner: %v", round, err)
+		}
+	}
 }
 
 func TestDefaultStoreSkillsCheckCacheWritesTimestampAndResultTogether(t *testing.T) {
@@ -711,6 +779,33 @@ func TestDefaultRunSkillsCheckCommandDoesNotWaitForDescendantPipes(t *testing.T)
 	}
 	if !strings.Contains(output, "2 updates available") {
 		t.Fatalf("output = %q, want update result", output)
+	}
+}
+
+func TestCappedSkillsCheckOutputRetainsLimitWhileDraining(t *testing.T) {
+	var output cappedSkillsCheckOutput
+	payload := bytes.Repeat([]byte("x"), maxSkillsCheckOutputBytes+4096)
+
+	written, err := output.Write(payload)
+	if err != nil {
+		t.Fatalf("Write() error: %v", err)
+	}
+	if written != len(payload) {
+		t.Fatalf("Write() = %d, want %d", written, len(payload))
+	}
+	if got := len(output.String()); got != maxSkillsCheckOutputBytes {
+		t.Fatalf("retained output = %d bytes, want %d", got, maxSkillsCheckOutputBytes)
+	}
+
+	written, err = output.Write([]byte("still drained"))
+	if err != nil {
+		t.Fatalf("second Write() error: %v", err)
+	}
+	if written != len("still drained") {
+		t.Fatalf("second Write() = %d, want %d", written, len("still drained"))
+	}
+	if got := len(output.String()); got != maxSkillsCheckOutputBytes {
+		t.Fatalf("retained output after cap = %d bytes, want %d", got, maxSkillsCheckOutputBytes)
 	}
 }
 

--- a/internal/cli/install/skills_check_test.go
+++ b/internal/cli/install/skills_check_test.go
@@ -3,12 +3,15 @@ package install
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -79,323 +82,572 @@ func TestSkillsOutputHasUpdates(t *testing.T) {
 	}
 }
 
-func TestMaybeCheckForSkillUpdates_NotifiesAndPersistsTimestamp(t *testing.T) {
-	origLoad := loadConfigForSkillsCheck
-	origPersist := persistSkillsCheckedAtForCheck
-	origNow := nowForSkillsCheck
-	origRun := runSkillsCheckCommand
-	origProgress := progressEnabledForCheck
-	t.Cleanup(func() {
-		loadConfigForSkillsCheck = origLoad
-		persistSkillsCheckedAtForCheck = origPersist
-		nowForSkillsCheck = origNow
-		runSkillsCheckCommand = origRun
-		progressEnabledForCheck = origProgress
-	})
-
-	t.Setenv(skillsAutoCheckEnvVar, "true")
-	t.Setenv("CI", "")
-
-	cfg := &config.Config{}
-	loadConfigForSkillsCheck = func() (*config.Config, error) { return cfg, nil }
-
-	savedAt := ""
-	persistSkillsCheckedAtForCheck = func(value string) error {
-		savedAt = strings.TrimSpace(value)
-		return nil
+func TestSkillsCheckSchedulerSchedulesOnlyWhenDue(t *testing.T) {
+	now := time.Date(2026, 3, 5, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name          string
+		legacyChecked string
+		cache         skillsCheckCache
+		cacheErr      error
+		wantStarted   bool
+	}{
+		{
+			name:        "missing cache and empty legacy timestamp is due",
+			cacheErr:    os.ErrNotExist,
+			wantStarted: true,
+		},
+		{
+			name:          "missing cache honors recent legacy timestamp",
+			legacyChecked: now.Add(-time.Hour).Format(skillsCheckedAtLayout),
+			cacheErr:      os.ErrNotExist,
+		},
+		{
+			name: "old cache is due",
+			cache: skillsCheckCache{
+				CheckedAt: now.Add(-25 * time.Hour).Format(skillsCheckedAtLayout),
+			},
+			wantStarted: true,
+		},
+		{
+			name: "recent cache is not due",
+			cache: skillsCheckCache{
+				CheckedAt: now.Add(-time.Hour).Format(skillsCheckedAtLayout),
+			},
+		},
 	}
 
-	fixedNow := time.Date(2026, 3, 5, 12, 30, 0, 0, time.UTC)
-	nowForSkillsCheck = func() time.Time { return fixedNow }
-	runSkillsCheckCommand = func(ctx context.Context) (string, error) {
-		return "2 updates available", nil
-	}
-	progressEnabledForCheck = func() bool { return true }
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			startCalls := 0
+			claimCalls := 0
+			scheduler := skillsCheckScheduler{
+				getenv: func(key string) string {
+					if key == skillsAutoCheckEnvVar {
+						return "true"
+					}
+					return ""
+				},
+				progressEnabled: func() bool { return true },
+				loadConfig: func() (*config.Config, error) {
+					return &config.Config{SkillsCheckedAt: tt.legacyChecked}, nil
+				},
+				statePaths: func() (skillsCheckStatePaths, error) {
+					return skillsCheckStatePaths{
+						cache: filepath.Join(tmpDir, skillsCheckCacheFilename),
+						lock:  filepath.Join(tmpDir, skillsCheckLockFilename),
+					}, nil
+				},
+				loadCache: func(string) (skillsCheckCache, error) {
+					return tt.cache, tt.cacheErr
+				},
+				storeCache: func(string, skillsCheckCache) error {
+					t.Fatal("storeCache should not run without a cached notice")
+					return nil
+				},
+				claimWorker: func(string, time.Time) (string, bool, error) {
+					claimCalls++
+					return "worker-token", true, nil
+				},
+				releaseWorker: func(string, string) error { return nil },
+				startWorker: func(spec skillsCheckWorkerSpec) error {
+					startCalls++
+					if spec.token != "worker-token" {
+						t.Fatalf("worker token = %q, want worker-token", spec.token)
+					}
+					return nil
+				},
+				now:    func() time.Time { return now },
+				stderr: io.Discard,
+			}
 
-	stderr := captureStderr(t, func() {
-		MaybeCheckForSkillUpdates(context.Background())
-	})
-
-	if savedAt != fixedNow.Format(skillsCheckedAtLayout) {
-		t.Fatalf("SkillsCheckedAt = %q, want %q", savedAt, fixedNow.Format(skillsCheckedAtLayout))
-	}
-	if !strings.Contains(stderr, "npx skills update") {
-		t.Fatalf("expected notification in stderr, got %q", stderr)
-	}
-}
-
-func TestMaybeCheckForSkillUpdates_SkipsWhenCheckedRecently(t *testing.T) {
-	origLoad := loadConfigForSkillsCheck
-	origPersist := persistSkillsCheckedAtForCheck
-	origNow := nowForSkillsCheck
-	origRun := runSkillsCheckCommand
-	origProgress := progressEnabledForCheck
-	t.Cleanup(func() {
-		loadConfigForSkillsCheck = origLoad
-		persistSkillsCheckedAtForCheck = origPersist
-		nowForSkillsCheck = origNow
-		runSkillsCheckCommand = origRun
-		progressEnabledForCheck = origProgress
-	})
-
-	t.Setenv(skillsAutoCheckEnvVar, "true")
-	t.Setenv("CI", "")
-
-	fixedNow := time.Date(2026, 3, 5, 15, 0, 0, 0, time.UTC)
-	nowForSkillsCheck = func() time.Time { return fixedNow }
-	loadConfigForSkillsCheck = func() (*config.Config, error) {
-		return &config.Config{SkillsCheckedAt: fixedNow.Add(-1 * time.Hour).Format(skillsCheckedAtLayout)}, nil
-	}
-	persistSkillsCheckedAtForCheck = func(value string) error {
-		t.Fatal("persist should not be called for recent checks")
-		return nil
-	}
-
-	called := false
-	runSkillsCheckCommand = func(ctx context.Context) (string, error) {
-		called = true
-		return "", nil
-	}
-	progressEnabledForCheck = func() bool { return true }
-
-	MaybeCheckForSkillUpdates(context.Background())
-	if called {
-		t.Fatal("expected skills check command to be skipped")
-	}
-}
-
-func TestMaybeCheckForSkillUpdates_DoesNotPersistWhenCheckCanceled(t *testing.T) {
-	origLoad := loadConfigForSkillsCheck
-	origPersist := persistSkillsCheckedAtForCheck
-	origNow := nowForSkillsCheck
-	origRun := runSkillsCheckCommand
-	origProgress := progressEnabledForCheck
-	t.Cleanup(func() {
-		loadConfigForSkillsCheck = origLoad
-		persistSkillsCheckedAtForCheck = origPersist
-		nowForSkillsCheck = origNow
-		runSkillsCheckCommand = origRun
-		progressEnabledForCheck = origProgress
-	})
-
-	t.Setenv(skillsAutoCheckEnvVar, "true")
-	t.Setenv("CI", "")
-	loadConfigForSkillsCheck = func() (*config.Config, error) { return &config.Config{}, nil }
-	nowForSkillsCheck = func() time.Time { return time.Date(2026, 3, 5, 16, 0, 0, 0, time.UTC) }
-	progressEnabledForCheck = func() bool { return true }
-	runSkillsCheckCommand = func(ctx context.Context) (string, error) {
-		return "", context.Canceled
-	}
-
-	persistCalled := false
-	persistSkillsCheckedAtForCheck = func(value string) error {
-		persistCalled = true
-		return nil
-	}
-
-	MaybeCheckForSkillUpdates(context.Background())
-	if persistCalled {
-		t.Fatal("expected canceled check not to persist timestamp")
+			scheduler.run()
+			if got := startCalls == 1; got != tt.wantStarted {
+				t.Fatalf("worker started = %v, want %v", got, tt.wantStarted)
+			}
+			if tt.wantStarted && claimCalls != 1 {
+				t.Fatalf("claim calls = %d, want 1", claimCalls)
+			}
+			if !tt.wantStarted && claimCalls != 0 {
+				t.Fatalf("claim calls = %d, want 0", claimCalls)
+			}
+		})
 	}
 }
 
-func TestMaybeCheckForSkillUpdates_DoesNotPersistWhenCheckerUnavailable(t *testing.T) {
-	origLoad := loadConfigForSkillsCheck
-	origPersist := persistSkillsCheckedAtForCheck
-	origNow := nowForSkillsCheck
-	origRun := runSkillsCheckCommand
-	origProgress := progressEnabledForCheck
-	t.Cleanup(func() {
-		loadConfigForSkillsCheck = origLoad
-		persistSkillsCheckedAtForCheck = origPersist
-		nowForSkillsCheck = origNow
-		runSkillsCheckCommand = origRun
-		progressEnabledForCheck = origProgress
-	})
-
-	t.Setenv(skillsAutoCheckEnvVar, "true")
-	t.Setenv("CI", "")
-	loadConfigForSkillsCheck = func() (*config.Config, error) { return &config.Config{}, nil }
-	nowForSkillsCheck = func() time.Time { return time.Date(2026, 3, 5, 16, 30, 0, 0, time.UTC) }
-	progressEnabledForCheck = func() bool { return true }
-	runSkillsCheckCommand = func(ctx context.Context) (string, error) {
-		return "", errSkillsCheckUnavailable
+func TestSkillsCheckSchedulerSkipsDisabledCIAndNonTTY(t *testing.T) {
+	tests := []struct {
+		name     string
+		auto     string
+		ci       string
+		progress bool
+	}{
+		{name: "disabled", auto: "false", progress: true},
+		{name: "CI", auto: "true", ci: "1", progress: true},
+		{name: "non TTY", auto: "true", progress: false},
 	}
 
-	persistCalled := false
-	persistSkillsCheckedAtForCheck = func(value string) error {
-		persistCalled = true
-		return nil
-	}
-
-	MaybeCheckForSkillUpdates(context.Background())
-	if persistCalled {
-		t.Fatal("expected unavailable checker not to persist timestamp")
-	}
-}
-
-func TestMaybeCheckForSkillUpdates_PersistsOnNonContextFailure(t *testing.T) {
-	origLoad := loadConfigForSkillsCheck
-	origPersist := persistSkillsCheckedAtForCheck
-	origNow := nowForSkillsCheck
-	origRun := runSkillsCheckCommand
-	origProgress := progressEnabledForCheck
-	t.Cleanup(func() {
-		loadConfigForSkillsCheck = origLoad
-		persistSkillsCheckedAtForCheck = origPersist
-		nowForSkillsCheck = origNow
-		runSkillsCheckCommand = origRun
-		progressEnabledForCheck = origProgress
-	})
-
-	t.Setenv(skillsAutoCheckEnvVar, "true")
-	t.Setenv("CI", "")
-	loadConfigForSkillsCheck = func() (*config.Config, error) { return &config.Config{}, nil }
-	fixedNow := time.Date(2026, 3, 5, 17, 0, 0, 0, time.UTC)
-	nowForSkillsCheck = func() time.Time { return fixedNow }
-	progressEnabledForCheck = func() bool { return true }
-	runSkillsCheckCommand = func(ctx context.Context) (string, error) {
-		return "", errors.New("exec failure")
-	}
-
-	savedAt := ""
-	persistSkillsCheckedAtForCheck = func(value string) error {
-		savedAt = strings.TrimSpace(value)
-		return nil
-	}
-
-	MaybeCheckForSkillUpdates(context.Background())
-	if savedAt != fixedNow.Format(skillsCheckedAtLayout) {
-		t.Fatalf("expected persistence on non-context failure, got %q", savedAt)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			loadCalled := false
+			scheduler := skillsCheckScheduler{
+				getenv: func(key string) string {
+					switch key {
+					case skillsAutoCheckEnvVar:
+						return tt.auto
+					case "CI":
+						return tt.ci
+					default:
+						return ""
+					}
+				},
+				progressEnabled: func() bool { return tt.progress },
+				loadConfig: func() (*config.Config, error) {
+					loadCalled = true
+					return &config.Config{}, nil
+				},
+				claimWorker: func(string, time.Time) (string, bool, error) {
+					t.Fatal("skipped scheduler must not claim a worker")
+					return "", false, nil
+				},
+				startWorker: func(skillsCheckWorkerSpec) error {
+					t.Fatal("skipped scheduler must not start a worker")
+					return nil
+				},
+			}
+			scheduler.run()
+			if loadCalled {
+				t.Fatal("config should not be loaded for skipped scheduler")
+			}
+		})
 	}
 }
 
-func TestMaybeCheckForSkillUpdates_SkipsWhenDisabled(t *testing.T) {
-	origLoad := loadConfigForSkillsCheck
-	origProgress := progressEnabledForCheck
-	t.Cleanup(func() {
-		loadConfigForSkillsCheck = origLoad
-		progressEnabledForCheck = origProgress
-	})
-
-	t.Setenv(skillsAutoCheckEnvVar, "false")
-	progressEnabledForCheck = func() bool { return true }
-	loadCalled := false
-	loadConfigForSkillsCheck = func() (*config.Config, error) {
-		loadCalled = true
-		return nil, errors.New("should not load")
+func TestSkillsCheckSchedulerDisplaysAndConsumesCachedNotice(t *testing.T) {
+	now := time.Date(2026, 3, 5, 12, 0, 0, 0, time.UTC)
+	cache := skillsCheckCache{
+		CheckedAt:       now.Add(-time.Hour).Format(skillsCheckedAtLayout),
+		UpdateAvailable: true,
+	}
+	var stderr bytes.Buffer
+	stored := skillsCheckCache{}
+	storeCalls := 0
+	scheduler := skillsCheckScheduler{
+		getenv:          func(string) string { return "" },
+		progressEnabled: func() bool { return true },
+		loadConfig:      func() (*config.Config, error) { return &config.Config{}, nil },
+		statePaths: func() (skillsCheckStatePaths, error) {
+			return skillsCheckStatePaths{cache: "/tmp/cache", lock: "/tmp/lock"}, nil
+		},
+		loadCache: func(string) (skillsCheckCache, error) { return cache, nil },
+		storeCache: func(_ string, value skillsCheckCache) error {
+			storeCalls++
+			stored = value
+			return nil
+		},
+		claimWorker: func(string, time.Time) (string, bool, error) {
+			t.Fatal("recent cache should not claim a worker")
+			return "", false, nil
+		},
+		now:    func() time.Time { return now },
+		stderr: &stderr,
 	}
 
-	MaybeCheckForSkillUpdates(context.Background())
-	if loadCalled {
-		t.Fatal("expected config load to be skipped when disabled")
+	scheduler.run()
+	if storeCalls != 1 {
+		t.Fatalf("store calls = %d, want 1", storeCalls)
+	}
+	if stored.UpdateAvailable {
+		t.Fatal("cached update notice should be consumed atomically")
+	}
+	if stored.CheckedAt != cache.CheckedAt {
+		t.Fatalf("checked_at = %q, want %q", stored.CheckedAt, cache.CheckedAt)
+	}
+	if !strings.Contains(stderr.String(), "npx skills update") {
+		t.Fatalf("expected stderr notice, got %q", stderr.String())
 	}
 }
 
-func TestMaybeCheckForSkillUpdates_RunsByDefaultWhenUnset(t *testing.T) {
-	origLoad := loadConfigForSkillsCheck
-	origProgress := progressEnabledForCheck
-	t.Cleanup(func() {
-		loadConfigForSkillsCheck = origLoad
-		progressEnabledForCheck = origProgress
-	})
-
-	t.Setenv(skillsAutoCheckEnvVar, "")
-	t.Setenv("CI", "")
-	progressEnabledForCheck = func() bool { return true }
-	loadCalled := false
-	loadConfigForSkillsCheck = func() (*config.Config, error) {
-		loadCalled = true
-		return nil, errors.New("load called as expected")
+func TestSkillsCheckSchedulerCacheFailuresAreSilent(t *testing.T) {
+	tests := []struct {
+		name       string
+		loadCache  func(string) (skillsCheckCache, error)
+		storeCache func(string, skillsCheckCache) error
+	}{
+		{
+			name: "malformed cache",
+			loadCache: func(string) (skillsCheckCache, error) {
+				return skillsCheckCache{}, errors.New("malformed cache")
+			},
+			storeCache: func(string, skillsCheckCache) error { return nil },
+		},
+		{
+			name: "cached notice write failure",
+			loadCache: func(string) (skillsCheckCache, error) {
+				return skillsCheckCache{
+					CheckedAt:       time.Now().UTC().Format(skillsCheckedAtLayout),
+					UpdateAvailable: true,
+				}, nil
+			},
+			storeCache: func(string, skillsCheckCache) error {
+				return errors.New("read-only cache")
+			},
+		},
 	}
 
-	MaybeCheckForSkillUpdates(context.Background())
-	if !loadCalled {
-		t.Fatal("expected config load to run when auto-check env var is unset")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stderr bytes.Buffer
+			started := false
+			scheduler := skillsCheckScheduler{
+				getenv:          func(string) string { return "" },
+				progressEnabled: func() bool { return true },
+				loadConfig:      func() (*config.Config, error) { return &config.Config{}, nil },
+				statePaths: func() (skillsCheckStatePaths, error) {
+					return skillsCheckStatePaths{cache: "/tmp/cache", lock: "/tmp/lock"}, nil
+				},
+				loadCache:  tt.loadCache,
+				storeCache: tt.storeCache,
+				claimWorker: func(string, time.Time) (string, bool, error) {
+					started = true
+					return "token", true, nil
+				},
+				startWorker: func(skillsCheckWorkerSpec) error {
+					started = true
+					return nil
+				},
+				now:    time.Now,
+				stderr: &stderr,
+			}
+
+			scheduler.run()
+			if started {
+				t.Fatal("cache failure should not schedule a worker")
+			}
+			if stderr.Len() != 0 {
+				t.Fatalf("cache failure should stay silent, got %q", stderr.String())
+			}
+		})
 	}
 }
 
-func TestDefaultRunSkillsCheckCommand_UsesSkillsBinaryCheckCommand(t *testing.T) {
-	origLookup := lookupSkillsCheckCLI
-	origLookupNpx := lookupNpx
-	t.Cleanup(func() {
-		lookupSkillsCheckCLI = origLookup
-		lookupNpx = origLookupNpx
+func TestSkillsCheckSchedulerReleasesLeaseWhenStartFails(t *testing.T) {
+	releasedToken := ""
+	scheduler := skillsCheckScheduler{
+		getenv:          func(string) string { return "" },
+		progressEnabled: func() bool { return true },
+		loadConfig:      func() (*config.Config, error) { return &config.Config{}, nil },
+		statePaths: func() (skillsCheckStatePaths, error) {
+			return skillsCheckStatePaths{cache: "/tmp/cache", lock: "/tmp/lock"}, nil
+		},
+		loadCache: func(string) (skillsCheckCache, error) {
+			return skillsCheckCache{}, os.ErrNotExist
+		},
+		storeCache: func(string, skillsCheckCache) error { return nil },
+		claimWorker: func(string, time.Time) (string, bool, error) {
+			return "claimed-token", true, nil
+		},
+		releaseWorker: func(_ string, token string) error {
+			releasedToken = token
+			return nil
+		},
+		startWorker: func(skillsCheckWorkerSpec) error {
+			return errors.New("start failed")
+		},
+		now:    time.Now,
+		stderr: io.Discard,
+	}
+
+	scheduler.run()
+	if releasedToken != "claimed-token" {
+		t.Fatalf("released token = %q, want claimed-token", releasedToken)
+	}
+}
+
+func TestDefaultClaimSkillsCheckWorkerAllowsOnlyOneConcurrentWorker(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), skillsCheckLockFilename)
+	now := time.Date(2026, 3, 5, 12, 0, 0, 0, time.UTC)
+	const contenders = 16
+	start := make(chan struct{})
+	var winners atomic.Int32
+	var winnerToken string
+	var winnerMu sync.Mutex
+	var wg sync.WaitGroup
+
+	for range contenders {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			token, claimed, err := defaultClaimSkillsCheckWorker(lockPath, now)
+			if err != nil {
+				t.Errorf("defaultClaimSkillsCheckWorker() error: %v", err)
+				return
+			}
+			if claimed {
+				winners.Add(1)
+				winnerMu.Lock()
+				winnerToken = token
+				winnerMu.Unlock()
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := winners.Load(); got != 1 {
+		t.Fatalf("worker claims = %d, want 1", got)
+	}
+	if err := defaultReleaseSkillsCheckWorker(lockPath, "not-the-owner"); err != nil {
+		t.Fatalf("mismatched release error: %v", err)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("mismatched release removed lock: %v", err)
+	}
+	if err := defaultReleaseSkillsCheckWorker(lockPath, winnerToken); err != nil {
+		t.Fatalf("owner release error: %v", err)
+	}
+}
+
+func TestDefaultClaimSkillsCheckWorkerReclaimsStaleLease(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), skillsCheckLockFilename)
+	now := time.Date(2026, 3, 5, 12, 0, 0, 0, time.UTC)
+	if err := createSkillsCheckLock(lockPath, "stale-token", now.Add(-skillsWorkerRetryDelay-time.Second)); err != nil {
+		t.Fatalf("createSkillsCheckLock() error: %v", err)
+	}
+
+	token, claimed, err := defaultClaimSkillsCheckWorker(lockPath, now)
+	if err != nil {
+		t.Fatalf("defaultClaimSkillsCheckWorker() error: %v", err)
+	}
+	if !claimed || token == "" || token == "stale-token" {
+		t.Fatalf("stale lease claim = (%q, %v), want new owner", token, claimed)
+	}
+}
+
+func TestDefaultStoreSkillsCheckCacheWritesTimestampAndResultTogether(t *testing.T) {
+	cachePath := filepath.Join(t.TempDir(), skillsCheckCacheFilename)
+	want := skillsCheckCache{
+		CheckedAt:       "2026-03-05T12:00:00Z",
+		UpdateAvailable: true,
+	}
+	if err := defaultStoreSkillsCheckCache(cachePath, want); err != nil {
+		t.Fatalf("defaultStoreSkillsCheckCache() error: %v", err)
+	}
+
+	got, err := defaultLoadSkillsCheckCache(cachePath)
+	if err != nil {
+		t.Fatalf("defaultLoadSkillsCheckCache() error: %v", err)
+	}
+	if got != want {
+		t.Fatalf("cache = %#v, want %#v", got, want)
+	}
+	info, err := os.Stat(cachePath)
+	if err != nil {
+		t.Fatalf("stat cache: %v", err)
+	}
+	if gotPerm := info.Mode().Perm(); gotPerm != 0o600 {
+		t.Fatalf("cache mode = %o, want 600", gotPerm)
+	}
+	leftovers, err := filepath.Glob(filepath.Join(filepath.Dir(cachePath), ".skills-check-*"))
+	if err != nil {
+		t.Fatalf("glob cache temporary files: %v", err)
+	}
+	if len(leftovers) != 0 {
+		t.Fatalf("atomic cache write left temporary files: %v", leftovers)
+	}
+}
+
+func TestDefaultStoreSkillsCheckCacheFailurePreservesSymlinkTarget(t *testing.T) {
+	tmpDir := t.TempDir()
+	targetPath := filepath.Join(tmpDir, "target.json")
+	cachePath := filepath.Join(tmpDir, skillsCheckCacheFilename)
+	wantTarget := []byte("do not replace")
+	if err := os.WriteFile(targetPath, wantTarget, 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	if err := os.Symlink(targetPath, cachePath); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	err := defaultStoreSkillsCheckCache(cachePath, skillsCheckCache{
+		CheckedAt:       "2026-03-05T12:00:00Z",
+		UpdateAvailable: true,
 	})
-
-	mockSkills := filepath.Join(t.TempDir(), "skills-mock.sh")
-	if err := os.WriteFile(mockSkills, []byte("#!/bin/sh\necho \"$@\"\n"), 0o755); err != nil {
-		t.Fatalf("WriteFile() error: %v", err)
+	if err == nil {
+		t.Fatal("expected symlink cache write to fail")
 	}
-	if err := os.Chmod(mockSkills, 0o755); err != nil {
-		t.Fatalf("Chmod() error: %v", err)
+	gotTarget, readErr := os.ReadFile(targetPath)
+	if readErr != nil {
+		t.Fatalf("read target: %v", readErr)
+	}
+	if !bytes.Equal(gotTarget, wantTarget) {
+		t.Fatalf("target changed to %q", gotTarget)
+	}
+}
+
+func TestSkillsCheckWorkerCachesResultAndReleasesLease(t *testing.T) {
+	now := time.Date(2026, 3, 5, 12, 0, 0, 0, time.UTC)
+	stored := skillsCheckCache{}
+	released := false
+	worker := skillsCheckWorker{
+		runCheck: func(context.Context) (string, error) {
+			return "2 updates available", nil
+		},
+		storeCache: func(path string, cache skillsCheckCache) error {
+			if path != "/tmp/cache" {
+				t.Fatalf("cache path = %q", path)
+			}
+			stored = cache
+			return nil
+		},
+		releaseWorker: func(path, token string) error {
+			released = path == "/tmp/lock" && token == "token"
+			return nil
+		},
+		now:     func() time.Time { return now },
+		timeout: time.Second,
+	}
+	spec := skillsCheckWorkerSpec{cachePath: "/tmp/cache", lockPath: "/tmp/lock", token: "token"}
+
+	if err := worker.run(context.Background(), spec); err != nil {
+		t.Fatalf("worker.run() error: %v", err)
+	}
+	if stored.CheckedAt != now.Format(skillsCheckedAtLayout) || !stored.UpdateAvailable {
+		t.Fatalf("stored cache = %#v", stored)
+	}
+	if !released {
+		t.Fatal("worker did not release successful lease")
+	}
+}
+
+func TestSkillsCheckWorkerPersistsGenericFailureButKeepsLeaseOnMaintenanceFailure(t *testing.T) {
+	errRun := errors.New("checker failed")
+	tests := []struct {
+		name        string
+		runErr      error
+		storeErr    error
+		wantStored  bool
+		wantRelease bool
+	}{
+		{
+			name:        "generic checker failure records attempt",
+			runErr:      errRun,
+			wantStored:  true,
+			wantRelease: true,
+		},
+		{
+			name:   "unavailable checker keeps cooldown lease",
+			runErr: errSkillsCheckUnavailable,
+		},
+		{
+			name:       "cache failure keeps cooldown lease",
+			storeErr:   errors.New("cache failed"),
+			wantStored: true,
+		},
 	}
 
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stored := false
+			released := false
+			worker := skillsCheckWorker{
+				runCheck: func(context.Context) (string, error) {
+					return "", tt.runErr
+				},
+				storeCache: func(_ string, cache skillsCheckCache) error {
+					stored = true
+					if cache.UpdateAvailable {
+						t.Fatal("failed checker must not cache an update")
+					}
+					return tt.storeErr
+				},
+				releaseWorker: func(string, string) error {
+					released = true
+					return nil
+				},
+				now:     time.Now,
+				timeout: time.Second,
+			}
+			spec := skillsCheckWorkerSpec{cachePath: "/tmp/cache", lockPath: "/tmp/lock", token: "token"}
+			_ = worker.run(context.Background(), spec)
+			if stored != tt.wantStored {
+				t.Fatalf("cache stored = %v, want %v", stored, tt.wantStored)
+			}
+			if released != tt.wantRelease {
+				t.Fatalf("lease released = %v, want %v", released, tt.wantRelease)
+			}
+		})
+	}
+}
+
+func TestRunSkillsCheckWorkerIfRequestedRequiresPrivateMarker(t *testing.T) {
+	t.Setenv(skillsWorkerEnvVar, "")
+	if RunSkillsCheckWorkerIfRequested() {
+		t.Fatal("ordinary process should not enter worker mode")
+	}
+
+	t.Setenv(skillsWorkerEnvVar, "1")
+	t.Setenv(skillsWorkerCacheEnvVar, "")
+	t.Setenv(skillsWorkerLockEnvVar, "")
+	t.Setenv(skillsWorkerTokenEnvVar, "")
+	if !RunSkillsCheckWorkerIfRequested() {
+		t.Fatal("private marker should consume the worker process")
+	}
+}
+
+func TestDefaultRunSkillsCheckCommandUsesSkillsBinaryCheckCommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	restoreSkillsCheckLookups(t)
+	mockSkills := writeExecutable(t, "#!/bin/sh\necho \"$@\"\n")
 	lookupSkillsCheckCLI = func(file string) (string, error) {
 		if file != "skills" {
 			t.Fatalf("lookupSkillsCheckCLI called with %q, want skills", file)
 		}
 		return mockSkills, nil
 	}
-	lookupNpx = func(file string) (string, error) {
-		t.Fatalf("lookupNpx should not be called when skills binary is available")
-		return "", errors.New("unexpected call")
+	lookupNpx = func(string) (string, error) {
+		t.Fatal("lookupNpx should not run when skills is available")
+		return "", errors.New("unexpected")
 	}
 
 	output, err := defaultRunSkillsCheckCommand(context.Background())
 	if err != nil {
 		t.Fatalf("defaultRunSkillsCheckCommand() error: %v", err)
 	}
-	if !strings.Contains(output, "check") {
-		t.Fatalf("expected check invocation, got %q", output)
-	}
-	if strings.Contains(output, "--no") {
-		t.Fatalf("expected no npx flags in invocation, got %q", output)
+	if strings.TrimSpace(output) != "check" {
+		t.Fatalf("checker args = %q, want check", output)
 	}
 }
 
-func TestDefaultRunSkillsCheckCommand_MissingSkillsCLIIsNoop(t *testing.T) {
-	origLookup := lookupSkillsCheckCLI
-	origLookupNpx := lookupNpx
-	t.Cleanup(func() {
-		lookupSkillsCheckCLI = origLookup
-		lookupNpx = origLookupNpx
-	})
-
-	lookupSkillsCheckCLI = func(file string) (string, error) {
-		return "", errors.New("not found")
+func TestDefaultRunSkillsCheckCommandMissingCLIsIsUnavailable(t *testing.T) {
+	restoreSkillsCheckLookups(t)
+	lookupSkillsCheckCLI = func(string) (string, error) {
+		return "", exec.ErrNotFound
 	}
-	lookupNpx = func(file string) (string, error) {
-		return "", errors.New("npx not found")
+	lookupNpx = func(string) (string, error) {
+		return "", exec.ErrNotFound
 	}
 
 	output, err := defaultRunSkillsCheckCommand(context.Background())
 	if !errors.Is(err, errSkillsCheckUnavailable) {
-		t.Fatalf("expected errSkillsCheckUnavailable when check command is unavailable, got %v", err)
+		t.Fatalf("error = %v, want errSkillsCheckUnavailable", err)
 	}
 	if output != "" {
-		t.Fatalf("expected empty output when skills is unavailable, got %q", output)
+		t.Fatalf("output = %q, want empty", output)
 	}
 }
 
-func TestDefaultRunSkillsCheckCommand_FallsBackToNpxOffline(t *testing.T) {
-	origLookup := lookupSkillsCheckCLI
-	origLookupNpx := lookupNpx
-	t.Cleanup(func() {
-		lookupSkillsCheckCLI = origLookup
-		lookupNpx = origLookupNpx
-	})
-
-	mockNpx := filepath.Join(t.TempDir(), "npx-mock.sh")
-	if err := os.WriteFile(mockNpx, []byte("#!/bin/sh\necho \"$@\"\necho \"$npm_config_offline\"\n"), 0o755); err != nil {
-		t.Fatalf("WriteFile() error: %v", err)
+func TestDefaultRunSkillsCheckCommandFallsBackToNpxOffline(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
 	}
-	if err := os.Chmod(mockNpx, 0o755); err != nil {
-		t.Fatalf("Chmod() error: %v", err)
-	}
-
-	lookupSkillsCheckCLI = func(file string) (string, error) {
-		return "", errors.New("not found")
+	restoreSkillsCheckLookups(t)
+	mockNpx := writeExecutable(t, "#!/bin/sh\nprintf '%s|%s\\n' \"$*\" \"$npm_config_offline\"\n")
+	lookupSkillsCheckCLI = func(string) (string, error) {
+		return "", exec.ErrNotFound
 	}
 	lookupNpx = func(file string) (string, error) {
 		if file != "npx" {
@@ -408,78 +660,81 @@ func TestDefaultRunSkillsCheckCommand_FallsBackToNpxOffline(t *testing.T) {
 	if err != nil {
 		t.Fatalf("defaultRunSkillsCheckCommand() error: %v", err)
 	}
-	if !strings.Contains(output, "--offline --yes skills check") {
-		t.Fatalf("expected --offline --yes skills check invocation, got %q", output)
-	}
-	if !strings.Contains(output, "\ntrue\n") && !strings.HasSuffix(output, "\ntrue") {
-		t.Fatalf("expected npm_config_offline=true in fallback environment, got %q", output)
+	if !strings.Contains(output, "--offline --yes skills check|true") {
+		t.Fatalf("offline npx invocation = %q", output)
 	}
 }
 
-func TestDefaultRunSkillsCheckCommand_OfflineCacheMissIsUnavailable(t *testing.T) {
-	origLookup := lookupSkillsCheckCLI
-	origLookupNpx := lookupNpx
-	t.Cleanup(func() {
-		lookupSkillsCheckCLI = origLookup
-		lookupNpx = origLookupNpx
-	})
-
-	mockNpx := filepath.Join(t.TempDir(), "npx-mock.sh")
-	script := "#!/bin/sh\necho \"npm ERR! code ENOTCACHED\" 1>&2\nexit 1\n"
-	if err := os.WriteFile(mockNpx, []byte(script), 0o755); err != nil {
-		t.Fatalf("WriteFile() error: %v", err)
+func TestDefaultRunSkillsCheckCommandOfflineCacheMissIsUnavailable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
 	}
-	if err := os.Chmod(mockNpx, 0o755); err != nil {
-		t.Fatalf("Chmod() error: %v", err)
+	restoreSkillsCheckLookups(t)
+	mockNpx := writeExecutable(t, "#!/bin/sh\necho ENOTCACHED >&2\nexit 1\n")
+	lookupSkillsCheckCLI = func(string) (string, error) {
+		return "", exec.ErrNotFound
 	}
-
-	lookupSkillsCheckCLI = func(file string) (string, error) {
-		return "", errors.New("not found")
-	}
-	lookupNpx = func(file string) (string, error) {
+	lookupNpx = func(string) (string, error) {
 		return mockNpx, nil
 	}
 
 	output, err := defaultRunSkillsCheckCommand(context.Background())
 	if !errors.Is(err, errSkillsCheckUnavailable) {
-		t.Fatalf("expected errSkillsCheckUnavailable for ENOTCACHED fallback, got %v", err)
+		t.Fatalf("error = %v, want errSkillsCheckUnavailable", err)
 	}
-	if !strings.Contains(strings.ToLower(output), "enotcached") {
-		t.Fatalf("expected ENOTCACHED output, got %q", output)
+	if !strings.Contains(output, "ENOTCACHED") {
+		t.Fatalf("output = %q, want ENOTCACHED", output)
 	}
 }
 
-func TestDefaultRunSkillsCheckCommand_UsesNonProjectWorkingDirectory(t *testing.T) {
-	origLookup := lookupSkillsCheckCLI
-	t.Cleanup(func() {
-		lookupSkillsCheckCLI = origLookup
-	})
+func TestDefaultRunSkillsCheckCommandDoesNotWaitForDescendantPipes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	restoreSkillsCheckLookups(t)
+	mockSkills := writeExecutable(t, "#!/bin/sh\nsleep 10 &\nprintf '2 updates available\\n'\n")
+	lookupSkillsCheckCLI = func(string) (string, error) {
+		return mockSkills, nil
+	}
+	lookupNpx = func(string) (string, error) {
+		t.Fatal("lookupNpx should not run")
+		return "", errors.New("unexpected")
+	}
 
-	homeDir := t.TempDir()
-	t.Setenv("HOME", homeDir)
-	t.Setenv("USERPROFILE", homeDir)
-
-	projectDir := t.TempDir()
-	originalWD, err := os.Getwd()
+	startedAt := time.Now()
+	output, err := defaultRunSkillsCheckCommand(context.Background())
 	if err != nil {
-		t.Fatalf("Getwd() error: %v", err)
+		t.Fatalf("defaultRunSkillsCheckCommand() error: %v", err)
 	}
-	if err := os.Chdir(projectDir); err != nil {
-		t.Fatalf("Chdir(projectDir) error: %v", err)
+	if elapsed := time.Since(startedAt); elapsed >= 2*time.Second {
+		t.Fatalf("checker waited %s for 10-second descendant", elapsed)
 	}
-	t.Cleanup(func() {
-		_ = os.Chdir(originalWD)
-	})
+	if !strings.Contains(output, "2 updates available") {
+		t.Fatalf("output = %q, want update result", output)
+	}
+}
 
-	mockSkills := filepath.Join(t.TempDir(), "skills-mock.sh")
-	if err := os.WriteFile(mockSkills, []byte("#!/bin/sh\nprintf \"%s\\n\" \"$PWD\"\n"), 0o755); err != nil {
-		t.Fatalf("WriteFile() error: %v", err)
+func TestRunSkillsCheckProcessReturnsContextDeadline(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
 	}
-	if err := os.Chmod(mockSkills, 0o755); err != nil {
-		t.Fatalf("Chmod() error: %v", err)
-	}
+	mockSkills := writeExecutable(t, "#!/bin/sh\nsleep 10\n")
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
 
-	lookupSkillsCheckCLI = func(file string) (string, error) {
+	_, err := runSkillsCheckProcess(ctx, mockSkills, nil, nil)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("runSkillsCheckProcess() error = %v, want deadline exceeded", err)
+	}
+}
+
+func TestDefaultRunSkillsCheckCommandUsesNonProjectWorkingDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	restoreSkillsCheckLookups(t)
+	mockSkills := writeExecutable(t, "#!/bin/sh\nprintf '%s\\n' \"$PWD\"\n")
+	lookupSkillsCheckCLI = func(string) (string, error) {
 		return mockSkills, nil
 	}
 
@@ -487,242 +742,76 @@ func TestDefaultRunSkillsCheckCommand_UsesNonProjectWorkingDirectory(t *testing.
 	if err != nil {
 		t.Fatalf("defaultRunSkillsCheckCommand() error: %v", err)
 	}
-	workingDir := strings.TrimSpace(output)
-	normalizedWorkingDir := workingDir
-	if resolved, resolveErr := filepath.EvalSymlinks(workingDir); resolveErr == nil {
-		normalizedWorkingDir = resolved
-	}
-	normalizedHomeDir := homeDir
-	if resolved, resolveErr := filepath.EvalSymlinks(homeDir); resolveErr == nil {
-		normalizedHomeDir = resolved
-	}
-	if normalizedWorkingDir != normalizedHomeDir {
-		t.Fatalf("expected command working directory %q, got %q", normalizedHomeDir, normalizedWorkingDir)
-	}
-	normalizedProjectDir := projectDir
-	if resolved, resolveErr := filepath.EvalSymlinks(projectDir); resolveErr == nil {
-		normalizedProjectDir = resolved
-	}
-	if normalizedWorkingDir == normalizedProjectDir {
-		t.Fatalf("expected command not to run in project directory %q", normalizedProjectDir)
+	want := skillsCheckWorkingDirectory()
+	if strings.TrimSpace(output) != want {
+		t.Fatalf("working directory = %q, want %q", strings.TrimSpace(output), want)
 	}
 }
 
-func TestDefaultRunSkillsCheckCommand_SkipsProjectLocalSkillsBinary(t *testing.T) {
-	origLookup := lookupSkillsCheckCLI
-	origLookupNpx := lookupNpx
-	t.Cleanup(func() {
-		lookupSkillsCheckCLI = origLookup
-		lookupNpx = origLookupNpx
-	})
-
+func TestShouldSkipProjectLocalSkillsBinary(t *testing.T) {
 	repoRoot := t.TempDir()
-	if err := os.WriteFile(filepath.Join(repoRoot, ".git"), []byte("gitdir"), 0o644); err != nil {
-		t.Fatalf("WriteFile() error: %v", err)
+	if err := os.Mkdir(filepath.Join(repoRoot, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
 	}
-	workingDir := filepath.Join(repoRoot, "subdir")
-	if err := os.MkdirAll(workingDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll() error: %v", err)
+	projectDir := filepath.Join(repoRoot, "subdir")
+	if err := os.Mkdir(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir project dir: %v", err)
 	}
-	originalWD, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Getwd() error: %v", err)
-	}
-	if err := os.Chdir(workingDir); err != nil {
-		t.Fatalf("Chdir() error: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = os.Chdir(originalWD)
-	})
+	t.Chdir(projectDir)
 
-	localSkills := filepath.Join(repoRoot, "node_modules", ".bin", "skills")
-	if err := os.MkdirAll(filepath.Dir(localSkills), 0o755); err != nil {
-		t.Fatalf("MkdirAll() error: %v", err)
+	localBinary := filepath.Join(repoRoot, "node_modules", ".bin", "skills")
+	if err := os.MkdirAll(filepath.Dir(localBinary), 0o755); err != nil {
+		t.Fatalf("mkdir local binary dir: %v", err)
 	}
-	if err := os.WriteFile(localSkills, []byte("#!/bin/sh\necho should-not-run\n"), 0o755); err != nil {
-		t.Fatalf("WriteFile() error: %v", err)
+	if err := os.WriteFile(localBinary, []byte("fixture"), 0o755); err != nil {
+		t.Fatalf("write local binary: %v", err)
 	}
-	if err := os.Chmod(localSkills, 0o755); err != nil {
-		t.Fatalf("Chmod() error: %v", err)
+	if !shouldSkipProjectLocalSkillsBinary(localBinary) {
+		t.Fatal("expected project-local skills binary to be skipped")
 	}
-
-	lookupSkillsCheckCLI = func(file string) (string, error) {
-		return localSkills, nil
-	}
-	lookupNpx = func(file string) (string, error) {
-		return "", errors.New("npx unavailable")
-	}
-
-	output, err := defaultRunSkillsCheckCommand(context.Background())
-	if !errors.Is(err, errSkillsCheckUnavailable) {
-		t.Fatalf("expected errSkillsCheckUnavailable for skipped local binary fallback failure, got %v", err)
-	}
-	if output != "" {
-		t.Fatalf("expected project-local skills binary to be skipped, got %q", output)
+	externalBinary := filepath.Join(t.TempDir(), "skills")
+	if shouldSkipProjectLocalSkillsBinary(externalBinary) {
+		t.Fatal("expected external skills binary to be allowed")
 	}
 }
 
-func TestShouldSkipProjectLocalSkillsBinary_NoRepoRootDoesNotSkip(t *testing.T) {
-	originalWD, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Getwd() error: %v", err)
+func TestValidateSkillsCheckWorkerSpec(t *testing.T) {
+	valid := skillsCheckWorkerSpec{
+		cachePath: filepath.Join(t.TempDir(), "cache"),
+		lockPath:  filepath.Join(t.TempDir(), "lock"),
+		token:     "token",
 	}
-	workingDir := t.TempDir()
-	if err := os.Chdir(workingDir); err != nil {
-		t.Fatalf("Chdir() error: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = os.Chdir(originalWD)
-	})
-
-	binaryPath := filepath.Join(workingDir, "bin", "skills")
-	if err := os.MkdirAll(filepath.Dir(binaryPath), 0o755); err != nil {
-		t.Fatalf("MkdirAll() error: %v", err)
-	}
-	if err := os.WriteFile(binaryPath, []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatalf("WriteFile() error: %v", err)
+	if err := validateSkillsCheckWorkerSpec(valid); err != nil {
+		t.Fatalf("valid spec error: %v", err)
 	}
 
-	if shouldSkipProjectLocalSkillsBinary(binaryPath) {
-		t.Fatal("expected no-repo-root working directory not to skip binary path")
+	invalid := []skillsCheckWorkerSpec{
+		{cachePath: "relative", lockPath: valid.lockPath, token: valid.token},
+		{cachePath: valid.cachePath, lockPath: "relative", token: valid.token},
+		{cachePath: valid.cachePath, lockPath: valid.lockPath},
+	}
+	for _, spec := range invalid {
+		if err := validateSkillsCheckWorkerSpec(spec); err == nil {
+			t.Fatalf("expected invalid spec error for %#v", spec)
+		}
 	}
 }
 
-func TestDefaultPersistSkillsCheckedAt_PreservesUnknownFields(t *testing.T) {
-	cfgPath := filepath.Join(t.TempDir(), "config.json")
-	t.Setenv("ASC_CONFIG_PATH", cfgPath)
-
-	initial := `{
-  "key_id": "ABC123",
-  "custom_future_key": "keep-me",
-  "custom_nested": {"enabled": true},
-  "skills_checked_at": "2026-03-01T00:00:00Z"
-}`
-	if err := os.WriteFile(cfgPath, []byte(initial), 0o600); err != nil {
-		t.Fatalf("WriteFile() error: %v", err)
-	}
-
-	want := "2026-03-05T14:00:00Z"
-	if err := defaultPersistSkillsCheckedAt(want); err != nil {
-		t.Fatalf("defaultPersistSkillsCheckedAt() error: %v", err)
-	}
-
-	data, err := os.ReadFile(cfgPath)
-	if err != nil {
-		t.Fatalf("ReadFile() error: %v", err)
-	}
-
-	var doc map[string]json.RawMessage
-	if err := json.Unmarshal(data, &doc); err != nil {
-		t.Fatalf("json.Unmarshal() error: %v", err)
-	}
-
-	var got string
-	if err := json.Unmarshal(doc["skills_checked_at"], &got); err != nil {
-		t.Fatalf("unmarshal skills_checked_at error: %v", err)
-	}
-	if got != want {
-		t.Fatalf("skills_checked_at = %q, want %q", got, want)
-	}
-
-	if _, ok := doc["custom_future_key"]; !ok {
-		t.Fatal("expected custom_future_key to be preserved")
-	}
-	if _, ok := doc["custom_nested"]; !ok {
-		t.Fatal("expected custom_nested to be preserved")
-	}
-}
-
-func TestDefaultPersistSkillsCheckedAt_PreservesTopLevelKeyOrder(t *testing.T) {
-	cfgPath := filepath.Join(t.TempDir(), "config.json")
-	t.Setenv("ASC_CONFIG_PATH", cfgPath)
-
-	initial := `{
-  "z_key": "z",
-  "skills_checked_at": "2026-03-01T00:00:00Z",
-  "a_key": "a"
-}`
-	if err := os.WriteFile(cfgPath, []byte(initial), 0o600); err != nil {
-		t.Fatalf("WriteFile() error: %v", err)
-	}
-
-	if err := defaultPersistSkillsCheckedAt("2026-03-05T18:00:00Z"); err != nil {
-		t.Fatalf("defaultPersistSkillsCheckedAt() error: %v", err)
-	}
-
-	data, err := os.ReadFile(cfgPath)
-	if err != nil {
-		t.Fatalf("ReadFile() error: %v", err)
-	}
-
-	content := string(data)
-	zIndex := strings.Index(content, `"z_key"`)
-	skillsIndex := strings.Index(content, `"skills_checked_at"`)
-	aIndex := strings.Index(content, `"a_key"`)
-	if zIndex == -1 || skillsIndex == -1 || aIndex == -1 {
-		t.Fatalf("expected keys in output, got %q", content)
-	}
-	if zIndex >= skillsIndex || skillsIndex >= aIndex {
-		t.Fatalf("expected top-level key order to be preserved, got %q", content)
-	}
-}
-
-func TestDefaultPersistSkillsCheckedAt_NullJSONCreatesObject(t *testing.T) {
-	cfgPath := filepath.Join(t.TempDir(), "config.json")
-	t.Setenv("ASC_CONFIG_PATH", cfgPath)
-
-	if err := os.WriteFile(cfgPath, []byte("null"), 0o600); err != nil {
-		t.Fatalf("WriteFile() error: %v", err)
-	}
-
-	want := "2026-03-05T15:00:00Z"
-	if err := defaultPersistSkillsCheckedAt(want); err != nil {
-		t.Fatalf("defaultPersistSkillsCheckedAt() error: %v", err)
-	}
-
-	data, err := os.ReadFile(cfgPath)
-	if err != nil {
-		t.Fatalf("ReadFile() error: %v", err)
-	}
-
-	var doc map[string]json.RawMessage
-	if err := json.Unmarshal(data, &doc); err != nil {
-		t.Fatalf("json.Unmarshal() error: %v", err)
-	}
-
-	var got string
-	if err := json.Unmarshal(doc["skills_checked_at"], &got); err != nil {
-		t.Fatalf("unmarshal skills_checked_at error: %v", err)
-	}
-	if got != want {
-		t.Fatalf("skills_checked_at = %q, want %q", got, want)
-	}
-}
-
-func captureStderr(t *testing.T, fn func()) string {
+func restoreSkillsCheckLookups(t *testing.T) {
 	t.Helper()
+	origSkills := lookupSkillsCheckCLI
+	origNpx := lookupNpx
+	t.Cleanup(func() {
+		lookupSkillsCheckCLI = origSkills
+		lookupNpx = origNpx
+	})
+}
 
-	oldStderr := os.Stderr
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("os.Pipe() error: %v", err)
+func writeExecutable(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "skills-check-fixture")
+	if err := os.WriteFile(path, []byte(contents), 0o755); err != nil {
+		t.Fatalf("write executable: %v", err)
 	}
-	os.Stderr = w
-
-	done := make(chan string, 1)
-	go func() {
-		var buf bytes.Buffer
-		_, _ = io.Copy(&buf, r)
-		_ = r.Close()
-		done <- buf.String()
-	}()
-
-	defer func() {
-		os.Stderr = oldStderr
-		_ = w.Close()
-	}()
-
-	fn()
-	_ = w.Close()
-	return <-done
+	return path
 }

--- a/internal/cli/install/skills_check_test.go
+++ b/internal/cli/install/skills_check_test.go
@@ -410,6 +410,32 @@ func TestDefaultClaimSkillsCheckWorkerAllowsOnlyOneConcurrentWorker(t *testing.T
 	}
 }
 
+func TestDefaultClaimSkillsCheckWorkerKeepsClaimWhenGuardReleaseReportsError(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), skillsCheckLockFilename)
+	now := time.Date(2026, 3, 5, 12, 0, 0, 0, time.UTC)
+	originalRelease := releaseSkillsCheckClaimGuardFn
+	t.Cleanup(func() {
+		releaseSkillsCheckClaimGuardFn = originalRelease
+	})
+	releaseSkillsCheckClaimGuardFn = func(file *os.File) error {
+		if err := originalRelease(file); err != nil {
+			return err
+		}
+		return errors.New("simulated guard release failure")
+	}
+
+	token, claimed, err := defaultClaimSkillsCheckWorker(lockPath, now)
+	if err != nil {
+		t.Fatalf("defaultClaimSkillsCheckWorker() error: %v", err)
+	}
+	if !claimed || token == "" {
+		t.Fatalf("claim after guard release error = (%q, %v), want owner", token, claimed)
+	}
+	if err := defaultReleaseSkillsCheckWorker(lockPath, token); err != nil {
+		t.Fatalf("release claimed worker: %v", err)
+	}
+}
+
 func TestDefaultClaimSkillsCheckWorkerReclaimsStaleLease(t *testing.T) {
 	lockPath := filepath.Join(t.TempDir(), skillsCheckLockFilename)
 	now := time.Date(2026, 3, 5, 12, 0, 0, 0, time.UTC)


### PR DESCRIPTION
## Summary

- Move the passive skills update check out of the foreground command path and into a detached copy of `asc`.
- Store `checked_at` and `update_available` together in an atomic sibling cache; a later interactive command consumes the cached notice on stderr.
- Gate launches with an atomic lease so concurrent commands produce one worker, with a ten-minute retry cooldown after cancellation, checker unavailability, or cache-write failure.
- Skip root help, subcommand help, version, `install-skills`, CI, non-TTY, disabled, and canceled invocations before worker startup.

## Design contract

**Placement and invocation.** The existing post-command hook remains in `cmd/run.go`; there is no registry entry, public command, or flag. A private environment marker sends a detached copy of the same executable directly to the maintenance worker before command-tree construction.

**Public behavior.** Existing commands, flags, stdout, exit codes, and help text stay unchanged. The only notice remains `skills updates may be available. Run 'npx skills update' to refresh installed skills.` on stderr. A due check no longer prints during the command that launches it; the next eligible interactive invocation may print the cached result once.

**API scope.** No App Store Connect endpoint, request schema, query parameter, or response shape is involved.

**Compatibility.** `ASC_SKILLS_AUTO_CHECK` keeps its default-enabled behavior and current true/false parsing. When the new cache does not exist, the scheduler uses the legacy `skills_checked_at` value as its initial timestamp. No migration or deprecation is needed.

**Process and failure behavior.** Unix workers start in a new session; Windows workers use `DETACHED_PROCESS` plus a new process group. All worker standard handles point to the null device before `Start`, and the parent releases the process handle immediately. The checker still gets an eight-second context timeout, while `WaitDelay` bounds inherited pipe handles from descendants. Cache and lease errors stay silent and never alter the foreground exit code.

**Alternatives considered.** An in-process goroutine can disappear when the CLI exits and cannot safely publish a result. Launching `skills` directly from the foreground cannot coordinate the timestamp, cached notice, and retry lease. Updating the main config from a detached worker also risks clobbering concurrent auth/config writes, so the worker uses `skills-check.json` beside the active config.

## Timing

Same macOS PTY command, due config, fake `skills` executable, and environment in both runs. The fake checker launches a descendant that sleeps for 10 seconds while retaining its inherited output handle.

```text
before: real 10.45s
 after: real  0.42s
```

The after-run worker wrote:

```json
{
  "checked_at": "2026-07-10T09:33:58Z",
  "update_available": true
}
```

The next interactive command printed the cached notice on stderr, changed `update_available` to `false`, and did not launch another worker.

## Validation

- [x] `make format`
- [x] `make check-docs`
- [x] `make lint`
- [x] `ASC_BYPASS_KEYCHAIN=1 make test`
- [x] `ASC_BYPASS_KEYCHAIN=1 go test ./...`
- [x] Focused race test for concurrent lease claims, detached launch, and inherited checker pipes
- [x] Windows amd64 cross-build of `/tmp/asc-skills.exe` and the build-tagged install test binary
- [x] `/tmp/asc-skills --help` matches the baseline byte-for-byte
- [x] Local `completion`, `search`, and `schema --list` commands succeed with `ASC_BYPASS_KEYCHAIN=1`; JSON outputs parse successfully
- [x] Due help and non-TTY smokes leave no marker, cache, or lease

## Risks

The Windows process path compiles with its platform test and the common detached-helper test, but this macOS run cannot execute the Windows binary. Failed background maintenance waits ten minutes before another attempt; foreground commands remain unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Skills update checks now run through a background worker/lease flow to keep foreground commands fast.
  - Foreground completion is protected from being delayed by auto-check work; worker execution is detached with safe environment isolation.
  - Skills update checks are skipped for help/version and expanded to exclude additional version-related invocations.
- **Reliability**
  - Strengthened cache/lock coordination with atomic cache updates, stale-lock recovery, and safer lock-claim behavior across Unix and Windows.
- **Tests**
  - Added a new PTY-based regression test to ensure the foreground command completes promptly.
  - Expanded unit/integration and platform-specific coverage for worker launching, locking, and retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->