### PR TITLE
perf: make telemetry store and forward

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -51,9 +51,6 @@ func Run(args []string, versionInfo string) int {
 			fmt.Fprint(os.Stderr, parseOutput.String())
 		}
 		if errors.Is(parseErr, flag.ErrHelp) {
-			emitImmediateTelemetry(args, root, versionInfo, ExitSuccess, telemetry.EventContext{
-				InvocationShape: analysis.shape,
-			})
 			return ExitSuccess
 		}
 		if parseOutput.Len() == 0 {
@@ -145,9 +142,6 @@ func Run(args []string, versionInfo string) int {
 	}
 
 	if renderGroupHelp {
-		emitTelemetry(commandName, versionInfo, elapsed, ExitSuccess, telemetry.EventContext{
-			InvocationShape: analysis.shape,
-		})
 		return ExitSuccess
 	}
 

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -31,6 +31,13 @@ import (
 
 func TestRun_VersionFlag(t *testing.T) {
 	resetReportFlags(t)
+	originalEmitTelemetry := emitTelemetry
+	t.Cleanup(func() { emitTelemetry = originalEmitTelemetry })
+
+	var telemetryCalls int
+	emitTelemetry = func(_ string, _ string, _ time.Duration, _ int, _ telemetry.EventContext) {
+		telemetryCalls++
+	}
 
 	stdout, _ := captureCommandOutput(t, func() {
 		code := Run([]string{"--version"}, "9.9.9")
@@ -41,6 +48,9 @@ func TestRun_VersionFlag(t *testing.T) {
 
 	if !strings.Contains(stdout, "9.9.9") {
 		t.Fatalf("expected version in stdout, got %q", stdout)
+	}
+	if telemetryCalls != 0 {
+		t.Fatalf("telemetry calls = %d, want 0 for version", telemetryCalls)
 	}
 }
 
@@ -165,9 +175,9 @@ func TestRun_BareGroupPrintsHelpToStdoutAndExitsSuccessfully(t *testing.T) {
 	originalEmitTelemetry := emitTelemetry
 	t.Cleanup(func() { emitTelemetry = originalEmitTelemetry })
 
-	var gotContext telemetry.EventContext
-	emitTelemetry = func(_ string, _ string, _ time.Duration, _ int, eventContext telemetry.EventContext) {
-		gotContext = eventContext
+	var telemetryCalls int
+	emitTelemetry = func(_ string, _ string, _ time.Duration, _ int, _ telemetry.EventContext) {
+		telemetryCalls++
 	}
 
 	stdout, stderr := captureCommandOutput(t, func() {
@@ -182,11 +192,8 @@ func TestRun_BareGroupPrintsHelpToStdoutAndExitsSuccessfully(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	if gotContext.InvocationShape != telemetry.InvocationShapeBareGroup {
-		t.Fatalf("InvocationShape = %q, want %q", gotContext.InvocationShape, telemetry.InvocationShapeBareGroup)
-	}
-	if gotContext.ErrorKind != "" || gotContext.FailureStage != "" {
-		t.Fatalf("successful help should not carry failure context: %+v", gotContext)
+	if telemetryCalls != 0 {
+		t.Fatalf("telemetry calls = %d, want 0 for group help", telemetryCalls)
 	}
 }
 
@@ -731,34 +738,23 @@ func TestRun_HelpSkipsAuthResolution(t *testing.T) {
 	}
 }
 
-func TestRun_HelpEmitsTelemetry(t *testing.T) {
+func TestRun_HelpSkipsTelemetry(t *testing.T) {
+	resetReportFlags(t)
 	originalEmitTelemetry := emitTelemetry
 	t.Cleanup(func() { emitTelemetry = originalEmitTelemetry })
 
-	var commandName string
-	var duration time.Duration
-	var exitCode int
-	emitTelemetry = func(command, _ string, elapsed time.Duration, code int, _ telemetry.EventContext) {
-		commandName = command
-		duration = elapsed
-		exitCode = code
+	var telemetryCalls int
+	emitTelemetry = func(_ string, _ string, _ time.Duration, _ int, _ telemetry.EventContext) {
+		telemetryCalls++
 	}
 
-	emitImmediateTelemetry(
-		[]string{"builds", "--help"},
-		RootCommand("1.0.0"),
-		"1.0.0",
-		ExitSuccess,
-		telemetry.EventContext{InvocationShape: telemetry.InvocationShapeGroupWithFlags},
-	)
-	if commandName != "asc builds" {
-		t.Fatalf("telemetry command = %q, want %q", commandName, "asc builds")
-	}
-	if duration != 0 {
-		t.Fatalf("telemetry duration = %s, want 0 for help", duration)
-	}
-	if exitCode != ExitSuccess {
-		t.Fatalf("telemetry exit code = %d, want %d", exitCode, ExitSuccess)
+	captureCommandOutput(t, func() {
+		if code := Run([]string{"builds", "--help"}, "1.0.0"); code != ExitSuccess {
+			t.Fatalf("Run() exit code = %d, want %d", code, ExitSuccess)
+		}
+	})
+	if telemetryCalls != 0 {
+		t.Fatalf("telemetry calls = %d, want 0 for help", telemetryCalls)
 	}
 }
 

--- a/cmd/run_telemetry_blackbox_test.go
+++ b/cmd/run_telemetry_blackbox_test.go
@@ -1,0 +1,130 @@
+package cmd
+
+import (
+	"errors"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestRun_BuiltBinaryDoesNotWaitForBlockedTelemetryEndpoint(t *testing.T) {
+	binaryPath := buildASCBlackboxBinary(t)
+	blockedEndpoint, accepted, release := startBlockedTelemetryEndpoint(t)
+
+	disabledHome := t.TempDir()
+	runTimedTelemetryCommand(t, binaryPath, disabledHome, true, "")
+	disabledDuration := runTimedTelemetryCommand(t, binaryPath, disabledHome, true, "")
+
+	blockedHome := t.TempDir()
+	blockedDuration := runTimedTelemetryCommand(t, binaryPath, blockedHome, false, blockedEndpoint)
+	t.Logf("foreground timing: disabled=%s blocked=%s added=%s", disabledDuration, blockedDuration, blockedDuration-disabledDuration)
+	if added := blockedDuration - disabledDuration; added >= 175*time.Millisecond {
+		t.Fatalf(
+			"blocked telemetry added %s to foreground runtime (disabled=%s blocked=%s), want less than 175ms",
+			added,
+			disabledDuration,
+			blockedDuration,
+		)
+	}
+
+	select {
+	case <-accepted:
+	case <-time.After(time.Second):
+		t.Fatal("detached telemetry worker did not reach blocked endpoint")
+	}
+	release()
+}
+
+func runTimedTelemetryCommand(
+	t *testing.T,
+	binaryPath string,
+	home string,
+	disabled bool,
+	endpoint string,
+) time.Duration {
+	t.Helper()
+	command := exec.Command(binaryPath, "builds", "--definitely-invalid")
+	command.Env = telemetryBlackboxEnv(home, disabled, endpoint)
+	start := time.Now()
+	output, err := command.CombinedOutput()
+	duration := time.Since(start)
+
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != ExitUsage {
+		t.Fatalf("built command error = %v, want exit %d; output=%s", err, ExitUsage, output)
+	}
+	return duration
+}
+
+func telemetryBlackboxEnv(home string, disabled bool, endpoint string) []string {
+	environment := filterEnvVars(
+		os.Environ(),
+		"ASC_BYPASS_KEYCHAIN",
+		"ASC_CONFIG_PATH",
+		"ASC_DEBUG",
+		"ASC_TELEMETRY_DISABLED",
+		"ASC_TELEMETRY_ENDPOINT",
+		"ASC_TELEMETRY_EPHEMERAL",
+		"ASC_TIMEOUT",
+		"ASC_TIMEOUT_SECONDS",
+		"DO_NOT_TRACK",
+		"HOME",
+	)
+	disabledValue := ""
+	if disabled {
+		disabledValue = "1"
+	}
+	return append(
+		environment,
+		"ASC_BYPASS_KEYCHAIN=1",
+		"ASC_CONFIG_PATH="+filepath.Join(home, "config.json"),
+		"ASC_DEBUG=",
+		"ASC_TELEMETRY_DISABLED="+disabledValue,
+		"ASC_TELEMETRY_ENDPOINT="+endpoint,
+		"ASC_TELEMETRY_EPHEMERAL=",
+		"ASC_TIMEOUT=1s",
+		"ASC_TIMEOUT_SECONDS=",
+		"DO_NOT_TRACK=",
+		"HOME="+home,
+	)
+}
+
+func startBlockedTelemetryEndpoint(t *testing.T) (string, <-chan struct{}, func()) {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen for blocked telemetry endpoint: %v", err)
+	}
+	accepted := make(chan struct{}, 1)
+	release := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		connection, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		accepted <- struct{}{}
+		<-release
+		_ = connection.Close()
+	}()
+
+	released := false
+	cleanup := func() {
+		if !released {
+			close(release)
+			released = true
+		}
+		_ = listener.Close()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Error("blocked telemetry endpoint did not shut down")
+		}
+	}
+	t.Cleanup(cleanup)
+	return "https://" + listener.Addr().String() + "/events", accepted, cleanup
+}

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -20,8 +20,6 @@ const (
 	maxSendDuration = 250 * time.Millisecond
 )
 
-var sendHTTP = sendHTTPEvent
-
 func Emit(commandName, version string, duration time.Duration, exitCode int) {
 	EmitWithContext(commandName, version, duration, exitCode, EventContext{InvocationShape: InvocationShapeLeaf})
 }
@@ -33,12 +31,14 @@ func EmitWithContext(
 	eventContext EventContext,
 ) {
 	commandPath := sanitizeCommandName(commandName)
-	if shouldSkipCommand(commandPath) {
+	if reason := environmentOptOutReason(); reason != "" {
+		if err := purgeDefaultSpool(); err != nil {
+			debugf("telemetry spool purge failed after %s: %v", reason, err)
+		}
+		debugf("telemetry disabled by %s", reason)
 		return
 	}
-
-	if reason := environmentOptOutReason(); reason != "" {
-		debugf("telemetry disabled by %s", reason)
+	if shouldSkipCommand(commandPath) {
 		return
 	}
 
@@ -49,6 +49,9 @@ func EmitWithContext(
 	}
 	enabled, reason := enabledFromState(st)
 	if !enabled {
+		if err := purgeDefaultSpool(); err != nil {
+			debugf("telemetry spool purge failed after %s: %v", reason, err)
+		}
 		debugf("telemetry disabled by %s", reason)
 		return
 	}
@@ -57,9 +60,23 @@ func EmitWithContext(
 	if !ok {
 		return
 	}
-
-	if err := sendHTTP(ev); err != nil {
+	endpointURL := endpoint()
+	if err := validateEndpoint(endpointURL); err != nil {
 		debugf("telemetry send failed: %v", err)
+		return
+	}
+
+	store, err := defaultSpoolStore()
+	if err != nil {
+		debugf("telemetry spool unavailable: %v", err)
+		return
+	}
+	if err := store.append(spoolRecord{Event: ev, Endpoint: endpointURL}); err != nil {
+		debugf("telemetry spool append failed: %v", err)
+		return
+	}
+	if err := startMaintenanceWorker(); err != nil {
+		debugf("telemetry worker start failed: %v", err)
 	}
 }
 
@@ -71,14 +88,12 @@ func loadCurrentState() (State, error) {
 	return loadState(path)
 }
 
-func sendHTTPEvent(ev Event) error {
-	endpoint := endpoint()
-	if endpoint == "" {
-		return nil
+func sendHTTPEventToEndpoint(ev Event, endpointURL string) error {
+	if err := validateEndpoint(endpointURL); err != nil {
+		return err
 	}
-	parsed, err := url.Parse(endpoint)
-	if err != nil || parsed.Scheme != "https" || parsed.Hostname() == "" || parsed.User != nil {
-		return fmt.Errorf("invalid telemetry endpoint")
+	if endpointURL == "" {
+		return nil
 	}
 
 	body, err := json.Marshal(ev)
@@ -91,7 +106,7 @@ func sendHTTPEvent(ev Event) error {
 	ctx, cancel := context.WithTimeout(configuredCtx, maxSendDuration)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpointURL, bytes.NewReader(body))
 	if err != nil {
 		return err
 	}
@@ -119,6 +134,17 @@ func sendHTTPEvent(ev Event) error {
 	return nil
 }
 
+func validateEndpoint(endpointURL string) error {
+	if endpointURL == "" {
+		return nil
+	}
+	parsed, err := url.Parse(endpointURL)
+	if err != nil || parsed.Scheme != "https" || parsed.Hostname() == "" || parsed.User != nil {
+		return fmt.Errorf("invalid telemetry endpoint")
+	}
+	return nil
+}
+
 func endpoint() string {
 	if raw := strings.TrimSpace(os.Getenv(endpointEnvVar)); raw != "" {
 		return raw
@@ -127,9 +153,13 @@ func endpoint() string {
 }
 
 func debugf(format string, args ...any) {
-	debug := strings.ToLower(strings.TrimSpace(os.Getenv("ASC_DEBUG")))
-	if debug == "" || debug == "0" || debug == "false" || debug == "off" {
+	if !debugEnabled() {
 		return
 	}
 	fmt.Fprintf(os.Stderr, format+"\n", args...)
+}
+
+func debugEnabled() bool {
+	debug := strings.ToLower(strings.TrimSpace(os.Getenv("ASC_DEBUG")))
+	return debug != "" && debug != "0" && debug != "false" && debug != "off"
 }

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -24,26 +24,55 @@ func TestDefaultEndpointUsesExistingRorkAPIRoute(t *testing.T) {
 	}
 }
 
-func TestEmitIsEnabledByDefaultAndSwallowsSenderErrors(t *testing.T) {
+func TestEmitQueuesEventAndSwallowsWorkerStartErrors(t *testing.T) {
 	clearContextEnv(t)
 	setTelemetryTestHome(t)
 	t.Setenv("ASC_TELEMETRY_DISABLED", "")
 	t.Setenv("DO_NOT_TRACK", "")
 
-	called := false
-	original := sendHTTP
-	sendHTTP = func(ev Event) error {
-		called = true
-		if ev.CommandPath != "asc builds list" {
-			t.Fatalf("CommandPath = %q", ev.CommandPath)
-		}
-		return errors.New("network down")
-	}
-	t.Cleanup(func() { sendHTTP = original })
+	workerStarted := false
+	stubMaintenanceWorkerStart(t, func() error {
+		workerStarted = true
+		return errors.New("process unavailable")
+	})
 
 	Emit("asc builds list", "1.2.3", time.Millisecond, 0)
-	if !called {
-		t.Fatal("expected sender to be called")
+	if !workerStarted {
+		t.Fatal("expected maintenance worker start")
+	}
+
+	records := readDefaultSpool(t)
+	if len(records) != 1 {
+		t.Fatalf("spool records = %d, want 1", len(records))
+	}
+	if records[0].Event.CommandPath != "asc builds list" {
+		t.Fatalf("CommandPath = %q, want %q", records[0].Event.CommandPath, "asc builds list")
+	}
+}
+
+func TestEmitDoesNotWaitForBlockedSender(t *testing.T) {
+	clearContextEnv(t)
+	setTelemetryTestHome(t)
+	t.Setenv("ASC_TELEMETRY_DISABLED", "")
+	t.Setenv("DO_NOT_TRACK", "")
+	t.Setenv(endpointEnvVar, "https://telemetry.example.test/events")
+
+	originalClient := http.DefaultClient
+	http.DefaultClient = &http.Client{
+		Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			<-request.Context().Done()
+			return nil, request.Context().Err()
+		}),
+	}
+	t.Cleanup(func() { http.DefaultClient = originalClient })
+	stubMaintenanceWorkerStart(t, func() error { return nil })
+
+	start := time.Now()
+	Emit("asc builds list", "1.2.3", time.Millisecond, 0)
+	elapsed := time.Since(start)
+
+	if elapsed >= 150*time.Millisecond {
+		t.Fatalf("Emit() elapsed = %s, want foreground return before blocked network deadline", elapsed)
 	}
 }
 
@@ -52,14 +81,15 @@ func TestEmitHonorsDisabledEnv(t *testing.T) {
 	setTelemetryTestHome(t)
 	t.Setenv("ASC_TELEMETRY_DISABLED", "1")
 
-	original := sendHTTP
-	sendHTTP = func(ev Event) error {
-		t.Fatal("sender should not be called when disabled")
+	stubMaintenanceWorkerStart(t, func() error {
+		t.Fatal("worker should not start when telemetry is disabled")
 		return nil
-	}
-	t.Cleanup(func() { sendHTTP = original })
+	})
 
 	Emit("asc builds list", "1.2.3", time.Millisecond, 0)
+	if records := readDefaultSpool(t); len(records) != 0 {
+		t.Fatalf("spool records = %d, want 0 when disabled", len(records))
+	}
 }
 
 func TestEmitMarksEphemeralRuntimeWithoutDisabling(t *testing.T) {
@@ -70,27 +100,80 @@ func TestEmitMarksEphemeralRuntimeWithoutDisabling(t *testing.T) {
 	t.Setenv(telemetryEphemeralEnvVar, "1")
 	t.Setenv("PI_CODING_AGENT", "true")
 
-	called := false
-	original := sendHTTP
-	sendHTTP = func(ev Event) error {
-		called = true
-		if ev.RuntimeContext != RuntimeEphemeral {
-			t.Fatalf("RuntimeContext = %q, want %q", ev.RuntimeContext, RuntimeEphemeral)
-		}
-		if ev.InvocationSource != SourcePi {
-			t.Fatalf("InvocationSource = %q, want %q", ev.InvocationSource, SourcePi)
-		}
-		if ev.InstallID != nil {
-			t.Fatalf("expected nil install ID, got %q", *ev.InstallID)
-		}
+	stubMaintenanceWorkerStart(t, func() error {
 		return nil
-	}
-	t.Cleanup(func() { sendHTTP = original })
+	})
 
 	Emit("asc builds list", "1.2.3", time.Millisecond, 0)
-	if !called {
-		t.Fatal("expected sender to be called for ephemeral runtime")
+	records := readDefaultSpool(t)
+	if len(records) != 1 {
+		t.Fatalf("spool records = %d, want 1", len(records))
 	}
+	ev := records[0].Event
+	if ev.RuntimeContext != RuntimeEphemeral {
+		t.Fatalf("RuntimeContext = %q, want %q", ev.RuntimeContext, RuntimeEphemeral)
+	}
+	if ev.InvocationSource != SourcePi {
+		t.Fatalf("InvocationSource = %q, want %q", ev.InvocationSource, SourcePi)
+	}
+	if ev.InstallID != nil {
+		t.Fatalf("expected nil install ID, got %q", *ev.InstallID)
+	}
+}
+
+func TestEmitCapturesEndpointOverrideInSpool(t *testing.T) {
+	clearContextEnv(t)
+	setTelemetryTestHome(t)
+	t.Setenv("ASC_TELEMETRY_DISABLED", "")
+	t.Setenv("DO_NOT_TRACK", "")
+	t.Setenv(endpointEnvVar, "https://override.example.test/events")
+	stubMaintenanceWorkerStart(t, func() error { return nil })
+
+	Emit("asc builds list", "1.2.3", time.Millisecond, 0)
+	records := readDefaultSpool(t)
+	if len(records) != 1 {
+		t.Fatalf("spool records = %d, want 1", len(records))
+	}
+	if got := records[0].Endpoint; got != "https://override.example.test/events" {
+		t.Fatalf("spooled endpoint = %q, want override", got)
+	}
+}
+
+func TestEmitDoesNotSpoolCredentialBearingEndpoint(t *testing.T) {
+	clearContextEnv(t)
+	setTelemetryTestHome(t)
+	t.Setenv("ASC_TELEMETRY_DISABLED", "")
+	t.Setenv("DO_NOT_TRACK", "")
+	t.Setenv(endpointEnvVar, "https://user:secret@telemetry.example.test/events")
+	stubMaintenanceWorkerStart(t, func() error {
+		t.Fatal("worker should not start for invalid endpoint")
+		return nil
+	})
+
+	Emit("asc builds list", "1.2.3", time.Millisecond, 0)
+	if records := readDefaultSpool(t); len(records) != 0 {
+		t.Fatalf("spool records = %d, want 0 for invalid endpoint", len(records))
+	}
+}
+
+func stubMaintenanceWorkerStart(t *testing.T, start func() error) {
+	t.Helper()
+	original := startMaintenanceWorker
+	startMaintenanceWorker = start
+	t.Cleanup(func() { startMaintenanceWorker = original })
+}
+
+func readDefaultSpool(t *testing.T) []spoolRecord {
+	t.Helper()
+	store, err := defaultSpoolStore()
+	if err != nil {
+		t.Fatalf("defaultSpoolStore() error = %v", err)
+	}
+	records, err := store.snapshot(0)
+	if err != nil {
+		t.Fatalf("snapshot() error = %v", err)
+	}
+	return records
 }
 
 func TestSendHTTPEventHonorsASCTimeout(t *testing.T) {
@@ -109,7 +192,7 @@ func TestSendHTTPEventHonorsASCTimeout(t *testing.T) {
 	setTelemetryTestHome(t)
 
 	start := time.Now()
-	err := sendHTTPEvent(Event{})
+	err := sendHTTPEventToEndpoint(Event{}, endpoint())
 	elapsed := time.Since(start)
 
 	if err == nil {
@@ -139,7 +222,7 @@ func TestSendHTTPEventCapsTelemetryTimeout(t *testing.T) {
 	setTelemetryTestHome(t)
 
 	start := time.Now()
-	err := sendHTTPEvent(Event{})
+	err := sendHTTPEventToEndpoint(Event{}, endpoint())
 	elapsed := time.Since(start)
 
 	if err == nil {
@@ -173,7 +256,7 @@ func TestSendHTTPEventRejectsPlaintextRedirect(t *testing.T) {
 	t.Setenv(endpointEnvVar, secureServer.URL)
 	setTelemetryTestHome(t)
 
-	if err := sendHTTPEvent(Event{}); err == nil {
+	if err := sendHTTPEventToEndpoint(Event{}, endpoint()); err == nil {
 		t.Fatal("expected plaintext redirect to be rejected")
 	}
 	if plaintextHit {
@@ -200,7 +283,7 @@ func TestSendHTTPEventRejectsHTTPSRedirect(t *testing.T) {
 	t.Setenv(endpointEnvVar, server.URL+"/events")
 	setTelemetryTestHome(t)
 
-	if err := sendHTTPEvent(Event{}); err == nil {
+	if err := sendHTTPEventToEndpoint(Event{}, endpoint()); err == nil {
 		t.Fatal("expected HTTPS redirect to be rejected")
 	}
 	if redirectedPathHit {
@@ -235,7 +318,7 @@ func TestSendHTTPEventDoesNotSendAmbientCookies(t *testing.T) {
 	t.Setenv(endpointEnvVar, server.URL+"/events")
 	setTelemetryTestHome(t)
 
-	if err := sendHTTPEvent(Event{}); err != nil {
+	if err := sendHTTPEventToEndpoint(Event{}, endpoint()); err != nil {
 		t.Fatalf("sendHTTPEvent() error = %v", err)
 	}
 	if receivedCookie != "" {
@@ -257,7 +340,7 @@ func TestSendHTTPEventRejectsCredentialBearingEndpoint(t *testing.T) {
 	t.Setenv(endpointEnvVar, "https://user:secret@telemetry.example.test/events")
 	setTelemetryTestHome(t)
 
-	if err := sendHTTPEvent(Event{}); err == nil {
+	if err := sendHTTPEventToEndpoint(Event{}, endpoint()); err == nil {
 		t.Fatal("expected credential-bearing telemetry endpoint to be rejected")
 	}
 	if called {

--- a/internal/telemetry/client_unix_test.go
+++ b/internal/telemetry/client_unix_test.go
@@ -49,6 +49,46 @@ func TestEmitHonorsEnvironmentOptOutBeforeStateRead(t *testing.T) {
 	}
 }
 
+func TestEmitDoesNotBlockOnNonRegularState(t *testing.T) {
+	clearContextEnv(t)
+	setTelemetryTestHome(t)
+	t.Setenv("ASC_TELEMETRY_DISABLED", "")
+	t.Setenv("DO_NOT_TRACK", "")
+	stubMaintenanceWorkerStart(t, func() error {
+		t.Fatal("worker should not start when telemetry state cannot be read")
+		return nil
+	})
+
+	path, err := StatePath()
+	if err != nil {
+		t.Fatalf("StatePath() error = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("create state directory: %v", err)
+	}
+	if err := unix.Mkfifo(path, 0o600); err != nil {
+		t.Fatalf("create non-regular state file: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		Emit("asc builds list", "1.2.3", time.Millisecond, 0)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(250 * time.Millisecond):
+		writer, err := os.OpenFile(path, os.O_WRONLY, 0o600)
+		if err != nil {
+			t.Fatalf("open state writer to unblock Emit(): %v", err)
+		}
+		_ = writer.Close()
+		<-done
+		t.Fatal("Emit() blocked on a non-regular telemetry state file")
+	}
+}
+
 func TestEmitSkipsIgnoredCommandBeforeStateRead(t *testing.T) {
 	clearContextEnv(t)
 	setTelemetryTestHome(t)

--- a/internal/telemetry/spool.go
+++ b/internal/telemetry/spool.go
@@ -1,0 +1,415 @@
+package telemetry
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	spoolFileName        = "telemetry-spool.jsonl"
+	maxSpoolRecords      = 128
+	maxSpoolBytes        = 256 * 1024
+	maxSpoolRecordBytes  = 16 * 1024
+	spoolLockTimeout     = 25 * time.Millisecond
+	spoolReaderBufferLen = 4 * 1024
+)
+
+var errSpoolRecordTooLarge = errors.New("telemetry spool record exceeds limit")
+
+type spoolRecord struct {
+	Event    Event  `json:"event"`
+	Endpoint string `json:"endpoint"`
+}
+
+type spoolStore struct {
+	path           string
+	maxRecords     int
+	maxBytes       int
+	maxRecordBytes int
+	lockWait       time.Duration
+}
+
+func defaultSpoolStore() (spoolStore, error) {
+	statePath, err := StatePath()
+	if err != nil {
+		return spoolStore{}, err
+	}
+	return spoolStore{
+		path:           filepath.Join(filepath.Dir(statePath), spoolFileName),
+		maxRecords:     maxSpoolRecords,
+		maxBytes:       maxSpoolBytes,
+		maxRecordBytes: maxSpoolRecordBytes,
+		lockWait:       spoolLockTimeout,
+	}, nil
+}
+
+func (store spoolStore) append(record spoolRecord) error {
+	encoded, err := encodeSpoolRecord(record)
+	if err != nil {
+		return fmt.Errorf("telemetry: failed to encode spool record: %w", err)
+	}
+	if len(encoded) > store.maxRecordBytes || len(encoded) > store.maxBytes {
+		return errSpoolRecordTooLarge
+	}
+
+	unlock, err := lockTelemetryFile(store.path, store.lockWait, "spool")
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	if err := store.removeOrphanedTempFilesUnlocked(); err != nil {
+		return err
+	}
+
+	records, _, err := store.readUnlocked()
+	if err != nil {
+		return err
+	}
+	records = append(records, record)
+	records, err = store.trimToLimits(records)
+	if err != nil {
+		return err
+	}
+	return store.writeUnlocked(records)
+}
+
+func (store spoolStore) snapshot(limit int) ([]spoolRecord, error) {
+	unlock, err := lockTelemetryFile(store.path, store.lockWait, "spool")
+	if err != nil {
+		return nil, err
+	}
+	defer unlock()
+	if err := store.removeOrphanedTempFilesUnlocked(); err != nil {
+		return nil, err
+	}
+
+	records, dirty, err := store.readUnlocked()
+	if err != nil {
+		return nil, err
+	}
+	trimmed, err := store.trimToLimits(records)
+	if err != nil {
+		return nil, err
+	}
+	if len(trimmed) != len(records) {
+		dirty = true
+	}
+	if dirty {
+		if err := store.writeUnlocked(trimmed); err != nil {
+			return nil, err
+		}
+	}
+	if limit > 0 && len(trimmed) > limit {
+		trimmed = trimmed[:limit]
+	}
+	return append([]spoolRecord(nil), trimmed...), nil
+}
+
+func (store spoolStore) removeDelivered(eventIDs map[string]struct{}) error {
+	if len(eventIDs) == 0 {
+		return nil
+	}
+	unlock, err := lockTelemetryFile(store.path, store.lockWait, "spool")
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	if err := store.removeOrphanedTempFilesUnlocked(); err != nil {
+		return err
+	}
+
+	records, dirty, err := store.readUnlocked()
+	if err != nil {
+		return err
+	}
+	kept := records[:0]
+	for _, record := range records {
+		if _, delivered := eventIDs[record.Event.EventID]; delivered {
+			dirty = true
+			continue
+		}
+		kept = append(kept, record)
+	}
+	if !dirty {
+		return nil
+	}
+	return store.writeUnlocked(kept)
+}
+
+func (store spoolStore) purge() error {
+	hasArtifacts, err := store.hasArtifacts()
+	if err != nil {
+		return err
+	}
+	if !hasArtifacts {
+		return nil
+	}
+	unlock, err := lockTelemetryFile(store.path, store.lockWait, "spool")
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	if err := os.Remove(store.path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("telemetry: failed to remove spool: %w", err)
+	}
+	if err := store.removeOrphanedTempFilesUnlocked(); err != nil {
+		return err
+	}
+	if err := syncTelemetryDirectory(filepath.Dir(store.path)); err != nil {
+		return fmt.Errorf("telemetry: failed to sync spool directory: %w", err)
+	}
+	return nil
+}
+
+func (store spoolStore) hasArtifacts() (bool, error) {
+	entries, err := os.ReadDir(filepath.Dir(store.path))
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("telemetry: failed to inspect spool directory: %w", err)
+	}
+	base := filepath.Base(store.path)
+	for _, entry := range entries {
+		if entry.Name() == base || isSpoolTempName(base, entry.Name()) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (store spoolStore) removeOrphanedTempFilesUnlocked() error {
+	dir := filepath.Dir(store.path)
+	entries, err := os.ReadDir(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("telemetry: failed to inspect spool temp files: %w", err)
+	}
+	base := filepath.Base(store.path)
+	for _, entry := range entries {
+		if !isSpoolTempName(base, entry.Name()) || entry.IsDir() {
+			continue
+		}
+		if err := os.Remove(filepath.Join(dir, entry.Name())); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("telemetry: failed to remove spool temp file: %w", err)
+		}
+	}
+	return nil
+}
+
+func isSpoolTempName(base, name string) bool {
+	return strings.HasPrefix(name, base+".") && strings.HasSuffix(name, ".tmp")
+}
+
+func purgeDefaultSpool() error {
+	store, err := defaultSpoolStore()
+	if err != nil {
+		return err
+	}
+	return store.purge()
+}
+
+func (store spoolStore) readUnlocked() ([]spoolRecord, bool, error) {
+	file, err := openTelemetryFileForRead(store.path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("telemetry: failed to read spool: %w", err)
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return nil, false, fmt.Errorf("telemetry: failed to stat spool: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, false, fmt.Errorf("telemetry: spool is not a regular file")
+	}
+	if err := os.Chmod(store.path, 0o600); err != nil {
+		return nil, false, fmt.Errorf("telemetry: failed to secure spool: %w", err)
+	}
+
+	dirty := false
+	maxRead := int64(store.maxBytes + store.maxRecordBytes)
+	if maxRead <= 0 {
+		maxRead = maxSpoolBytes + maxSpoolRecordBytes
+	}
+	start := info.Size() - maxRead
+	if start > 0 {
+		dirty = true
+		var previous [1]byte
+		if _, err := file.ReadAt(previous[:], start-1); err != nil {
+			return nil, false, fmt.Errorf("telemetry: failed to seek spool: %w", err)
+		}
+		if _, err := file.Seek(start, io.SeekStart); err != nil {
+			return nil, false, fmt.Errorf("telemetry: failed to seek spool: %w", err)
+		}
+		if previous[0] != '\n' {
+			reader := bufio.NewReaderSize(file, spoolReaderBufferLen)
+			if err := discardSpoolLine(reader); err != nil && !errors.Is(err, io.EOF) {
+				return nil, false, fmt.Errorf("telemetry: failed to recover spool boundary: %w", err)
+			}
+			return store.decodeSpoolReader(reader, dirty)
+		}
+	}
+
+	reader := bufio.NewReaderSize(file, spoolReaderBufferLen)
+	return store.decodeSpoolReader(reader, dirty)
+}
+
+func (store spoolStore) decodeSpoolReader(reader *bufio.Reader, dirty bool) ([]spoolRecord, bool, error) {
+	records := make([]spoolRecord, 0)
+	for {
+		line, oversized, readErr := readBoundedSpoolLine(reader, store.maxRecordBytes)
+		if oversized {
+			dirty = true
+		} else if len(strings.TrimSpace(string(line))) > 0 {
+			var record spoolRecord
+			if err := json.Unmarshal(line, &record); err != nil || !validSpoolRecord(record) {
+				dirty = true
+			} else {
+				records = append(records, record)
+			}
+		}
+		if errors.Is(readErr, io.EOF) {
+			if len(line) > 0 {
+				dirty = true
+			}
+			break
+		}
+		if readErr != nil {
+			return nil, false, fmt.Errorf("telemetry: failed to scan spool: %w", readErr)
+		}
+	}
+	return records, dirty, nil
+}
+
+func readBoundedSpoolLine(reader *bufio.Reader, maxBytes int) ([]byte, bool, error) {
+	if maxBytes <= 0 {
+		maxBytes = maxSpoolRecordBytes
+	}
+	var line []byte
+	oversized := false
+	for {
+		fragment, err := reader.ReadSlice('\n')
+		if !oversized {
+			if len(line)+len(fragment) > maxBytes {
+				line = nil
+				oversized = true
+			} else {
+				line = append(line, fragment...)
+			}
+		}
+		if errors.Is(err, bufio.ErrBufferFull) {
+			continue
+		}
+		return line, oversized, err
+	}
+}
+
+func discardSpoolLine(reader *bufio.Reader) error {
+	for {
+		_, err := reader.ReadSlice('\n')
+		if errors.Is(err, bufio.ErrBufferFull) {
+			continue
+		}
+		return err
+	}
+}
+
+func (store spoolStore) trimToLimits(records []spoolRecord) ([]spoolRecord, error) {
+	sizes := make([]int, len(records))
+	total := 0
+	for index, record := range records {
+		encoded, err := encodeSpoolRecord(record)
+		if err != nil {
+			return nil, fmt.Errorf("telemetry: failed to encode spool record: %w", err)
+		}
+		sizes[index] = len(encoded)
+		total += len(encoded)
+	}
+	first := 0
+	for first < len(records) && (len(records)-first > store.maxRecords || total > store.maxBytes) {
+		total -= sizes[first]
+		first++
+	}
+	return append([]spoolRecord(nil), records[first:]...), nil
+}
+
+func (store spoolStore) writeUnlocked(records []spoolRecord) error {
+	dir := filepath.Dir(store.path)
+	if err := ensureSecureTelemetryDirectory(dir); err != nil {
+		return fmt.Errorf("telemetry: failed to create spool directory: %w", err)
+	}
+	if len(records) == 0 {
+		if err := os.Remove(store.path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("telemetry: failed to remove empty spool: %w", err)
+		}
+		if err := syncTelemetryDirectory(dir); err != nil {
+			return fmt.Errorf("telemetry: failed to sync spool directory: %w", err)
+		}
+		return nil
+	}
+
+	tmp, err := os.CreateTemp(dir, spoolFileName+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("telemetry: failed to create temp spool: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("telemetry: failed to secure temp spool: %w", err)
+	}
+	for _, record := range records {
+		encoded, err := encodeSpoolRecord(record)
+		if err != nil {
+			_ = tmp.Close()
+			return fmt.Errorf("telemetry: failed to encode spool record: %w", err)
+		}
+		if _, err := tmp.Write(encoded); err != nil {
+			_ = tmp.Close()
+			return fmt.Errorf("telemetry: failed to write spool: %w", err)
+		}
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("telemetry: failed to sync spool: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("telemetry: failed to close spool: %w", err)
+	}
+	if err := replaceTelemetryFile(tmpPath, store.path, store.lockWait); err != nil {
+		return fmt.Errorf("telemetry: failed to replace spool: %w", err)
+	}
+	if err := syncTelemetryDirectory(dir); err != nil {
+		return fmt.Errorf("telemetry: failed to sync spool directory: %w", err)
+	}
+	return nil
+}
+
+func encodeSpoolRecord(record spoolRecord) ([]byte, error) {
+	data, err := json.Marshal(record)
+	if err != nil {
+		return nil, err
+	}
+	return append(data, '\n'), nil
+}
+
+func validSpoolRecord(record spoolRecord) bool {
+	return strings.TrimSpace(record.Event.EventID) != "" &&
+		record.Event.SchemaVersion != 0 &&
+		strings.TrimSpace(record.Event.CommandPath) != "" &&
+		strings.TrimSpace(record.Endpoint) != ""
+}

--- a/internal/telemetry/spool_test.go
+++ b/internal/telemetry/spool_test.go
@@ -1,0 +1,195 @@
+package telemetry
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const spoolWriterHelperEnv = "ASC_TEST_TELEMETRY_SPOOL_WRITER"
+
+func TestSpoolEvictsOldestRecordsByCount(t *testing.T) {
+	store := testSpoolStore(filepath.Join(t.TempDir(), "telemetry-spool.jsonl"))
+	store.maxRecords = 3
+
+	for i := range 5 {
+		if err := store.append(testSpoolRecord(fmt.Sprintf("event-%02d", i))); err != nil {
+			t.Fatalf("append event %d: %v", i, err)
+		}
+	}
+
+	assertSpoolEventIDs(t, store, "event-02", "event-03", "event-04")
+}
+
+func TestSpoolEvictsOldestRecordsByEncodedBytes(t *testing.T) {
+	store := testSpoolStore(filepath.Join(t.TempDir(), "telemetry-spool.jsonl"))
+	recordSize := len(mustEncodeSpoolRecord(t, testSpoolRecord("event-00")))
+	store.maxBytes = recordSize * 2
+
+	for i := range 3 {
+		if err := store.append(testSpoolRecord(fmt.Sprintf("event-%02d", i))); err != nil {
+			t.Fatalf("append event %d: %v", i, err)
+		}
+	}
+
+	assertSpoolEventIDs(t, store, "event-01", "event-02")
+}
+
+func TestSpoolRejectsOversizedNewestWithoutEvictingQueue(t *testing.T) {
+	store := testSpoolStore(filepath.Join(t.TempDir(), "telemetry-spool.jsonl"))
+	existing := testSpoolRecord("event-old")
+	if err := store.append(existing); err != nil {
+		t.Fatalf("append existing event: %v", err)
+	}
+
+	existingSize := len(mustEncodeSpoolRecord(t, existing))
+	store.maxBytes = existingSize + 16
+	store.maxRecordBytes = store.maxBytes * 4
+	oversized := testSpoolRecord("event-new")
+	oversized.Event.ASCVersion = strings.Repeat("x", store.maxBytes)
+
+	if err := store.append(oversized); !errors.Is(err, errSpoolRecordTooLarge) {
+		t.Fatalf("append oversized event error = %v, want %v", err, errSpoolRecordTooLarge)
+	}
+	assertSpoolEventIDs(t, store, "event-old")
+}
+
+func TestSpoolRecoversCorruptAndTruncatedRecords(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "telemetry-spool.jsonl")
+	store := testSpoolStore(path)
+	if err := os.WriteFile(path, append(mustEncodeSpoolRecord(t, testSpoolRecord("event-01")), []byte("{\"event\":")...), 0o600); err != nil {
+		t.Fatalf("write truncated spool: %v", err)
+	}
+	crashTempPath := path + ".crash.tmp"
+	if err := os.WriteFile(crashTempPath, mustEncodeSpoolRecord(t, testSpoolRecord("event-temp")), 0o600); err != nil {
+		t.Fatalf("write abandoned temp file: %v", err)
+	}
+
+	if err := store.append(testSpoolRecord("event-02")); err != nil {
+		t.Fatalf("append after truncated record: %v", err)
+	}
+	assertSpoolEventIDs(t, store, "event-01", "event-02")
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read repaired spool: %v", err)
+	}
+	if strings.Contains(string(data), "{\"event\":\n") || strings.Contains(string(data), "event-temp") {
+		t.Fatalf("repaired spool retained crash debris: %q", data)
+	}
+	if _, err := os.Stat(crashTempPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("crash temp stat error = %v, want not exist after recovery", err)
+	}
+}
+
+func TestSpoolConcurrentProcessWriters(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "telemetry-spool.jsonl")
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable() error = %v", err)
+	}
+
+	type process struct {
+		id  string
+		cmd *exec.Cmd
+	}
+	processes := make([]process, 0, 12)
+	for i := range 12 {
+		id := fmt.Sprintf("event-%02d", i)
+		cmd := exec.Command(executable, "-test.run=^TestSpoolWriterHelperProcess$")
+		cmd.Env = append(
+			os.Environ(),
+			spoolWriterHelperEnv+"=1",
+			"ASC_TEST_TELEMETRY_SPOOL_PATH="+path,
+			"ASC_TEST_TELEMETRY_EVENT_ID="+id,
+		)
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("start writer %s: %v", id, err)
+		}
+		processes = append(processes, process{id: id, cmd: cmd})
+	}
+	for _, process := range processes {
+		if err := process.cmd.Wait(); err != nil {
+			t.Fatalf("writer %s failed: %v", process.id, err)
+		}
+	}
+
+	store := testSpoolStore(path)
+	records, err := store.snapshot(0)
+	if err != nil {
+		t.Fatalf("snapshot() error = %v", err)
+	}
+	if len(records) != len(processes) {
+		t.Fatalf("spool records = %d, want %d", len(records), len(processes))
+	}
+	seen := make(map[string]bool, len(records))
+	for _, record := range records {
+		seen[record.Event.EventID] = true
+	}
+	for _, process := range processes {
+		if !seen[process.id] {
+			t.Errorf("missing concurrently written event %q", process.id)
+		}
+	}
+}
+
+func TestSpoolWriterHelperProcess(t *testing.T) {
+	if os.Getenv(spoolWriterHelperEnv) != "1" {
+		return
+	}
+	store := testSpoolStore(os.Getenv("ASC_TEST_TELEMETRY_SPOOL_PATH"))
+	store.lockWait = lockTimeout
+	if err := store.append(testSpoolRecord(os.Getenv("ASC_TEST_TELEMETRY_EVENT_ID"))); err != nil {
+		t.Fatalf("append helper record: %v", err)
+	}
+}
+
+func testSpoolStore(path string) spoolStore {
+	return spoolStore{
+		path:           path,
+		maxRecords:     maxSpoolRecords,
+		maxBytes:       maxSpoolBytes,
+		maxRecordBytes: maxSpoolRecordBytes,
+		lockWait:       lockTimeout,
+	}
+}
+
+func testSpoolRecord(eventID string) spoolRecord {
+	return spoolRecord{
+		Event: Event{
+			EventID:       eventID,
+			SchemaVersion: 3,
+			ASCVersion:    "1.2.3",
+			CommandPath:   "asc builds list",
+		},
+		Endpoint: "https://telemetry.example.test/events",
+	}
+}
+
+func mustEncodeSpoolRecord(t *testing.T, record spoolRecord) []byte {
+	t.Helper()
+	data, err := encodeSpoolRecord(record)
+	if err != nil {
+		t.Fatalf("encodeSpoolRecord() error = %v", err)
+	}
+	return data
+}
+
+func assertSpoolEventIDs(t *testing.T, store spoolStore, want ...string) {
+	t.Helper()
+	records, err := store.snapshot(0)
+	if err != nil {
+		t.Fatalf("snapshot() error = %v", err)
+	}
+	got := make([]string, 0, len(records))
+	for _, record := range records {
+		got = append(got, record.Event.EventID)
+	}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("spool event IDs = %v, want %v", got, want)
+	}
+}

--- a/internal/telemetry/spool_unix_test.go
+++ b/internal/telemetry/spool_unix_test.go
@@ -1,0 +1,35 @@
+//go:build darwin || linux
+
+package telemetry
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSpoolUsesSecurePermissions(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), ".asc")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("create permissive spool directory: %v", err)
+	}
+	store := testSpoolStore(filepath.Join(dir, spoolFileName))
+	if err := store.append(testSpoolRecord("event-01")); err != nil {
+		t.Fatalf("append event: %v", err)
+	}
+
+	assertFileMode(t, dir, 0o700)
+	assertFileMode(t, store.path, 0o600)
+	assertFileMode(t, store.path+".lock", 0o600)
+}
+
+func assertFileMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("%s mode = %04o, want %04o", path, got, want)
+	}
+}

--- a/internal/telemetry/state.go
+++ b/internal/telemetry/state.go
@@ -22,6 +22,8 @@ const (
 	maxStateFileBytes  = 64 * 1024
 )
 
+var errTelemetryLockBusy = errors.New("telemetry lock busy")
+
 type State struct {
 	InstallID string `json:"install_id,omitempty"`
 	Disabled  bool   `json:"disabled,omitempty"`
@@ -91,10 +93,18 @@ func SetEnabled(enabled bool) error {
 	if err != nil {
 		return err
 	}
-	return updateState(path, func(st *State) error {
+	if err := updateState(path, func(st *State) error {
 		st.Disabled = !enabled
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
+	if !enabled {
+		if err := purgeDefaultSpool(); err != nil {
+			debugf("telemetry spool purge failed after state opt-out: %v", err)
+		}
+	}
+	return nil
 }
 
 func ResetInstallID() (string, error) {
@@ -174,9 +184,13 @@ func updateStateWithLockTimeout(path string, wait time.Duration, mutate func(*St
 }
 
 func lockState(path string, wait time.Duration) (func(), error) {
+	return lockTelemetryFile(path, wait, "state")
+}
+
+func lockTelemetryFile(path string, wait time.Duration, purpose string) (func(), error) {
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return nil, fmt.Errorf("telemetry: failed to create state directory: %w", err)
+	if err := ensureSecureTelemetryDirectory(dir); err != nil {
+		return nil, fmt.Errorf("telemetry: failed to create %s directory: %w", purpose, err)
 	}
 	lockPath := path + ".lock"
 	deadline := time.Now().Add(wait)
@@ -186,39 +200,43 @@ func lockState(path string, wait time.Duration) (func(), error) {
 			info, statErr := statStateLock(lockPath)
 			if errors.Is(statErr, os.ErrNotExist) {
 				if !waitForStateLockRetry(wait, deadline) {
-					return nil, fmt.Errorf("telemetry: timed out locking state")
+					return nil, telemetryLockBusyError(purpose)
 				}
 				continue
 			}
 			if statErr != nil || !info.IsDir() {
-				return nil, fmt.Errorf("telemetry: failed to open state lock: %w", err)
+				return nil, fmt.Errorf("telemetry: failed to open %s lock: %w", purpose, err)
 			}
 			if time.Since(info.ModTime()) > legacyLockStaleAge {
 				migrated, migrateErr := migrateLegacyStateLockDirectory(lockPath, info)
 				if migrateErr != nil {
-					return nil, fmt.Errorf("telemetry: failed to migrate legacy state lock: %w", migrateErr)
+					return nil, fmt.Errorf("telemetry: failed to migrate legacy %s lock: %w", purpose, migrateErr)
 				}
 				if migrated {
 					continue
 				}
 			}
 			if wait <= 0 || time.Now().After(deadline) {
-				return nil, fmt.Errorf("telemetry: timed out locking state")
+				return nil, telemetryLockBusyError(purpose)
 			}
 			if !waitForStateLockRetry(wait, deadline) {
-				return nil, fmt.Errorf("telemetry: timed out locking state")
+				return nil, telemetryLockBusyError(purpose)
 			}
 			continue
 		}
+		if err := lockFile.Chmod(0o600); err != nil {
+			_ = lockFile.Close()
+			return nil, fmt.Errorf("telemetry: failed to secure %s lock: %w", purpose, err)
+		}
 		if wait > 0 && time.Until(deadline) <= 0 {
 			_ = lockFile.Close()
-			return nil, fmt.Errorf("telemetry: timed out locking state")
+			return nil, telemetryLockBusyError(purpose)
 		}
 
 		locked, lockErr := tryLockStateFile(lockFile)
 		if lockErr != nil {
 			_ = lockFile.Close()
-			return nil, fmt.Errorf("telemetry: failed to lock state: %w", lockErr)
+			return nil, fmt.Errorf("telemetry: failed to lock %s: %w", purpose, lockErr)
 		}
 		if locked {
 			return func() {
@@ -228,14 +246,25 @@ func lockState(path string, wait time.Duration) (func(), error) {
 		}
 		if wait <= 0 || time.Now().After(deadline) {
 			_ = lockFile.Close()
-			return nil, fmt.Errorf("telemetry: timed out locking state")
+			return nil, telemetryLockBusyError(purpose)
 		}
 		if !waitForStateLockRetry(wait, deadline) {
 			_ = lockFile.Close()
-			return nil, fmt.Errorf("telemetry: timed out locking state")
+			return nil, telemetryLockBusyError(purpose)
 		}
 		_ = lockFile.Close()
 	}
+}
+
+func telemetryLockBusyError(purpose string) error {
+	return fmt.Errorf("telemetry: timed out locking %s: %w", purpose, errTelemetryLockBusy)
+}
+
+func ensureSecureTelemetryDirectory(dir string) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	return os.Chmod(dir, 0o700)
 }
 
 func migrateLegacyStateLockDirectory(lockPath string, expected os.FileInfo) (bool, error) {
@@ -326,7 +355,7 @@ func waitForStateLockRetry(wait time.Duration, deadline time.Time) bool {
 
 func saveState(path string, st State, wait time.Duration) error {
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
+	if err := ensureSecureTelemetryDirectory(dir); err != nil {
 		return fmt.Errorf("telemetry: failed to create state directory: %w", err)
 	}
 	st.UpdatedAt = time.Now().UTC().Format(time.RFC3339)

--- a/internal/telemetry/state_lock_unix.go
+++ b/internal/telemetry/state_lock_unix.go
@@ -26,7 +26,20 @@ func unlockStateFile(file *os.File) error {
 }
 
 func openStateFileForRead(path string) (*os.File, error) {
-	return os.Open(path)
+	return openTelemetryFileForRead(path)
+}
+
+func openTelemetryFileForRead(path string) (*os.File, error) {
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NONBLOCK|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, &os.PathError{Op: "open", Path: path, Err: err}
+	}
+	file := os.NewFile(uintptr(fd), path)
+	if file == nil {
+		_ = unix.Close(fd)
+		return nil, &os.PathError{Op: "open", Path: path, Err: unix.EBADF}
+	}
+	return file, nil
 }
 
 func openStateLockForStat(path string) (*os.File, error) {
@@ -34,7 +47,23 @@ func openStateLockForStat(path string) (*os.File, error) {
 }
 
 func replaceStateFile(oldPath, newPath string, _ time.Duration) error {
+	return replaceTelemetryFile(oldPath, newPath, 0)
+}
+
+func replaceTelemetryFile(oldPath, newPath string, _ time.Duration) error {
 	return os.Rename(oldPath, newPath)
+}
+
+func syncTelemetryDirectory(path string) error {
+	dir, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+	if err := dir.Sync(); err != nil && !errors.Is(err, unix.EINVAL) && !errors.Is(err, unix.ENOTSUP) {
+		return err
+	}
+	return nil
 }
 
 func removeLegacyStateLockDirectory(path string) error {

--- a/internal/telemetry/state_lock_windows.go
+++ b/internal/telemetry/state_lock_windows.go
@@ -35,6 +35,10 @@ func unlockStateFile(file *os.File) error {
 }
 
 func openStateFileForRead(path string) (*os.File, error) {
+	return openTelemetryFileForRead(path)
+}
+
+func openTelemetryFileForRead(path string) (*os.File, error) {
 	pathPointer, err := windows.UTF16PtrFromString(path)
 	if err != nil {
 		return nil, &os.PathError{Op: "open", Path: path, Err: err}
@@ -85,6 +89,10 @@ func openStateLockForStat(path string) (*os.File, error) {
 }
 
 func replaceStateFile(oldPath, newPath string, wait time.Duration) error {
+	return replaceTelemetryFile(oldPath, newPath, wait)
+}
+
+func replaceTelemetryFile(oldPath, newPath string, wait time.Duration) error {
 	deadline := time.Now().Add(wait)
 	for {
 		err := os.Rename(oldPath, newPath)
@@ -98,6 +106,10 @@ func replaceStateFile(oldPath, newPath string, wait time.Duration) error {
 			return err
 		}
 	}
+}
+
+func syncTelemetryDirectory(string) error {
+	return nil
 }
 
 func isRetryableStateReplaceError(err error) bool {

--- a/internal/telemetry/worker.go
+++ b/internal/telemetry/worker.go
@@ -1,0 +1,189 @@
+package telemetry
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	internalWorkerArg      = "--asc-internal-telemetry-worker"
+	internalWorkerEnvVar   = "ASC_INTERNAL_TELEMETRY_WORKER"
+	workerResourceName     = "telemetry-worker"
+	workerDiagnosticName   = "telemetry-worker.log"
+	maintenanceWorkerBatch = 16
+	workerLockHandoff      = 100 * time.Millisecond
+)
+
+type eventSender func(Event, string) error
+
+var startMaintenanceWorker = startDetachedMaintenanceWorker
+
+func RunMaintenanceWorkerIfRequested(args []string) bool {
+	if !isMaintenanceWorkerInvocation(args) {
+		return false
+	}
+	if err := runDefaultMaintenanceWorker(); err != nil {
+		debugf("telemetry worker failed: %v", err)
+	}
+	return true
+}
+
+func isMaintenanceWorkerInvocation(args []string) bool {
+	return len(args) == 1 && args[0] == internalWorkerArg && os.Getenv(internalWorkerEnvVar) == "1"
+}
+
+func runDefaultMaintenanceWorker() error {
+	store, err := defaultSpoolStore()
+	if err != nil {
+		return err
+	}
+	workerPath := filepath.Join(filepath.Dir(store.path), workerResourceName)
+	return runMaintenanceWorker(workerPath, store, sendHTTPEventToEndpoint)
+}
+
+func runMaintenanceWorker(workerPath string, store spoolStore, deliver eventSender) error {
+	unlock, err := lockTelemetryFile(workerPath, workerLockHandoff, "worker")
+	if errors.Is(err, errTelemetryLockBusy) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	return flushSpoolWhileEnabled(store, deliver, func() (bool, error) {
+		return telemetryDeliveryAllowed(store)
+	})
+}
+
+func flushSpool(store spoolStore, deliver eventSender) error {
+	return flushSpoolWhileEnabled(store, deliver, func() (bool, error) { return true, nil })
+}
+
+func flushSpoolWhileEnabled(
+	store spoolStore,
+	deliver eventSender,
+	deliveryAllowed func() (bool, error),
+) error {
+	for {
+		records, err := store.snapshot(maintenanceWorkerBatch)
+		if err != nil {
+			return err
+		}
+		if len(records) == 0 {
+			return nil
+		}
+
+		delivered := make(map[string]struct{}, len(records))
+		hadFailure := false
+		for _, record := range records {
+			allowed, err := deliveryAllowed()
+			if err != nil {
+				return err
+			}
+			if !allowed {
+				return nil
+			}
+			if err := deliver(record.Event, record.Endpoint); err != nil {
+				hadFailure = true
+				debugf("telemetry send failed: %v", err)
+				continue
+			}
+			delivered[record.Event.EventID] = struct{}{}
+		}
+		if err := store.removeDelivered(delivered); err != nil {
+			return err
+		}
+		if hadFailure {
+			return nil
+		}
+	}
+}
+
+func telemetryDeliveryAllowed(store spoolStore) (bool, error) {
+	if reason := environmentOptOutReason(); reason != "" {
+		purgeSpoolAfterOptOut(store, reason)
+		return false, nil
+	}
+	state, err := loadCurrentState()
+	if err != nil {
+		debugf("telemetry worker disabled: %v", err)
+		return false, nil
+	}
+	if enabled, reason := enabledFromState(state); !enabled {
+		purgeSpoolAfterOptOut(store, reason)
+		return false, nil
+	}
+	return true, nil
+}
+
+func purgeSpoolAfterOptOut(store spoolStore, reason string) {
+	if err := store.purge(); err != nil {
+		debugf("telemetry spool purge failed after %s: %v", reason, err)
+		return
+	}
+	debugf("telemetry spool purged after %s", reason)
+}
+
+func startDetachedMaintenanceWorker() error {
+	executable, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve executable: %w", err)
+	}
+	command := exec.Command(executable, internalWorkerArg)
+	command.Env = setEnvironmentValue(os.Environ(), internalWorkerEnvVar, "1")
+	configureDetachedProcess(command)
+
+	var diagnostic *os.File
+	if debugEnabled() {
+		store, pathErr := defaultSpoolStore()
+		if pathErr != nil {
+			debugf("telemetry worker diagnostics unavailable: %v", pathErr)
+		} else if err := ensureSecureTelemetryDirectory(filepath.Dir(store.path)); err != nil {
+			debugf("telemetry worker diagnostics unavailable: %v", err)
+		} else {
+			diagnosticPath := filepath.Join(filepath.Dir(store.path), workerDiagnosticName)
+			diagnostic, err = os.OpenFile(diagnosticPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+			if err != nil {
+				debugf("telemetry worker diagnostics unavailable: %v", err)
+			} else if err := diagnostic.Chmod(0o600); err != nil {
+				_ = diagnostic.Close()
+				diagnostic = nil
+				debugf("telemetry worker diagnostics unavailable: %v", err)
+			} else {
+				command.Stderr = diagnostic
+				debugf("telemetry worker diagnostics: %s", diagnosticPath)
+			}
+		}
+	}
+
+	if err := command.Start(); err != nil {
+		if diagnostic != nil {
+			_ = diagnostic.Close()
+		}
+		return fmt.Errorf("start worker: %w", err)
+	}
+	if diagnostic != nil {
+		_ = diagnostic.Close()
+	}
+	if err := command.Process.Release(); err != nil {
+		return fmt.Errorf("release worker: %w", err)
+	}
+	return nil
+}
+
+func setEnvironmentValue(environment []string, key, value string) []string {
+	result := make([]string, 0, len(environment)+1)
+	for _, entry := range environment {
+		name, _, _ := strings.Cut(entry, "=")
+		if name != key {
+			result = append(result, entry)
+		}
+	}
+	return append(result, key+"="+value)
+}

--- a/internal/telemetry/worker_process_unix.go
+++ b/internal/telemetry/worker_process_unix.go
@@ -1,0 +1,12 @@
+//go:build darwin || linux
+
+package telemetry
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func configureDetachedProcess(command *exec.Cmd) {
+	command.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}

--- a/internal/telemetry/worker_process_unix_test.go
+++ b/internal/telemetry/worker_process_unix_test.go
@@ -1,0 +1,16 @@
+//go:build darwin || linux
+
+package telemetry
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestConfigureDetachedProcessCreatesNewSession(t *testing.T) {
+	command := &exec.Cmd{}
+	configureDetachedProcess(command)
+	if command.SysProcAttr == nil || !command.SysProcAttr.Setsid {
+		t.Fatalf("detached SysProcAttr = %+v, want Setsid", command.SysProcAttr)
+	}
+}

--- a/internal/telemetry/worker_process_windows.go
+++ b/internal/telemetry/worker_process_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package telemetry
+
+import (
+	"os/exec"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+func configureDetachedProcess(command *exec.Cmd) {
+	command.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: uint32(windows.DETACHED_PROCESS | windows.CREATE_NEW_PROCESS_GROUP),
+		HideWindow:    true,
+	}
+}

--- a/internal/telemetry/worker_process_windows_test.go
+++ b/internal/telemetry/worker_process_windows_test.go
@@ -1,0 +1,25 @@
+//go:build windows
+
+package telemetry
+
+import (
+	"os/exec"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestConfigureDetachedProcessUsesWindowsDetachFlags(t *testing.T) {
+	command := &exec.Cmd{}
+	configureDetachedProcess(command)
+	if command.SysProcAttr == nil {
+		t.Fatal("detached SysProcAttr is nil")
+	}
+	want := uint32(windows.DETACHED_PROCESS | windows.CREATE_NEW_PROCESS_GROUP)
+	if got := command.SysProcAttr.CreationFlags & want; got != want {
+		t.Fatalf("CreationFlags = %#x, want %#x", command.SysProcAttr.CreationFlags, want)
+	}
+	if !command.SysProcAttr.HideWindow {
+		t.Fatal("detached worker window is visible")
+	}
+}

--- a/internal/telemetry/worker_test.go
+++ b/internal/telemetry/worker_test.go
@@ -1,0 +1,200 @@
+package telemetry
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestFlushSpoolRemovesSuccessfullyDeliveredEvents(t *testing.T) {
+	store := testSpoolStore(filepath.Join(t.TempDir(), spoolFileName))
+	for _, id := range []string{"event-01", "event-02"} {
+		if err := store.append(testSpoolRecord(id)); err != nil {
+			t.Fatalf("append %s: %v", id, err)
+		}
+	}
+
+	var delivered []string
+	err := flushSpool(store, func(event Event, endpoint string) error {
+		delivered = append(delivered, event.EventID+"@"+endpoint)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("flushSpool() error = %v", err)
+	}
+	if len(delivered) != 2 {
+		t.Fatalf("delivered events = %v, want 2", delivered)
+	}
+	assertSpoolEventIDs(t, store)
+}
+
+func TestFlushSpoolRetainsOnlyFailedEvents(t *testing.T) {
+	store := testSpoolStore(filepath.Join(t.TempDir(), spoolFileName))
+	for _, id := range []string{"event-01", "event-02", "event-03"} {
+		if err := store.append(testSpoolRecord(id)); err != nil {
+			t.Fatalf("append %s: %v", id, err)
+		}
+	}
+
+	err := flushSpool(store, func(event Event, _ string) error {
+		if event.EventID == "event-02" {
+			return errors.New("endpoint unavailable")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("flushSpool() error = %v", err)
+	}
+	assertSpoolEventIDs(t, store, "event-02")
+}
+
+func TestMaintenanceWorkerDeduplicatesActiveFlushes(t *testing.T) {
+	clearContextEnv(t)
+	setTelemetryTestHome(t)
+	store := testSpoolStore(filepath.Join(t.TempDir(), spoolFileName))
+	if err := store.append(testSpoolRecord("event-01")); err != nil {
+		t.Fatalf("append event: %v", err)
+	}
+	workerPath := filepath.Join(t.TempDir(), "telemetry-worker")
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	firstDone := make(chan error, 1)
+	var deliveries atomic.Int32
+	deliver := func(event Event, _ string) error {
+		if event.EventID == "" {
+			return errors.New("missing event ID")
+		}
+		if deliveries.Add(1) == 1 {
+			close(entered)
+		}
+		<-release
+		return nil
+	}
+	go func() {
+		firstDone <- runMaintenanceWorker(workerPath, store, deliver)
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("first worker did not begin delivery")
+	}
+	if err := runMaintenanceWorker(workerPath, store, deliver); err != nil {
+		t.Fatalf("duplicate worker error = %v", err)
+	}
+	if got := deliveries.Load(); got != 1 {
+		t.Fatalf("deliveries while first worker active = %d, want 1", got)
+	}
+
+	close(release)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first worker error = %v", err)
+	}
+}
+
+func TestMaintenanceWorkerWaitsForPreviousWorkerHandoff(t *testing.T) {
+	clearContextEnv(t)
+	setTelemetryTestHome(t)
+	store := testSpoolStore(filepath.Join(t.TempDir(), spoolFileName))
+	if err := store.append(testSpoolRecord("event-01")); err != nil {
+		t.Fatalf("append event: %v", err)
+	}
+	workerPath := filepath.Join(t.TempDir(), "telemetry-worker")
+	unlock, err := lockTelemetryFile(workerPath, 0, "worker")
+	if err != nil {
+		t.Fatalf("lock active worker: %v", err)
+	}
+
+	delivered := make(chan struct{}, 1)
+	done := make(chan error, 1)
+	go func() {
+		done <- runMaintenanceWorker(workerPath, store, func(Event, string) error {
+			delivered <- struct{}{}
+			return nil
+		})
+	}()
+	select {
+	case <-delivered:
+		unlock()
+		t.Fatal("handoff worker delivered before active worker released lock")
+	case <-time.After(20 * time.Millisecond):
+	}
+	unlock()
+
+	select {
+	case <-delivered:
+	case <-time.After(time.Second):
+		t.Fatal("handoff worker did not flush after active worker released lock")
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("handoff worker error = %v", err)
+	}
+}
+
+func TestMaintenanceWorkerPurgesQueueWhenEnvironmentOptsOut(t *testing.T) {
+	clearContextEnv(t)
+	setTelemetryTestHome(t)
+	store, err := defaultSpoolStore()
+	if err != nil {
+		t.Fatalf("defaultSpoolStore() error = %v", err)
+	}
+	if err := store.append(testSpoolRecord("event-01")); err != nil {
+		t.Fatalf("append event: %v", err)
+	}
+	t.Setenv("ASC_TELEMETRY_DISABLED", "1")
+
+	err = runMaintenanceWorker(filepath.Join(filepath.Dir(store.path), "telemetry-worker"), store, func(Event, string) error {
+		t.Fatal("worker delivered an event after opt-out")
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("runMaintenanceWorker() error = %v", err)
+	}
+	if _, err := os.Stat(store.path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("spool stat error = %v, want not exist after opt-out", err)
+	}
+}
+
+func TestSetEnabledFalsePurgesQueuedEvents(t *testing.T) {
+	clearContextEnv(t)
+	setTelemetryTestHome(t)
+	store, err := defaultSpoolStore()
+	if err != nil {
+		t.Fatalf("defaultSpoolStore() error = %v", err)
+	}
+	if err := store.append(testSpoolRecord("event-01")); err != nil {
+		t.Fatalf("append event: %v", err)
+	}
+	crashTempPath := store.path + ".crash.tmp"
+	if err := os.WriteFile(crashTempPath, []byte("queued telemetry"), 0o600); err != nil {
+		t.Fatalf("write abandoned temp file: %v", err)
+	}
+
+	if err := SetEnabled(false); err != nil {
+		t.Fatalf("SetEnabled(false) error = %v", err)
+	}
+	if _, err := os.Stat(store.path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("spool stat error = %v, want not exist after disable", err)
+	}
+	if _, err := os.Stat(crashTempPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("crash temp stat error = %v, want not exist after disable", err)
+	}
+}
+
+func TestInternalWorkerInvocationRequiresMarker(t *testing.T) {
+	t.Setenv(internalWorkerEnvVar, "")
+	if isMaintenanceWorkerInvocation([]string{internalWorkerArg}) {
+		t.Fatal("worker argument was accepted without internal marker")
+	}
+	t.Setenv(internalWorkerEnvVar, "1")
+	if !isMaintenanceWorkerInvocation([]string{internalWorkerArg}) {
+		t.Fatal("worker argument and marker were not recognized")
+	}
+	if isMaintenanceWorkerInvocation([]string{internalWorkerArg, "extra"}) {
+		t.Fatal("worker invocation accepted extra arguments")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/telemetry"
 )
 
 var (
@@ -18,6 +19,9 @@ func versionInfoString() string {
 }
 
 func run(args []string) int {
+	if telemetry.RunMaintenanceWorkerIfRequested(args) {
+		return cmd.ExitSuccess
+	}
 	return cmd.Run(args, versionInfoString())
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -31,3 +31,13 @@ func TestRunVersionFlagReturnsSuccess(t *testing.T) {
 		t.Fatalf("expected exit success (%d), got %d", cmd.ExitSuccess, code)
 	}
 }
+
+func TestRunHandlesInternalTelemetryWorkerBeforeCLI(t *testing.T) {
+	t.Setenv("ASC_INTERNAL_TELEMETRY_WORKER", "1")
+	t.Setenv("HOME", t.TempDir())
+
+	code := run([]string{"--asc-internal-telemetry-worker"})
+	if code != cmd.ExitSuccess {
+		t.Fatalf("internal telemetry worker exit code = %d, want %d", code, cmd.ExitSuccess)
+	}
+}


### PR DESCRIPTION
## Summary
- Replace synchronous telemetry delivery with a bounded, owner-only JSONL spool and a detached maintenance worker.
- Reuse the existing cross-process state locks and atomic replacement primitives for concurrent writers, crash recovery, and success-only queue removal.
- Purge queued events and orphaned atomic-write files after opt-out; preserve disabled, endpoint override, ephemeral, privacy allowlist, debug, identifier, and schema behavior.
- Skip help and version telemetry. Private worker interception lives in main.run so it does not overlap the skills PR hook in cmd.Run.

## Compatibility
No public command, flag, output, identifier, or event-schema contract changes.

The spool is capped at 128 records, 256 KiB total, and 16 KiB per record. Oldest records are evicted first; an oversized newest record is rejected without evicting the existing queue. Storage and worker failures remain best-effort and never fail the user command.

Delivery is at least once: a worker crash after server receipt but before atomic queue replacement can retry an event with the same event_id.

## Validation
- Established RED: the foreground sender paid the 250 ms network deadline, and help/group invocations emitted telemetry.
- Built `/tmp/asc-telemetry-before` from base `9e9649c8c1064daf7e5a79ec78db5527847a2980` and `/tmp/asc-telemetry` from this change.
- Controlled blocked TLS endpoint, five warmed real invocations of `asc builds --definitely-invalid`:
  - Before: 271.2, 276.6, 272.2, 273.1, 271.5 ms
  - After: 33.0, 33.7, 30.0, 31.3, 32.2 ms
- Real built-binary test confirms blocked telemetry adds less than 175 ms and the detached worker reaches the blocked endpoint.
- `ASC_BYPASS_KEYCHAIN=1 go test -race ./internal/telemetry -count=1`
- Darwin amd64/arm64, Linux amd64/arm64, and Windows amd64 builds; Windows telemetry test compilation.
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`

Required remote checks are green: `format-and-lint`, `unit-tests`, and `build`. Merge remains gated on one approval and resolved conversations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Telemetry is now queued and delivered in the background, reducing command-line delays.
  * Telemetry delivery supports configured secure endpoints and automatically manages queued events.
  * Added improved handling for telemetry preferences, including cleanup when telemetry is disabled.

* **Bug Fixes**
  * Help, version, and bare-group help commands no longer emit telemetry.
  * Invalid or blocked telemetry endpoints no longer delay command completion.
  * Improved protection for telemetry data files and endpoint configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->