### PR TITLE
perf: collapse and parallelize readiness validation

### DIFF
--- a/internal/asc/client.go
+++ b/internal/asc/client.go
@@ -1649,8 +1649,16 @@ func (c *Client) DeleteAppInfoLocalization(ctx context.Context, localizationID s
 }
 
 // GetAppInfos retrieves app info records for an app.
-func (c *Client) GetAppInfos(ctx context.Context, appID string) (*AppInfosResponse, error) {
+func (c *Client) GetAppInfos(ctx context.Context, appID string, opts ...AppInfoOption) (*AppInfosResponse, error) {
+	query := &appInfoQuery{}
+	for _, opt := range opts {
+		opt(query)
+	}
+
 	path := fmt.Sprintf("/v1/apps/%s/appInfos", appID)
+	if queryString := buildAppInfoQuery(query); queryString != "" {
+		path += "?" + queryString
+	}
 	data, err := c.do(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, err

--- a/internal/asc/client_http_test.go
+++ b/internal/asc/client_http_test.go
@@ -1612,6 +1612,31 @@ func TestGetAppStoreVersion(t *testing.T) {
 	}
 }
 
+func TestGetAppStoreVersion_WithCompoundReadOptions(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":{"type":"appStoreVersions","id":"1"},"included":[]}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/appStoreVersions/1" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+		if got := req.URL.Query().Get("include"); got != "appStoreVersionLocalizations,build,appStoreReviewDetail" {
+			t.Fatalf("include = %q", got)
+		}
+		if got := req.URL.Query().Get("limit[appStoreVersionLocalizations]"); got != "50" {
+			t.Fatalf("localization include limit = %q", got)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetAppStoreVersion(
+		context.Background(),
+		"1",
+		WithAppStoreVersionInclude([]string{"appStoreVersionLocalizations", "build", "appStoreReviewDetail"}),
+		WithAppStoreVersionLocalizationsIncludeLimit(50),
+	); err != nil {
+		t.Fatalf("GetAppStoreVersion() error: %v", err)
+	}
+}
+
 func TestCreateAppStoreVersion(t *testing.T) {
 	response := jsonResponse(http.StatusCreated, `{"data":{"type":"appStoreVersions","id":"VERSION_123","attributes":{"versionString":"1.0.0","platform":"IOS"}}}`)
 	client := newTestClient(t, func(req *http.Request) {
@@ -3674,6 +3699,31 @@ func TestGetAppInfos(t *testing.T) {
 	}, response)
 
 	if _, err := client.GetAppInfos(context.Background(), "app-1"); err != nil {
+		t.Fatalf("GetAppInfos() error: %v", err)
+	}
+}
+
+func TestGetAppInfos_WithCompoundReadOptions(t *testing.T) {
+	response := jsonResponse(http.StatusOK, `{"data":[{"type":"appInfos","id":"info-1"}],"included":[]}`)
+	client := newTestClient(t, func(req *http.Request) {
+		if req.Method != http.MethodGet || req.URL.Path != "/v1/apps/app-1/appInfos" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+		if got := req.URL.Query().Get("include"); got != "app,ageRatingDeclaration,appInfoLocalizations,primaryCategory" {
+			t.Fatalf("include = %q", got)
+		}
+		if got := req.URL.Query().Get("limit[appInfoLocalizations]"); got != "50" {
+			t.Fatalf("localization include limit = %q", got)
+		}
+		assertAuthorized(t, req)
+	}, response)
+
+	if _, err := client.GetAppInfos(
+		context.Background(),
+		"app-1",
+		WithAppInfoInclude([]string{"app", "ageRatingDeclaration", "appInfoLocalizations", "primaryCategory"}),
+		WithAppInfoLocalizationsIncludeLimit(50),
+	); err != nil {
 		t.Fatalf("GetAppInfos() error: %v", err)
 	}
 }

--- a/internal/asc/client_options.go
+++ b/internal/asc/client_options.go
@@ -1822,6 +1822,16 @@ func WithAppStoreVersionInclude(include []string) AppStoreVersionOption {
 	}
 }
 
+// WithAppStoreVersionLocalizationsIncludeLimit sets the maximum number of
+// localizations returned through an app store version include.
+func WithAppStoreVersionLocalizationsIncludeLimit(limit int) AppStoreVersionOption {
+	return func(q *appStoreVersionQuery) {
+		if limit > 0 {
+			q.localizationsLimit = limit
+		}
+	}
+}
+
 // WithReviewSubmissionsLimit sets the max number of review submissions to return.
 func WithReviewSubmissionsLimit(limit int) ReviewSubmissionsOption {
 	return func(q *reviewSubmissionsQuery) {
@@ -3113,6 +3123,16 @@ func WithAppInfoLocalizationLocales(locales []string) AppInfoLocalizationsOption
 func WithAppInfoInclude(include []string) AppInfoOption {
 	return func(q *appInfoQuery) {
 		q.include = normalizeList(include)
+	}
+}
+
+// WithAppInfoLocalizationsIncludeLimit sets the maximum number of
+// localizations returned through an app info include.
+func WithAppInfoLocalizationsIncludeLimit(limit int) AppInfoOption {
+	return func(q *appInfoQuery) {
+		if limit > 0 {
+			q.localizationsLimit = limit
+		}
 	}
 }
 

--- a/internal/asc/client_queries.go
+++ b/internal/asc/client_queries.go
@@ -252,7 +252,8 @@ type appStoreVersionsQuery struct {
 }
 
 type appStoreVersionQuery struct {
-	include []string
+	include            []string
+	localizationsLimit int
 }
 
 type reviewSubmissionsQuery struct {
@@ -310,7 +311,8 @@ type appInfoLocalizationsQuery struct {
 }
 
 type appInfoQuery struct {
-	include []string
+	include            []string
+	localizationsLimit int
 }
 
 type territoryAgeRatingsQuery struct {
@@ -1364,6 +1366,9 @@ func buildAppStoreVersionsQuery(query *appStoreVersionsQuery) string {
 func buildAppStoreVersionQuery(query *appStoreVersionQuery) string {
 	values := url.Values{}
 	addCSV(values, "include", query.include)
+	if query.localizationsLimit > 0 {
+		values.Set("limit[appStoreVersionLocalizations]", strconv.Itoa(query.localizationsLimit))
+	}
 	return values.Encode()
 }
 
@@ -1457,6 +1462,9 @@ func buildAppInfoLocalizationsQuery(query *appInfoLocalizationsQuery) string {
 func buildAppInfoQuery(query *appInfoQuery) string {
 	values := url.Values{}
 	addCSV(values, "include", query.include)
+	if query.localizationsLimit > 0 {
+		values.Set("limit[appInfoLocalizations]", strconv.Itoa(query.localizationsLimit))
+	}
 	return values.Encode()
 }
 

--- a/internal/asc/client_test.go
+++ b/internal/asc/client_test.go
@@ -980,6 +980,7 @@ func TestBuildAppSearchKeywordsQuery(t *testing.T) {
 func TestBuildAppStoreVersionQuery(t *testing.T) {
 	query := &appStoreVersionQuery{}
 	WithAppStoreVersionInclude([]string{"appStoreReviewDetail", "ageRatingDeclaration"})(query)
+	WithAppStoreVersionLocalizationsIncludeLimit(50)(query)
 
 	values, err := url.ParseQuery(buildAppStoreVersionQuery(query))
 	if err != nil {
@@ -988,11 +989,15 @@ func TestBuildAppStoreVersionQuery(t *testing.T) {
 	if got := values.Get("include"); got != "appStoreReviewDetail,ageRatingDeclaration" {
 		t.Fatalf("expected include=appStoreReviewDetail,ageRatingDeclaration, got %q", got)
 	}
+	if got := values.Get("limit[appStoreVersionLocalizations]"); got != "50" {
+		t.Fatalf("expected localization include limit 50, got %q", got)
+	}
 }
 
 func TestBuildAppInfoQuery(t *testing.T) {
 	query := &appInfoQuery{}
 	WithAppInfoInclude([]string{"ageRatingDeclaration", "territoryAgeRatings"})(query)
+	WithAppInfoLocalizationsIncludeLimit(50)(query)
 
 	values, err := url.ParseQuery(buildAppInfoQuery(query))
 	if err != nil {
@@ -1000,6 +1005,9 @@ func TestBuildAppInfoQuery(t *testing.T) {
 	}
 	if got := values.Get("include"); got != "ageRatingDeclaration,territoryAgeRatings" {
 		t.Fatalf("expected include=ageRatingDeclaration,territoryAgeRatings, got %q", got)
+	}
+	if got := values.Get("limit[appInfoLocalizations]"); got != "50" {
+		t.Fatalf("expected localization include limit 50, got %q", got)
 	}
 }
 

--- a/internal/cli/validate/availability.go
+++ b/internal/cli/validate/availability.go
@@ -16,12 +16,15 @@ import (
 var fetchAvailableTerritoryDetailsFn = fetchAvailableTerritoryDetails
 
 func fetchAvailableTerritoryDetails(ctx context.Context, client *asc.Client, appID string) (string, []string, int, error) {
+	ctx = withReadinessRequestGate(ctx)
 	availabilityID := ""
 	availableTerritories := 0
 	decodedAvailableTerritories := 0
 	territoryIDs := make(map[string]struct{})
 
-	availabilityResp, err := client.GetAppAvailabilityV2(ctx, appID)
+	availabilityResp, err := doReadinessRequest(ctx, func(requestCtx context.Context) (*asc.AppAvailabilityV2Response, error) {
+		return client.GetAppAvailabilityV2(requestCtx, appID)
+	})
 	if err != nil {
 		if shared.IsAppAvailabilityMissing(err) {
 			return "", nil, 0, nil
@@ -36,12 +39,13 @@ func fetchAvailableTerritoryDetails(ctx context.Context, client *asc.Client, app
 
 	nextURL := ""
 	for {
-		var territoryResp *asc.TerritoryAvailabilitiesResponse
-		if strings.TrimSpace(nextURL) != "" {
-			territoryResp, err = client.GetTerritoryAvailabilities(ctx, availabilityID, asc.WithTerritoryAvailabilitiesNextURL(nextURL))
-		} else {
-			territoryResp, err = client.GetTerritoryAvailabilities(ctx, availabilityID, asc.WithTerritoryAvailabilitiesLimit(200))
-		}
+		territoryResp, requestErr := doReadinessRequest(ctx, func(requestCtx context.Context) (*asc.TerritoryAvailabilitiesResponse, error) {
+			if strings.TrimSpace(nextURL) != "" {
+				return client.GetTerritoryAvailabilities(requestCtx, availabilityID, asc.WithTerritoryAvailabilitiesNextURL(nextURL))
+			}
+			return client.GetTerritoryAvailabilities(requestCtx, availabilityID, asc.WithTerritoryAvailabilitiesLimit(200))
+		})
+		err = requestErr
 		if err != nil {
 			return availabilityID, nil, availableTerritories, fmt.Errorf("failed to fetch territory availabilities: %w", err)
 		}

--- a/internal/cli/validate/builds.go
+++ b/internal/cli/validate/builds.go
@@ -6,15 +6,15 @@ import (
 	"fmt"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
-	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 )
 
 var fetchAppBuildCountFn = fetchAppBuildCount
 
 func fetchAppBuildCount(ctx context.Context, client *asc.Client, appID string) (int, metadataCheckStatus, error) {
-	reqCtx, cancel := shared.ContextWithTimeout(ctx)
-	resp, err := client.GetBuilds(reqCtx, appID)
-	cancel()
+	ctx = withReadinessRequestGate(ctx)
+	resp, err := doReadinessRequest(ctx, func(requestCtx context.Context) (*asc.BuildsResponse, error) {
+		return client.GetBuilds(requestCtx, appID)
+	})
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			return 0, metadataCheckStatus{}, err

--- a/internal/cli/validate/compound.go
+++ b/internal/cli/validate/compound.go
@@ -1,0 +1,268 @@
+package validate
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/validation"
+)
+
+const compoundLocalizationLimit = 50
+
+type compoundLinkageState uint8
+
+const (
+	compoundLinkageFallback compoundLinkageState = iota
+	compoundLinkageEmpty
+	compoundLinkageResolved
+)
+
+type includedResourceKey struct {
+	resourceType asc.ResourceType
+	id           string
+}
+
+type includedResourceIndex struct {
+	resources map[includedResourceKey]json.RawMessage
+	ambiguous map[includedResourceKey]struct{}
+	decodable bool
+}
+
+func newIncludedResourceIndex(raw json.RawMessage) includedResourceIndex {
+	index := includedResourceIndex{
+		resources: make(map[includedResourceKey]json.RawMessage),
+		ambiguous: make(map[includedResourceKey]struct{}),
+	}
+	if len(bytes.TrimSpace(raw)) == 0 || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return index
+	}
+
+	var items []json.RawMessage
+	if err := json.Unmarshal(raw, &items); err != nil {
+		return index
+	}
+	index.decodable = true
+
+	for _, item := range items {
+		var identity struct {
+			Type asc.ResourceType `json:"type"`
+			ID   string           `json:"id"`
+		}
+		if err := json.Unmarshal(item, &identity); err != nil {
+			continue
+		}
+		identity.ID = strings.TrimSpace(identity.ID)
+		if identity.Type == "" || identity.ID == "" {
+			continue
+		}
+
+		key := includedResourceKey{resourceType: identity.Type, id: identity.ID}
+		if _, exists := index.resources[key]; exists {
+			index.ambiguous[key] = struct{}{}
+			continue
+		}
+		index.resources[key] = append(json.RawMessage(nil), item...)
+	}
+
+	return index
+}
+
+func decodeIncludedResource[T any](index includedResourceIndex, resourceType asc.ResourceType, id string) (asc.Resource[T], bool) {
+	var zero asc.Resource[T]
+	id = strings.TrimSpace(id)
+	if !index.decodable || id == "" {
+		return zero, false
+	}
+
+	key := includedResourceKey{resourceType: resourceType, id: id}
+	if _, ambiguous := index.ambiguous[key]; ambiguous {
+		return zero, false
+	}
+	raw, ok := index.resources[key]
+	if !ok {
+		return zero, false
+	}
+
+	var resource asc.Resource[T]
+	if err := json.Unmarshal(raw, &resource); err != nil {
+		return zero, false
+	}
+	if resource.Type != resourceType || strings.TrimSpace(resource.ID) != id {
+		return zero, false
+	}
+	return resource, true
+}
+
+func resolveCompoundToOne[T any](relationships json.RawMessage, included includedResourceIndex, name string, resourceType asc.ResourceType) (asc.Resource[T], compoundLinkageState) {
+	var zero asc.Resource[T]
+	id, state := compoundToOneID(relationships, name, resourceType)
+	if state != compoundLinkageResolved {
+		return zero, state
+	}
+	resource, ok := decodeIncludedResource[T](included, resourceType, id)
+	if !ok {
+		return zero, compoundLinkageFallback
+	}
+	return resource, compoundLinkageResolved
+}
+
+func resolveCompoundToMany[T any](relationships json.RawMessage, included includedResourceIndex, name string, resourceType asc.ResourceType) ([]asc.Resource[T], bool) {
+	ids, ok := compoundToManyIDs(relationships, name, resourceType)
+	if !ok {
+		return nil, false
+	}
+
+	resources := make([]asc.Resource[T], 0, len(ids))
+	for _, id := range ids {
+		resource, found := decodeIncludedResource[T](included, resourceType, id)
+		if !found {
+			return nil, false
+		}
+		resources = append(resources, resource)
+	}
+	return resources, true
+}
+
+func compoundToOneID(relationships json.RawMessage, name string, resourceType asc.ResourceType) (string, compoundLinkageState) {
+	relationship, ok := compoundRelationship(relationships, name)
+	if !ok || len(bytes.TrimSpace(relationship.Data)) == 0 {
+		return "", compoundLinkageFallback
+	}
+	if bytes.Equal(bytes.TrimSpace(relationship.Data), []byte("null")) {
+		return "", compoundLinkageEmpty
+	}
+
+	var linkage asc.ResourceData
+	if err := json.Unmarshal(relationship.Data, &linkage); err != nil {
+		return "", compoundLinkageFallback
+	}
+	linkage.ID = strings.TrimSpace(linkage.ID)
+	if linkage.Type != resourceType || linkage.ID == "" {
+		return "", compoundLinkageFallback
+	}
+	return linkage.ID, compoundLinkageResolved
+}
+
+func compoundToManyIDs(relationships json.RawMessage, name string, resourceType asc.ResourceType) ([]string, bool) {
+	relationship, ok := compoundRelationship(relationships, name)
+	if !ok || len(bytes.TrimSpace(relationship.Data)) == 0 || bytes.Equal(bytes.TrimSpace(relationship.Data), []byte("null")) {
+		return nil, false
+	}
+
+	var linkages []asc.ResourceData
+	if err := json.Unmarshal(relationship.Data, &linkages); err != nil {
+		return nil, false
+	}
+
+	ids := make([]string, 0, len(linkages))
+	seen := make(map[string]struct{}, len(linkages))
+	for _, linkage := range linkages {
+		linkage.ID = strings.TrimSpace(linkage.ID)
+		if linkage.Type != resourceType || linkage.ID == "" {
+			return nil, false
+		}
+		if _, duplicate := seen[linkage.ID]; duplicate {
+			return nil, false
+		}
+		seen[linkage.ID] = struct{}{}
+		ids = append(ids, linkage.ID)
+	}
+
+	if !compoundRelationshipIsComplete(relationship.Meta, len(ids)) {
+		return nil, false
+	}
+	return ids, true
+}
+
+type rawCompoundRelationship struct {
+	Data json.RawMessage `json:"data"`
+	Meta json.RawMessage `json:"meta"`
+}
+
+func compoundRelationship(relationships json.RawMessage, name string) (rawCompoundRelationship, bool) {
+	var zero rawCompoundRelationship
+	if len(bytes.TrimSpace(relationships)) == 0 {
+		return zero, false
+	}
+
+	var rawRelationships map[string]json.RawMessage
+	if err := json.Unmarshal(relationships, &rawRelationships); err != nil {
+		return zero, false
+	}
+	raw, ok := rawRelationships[name]
+	if !ok {
+		return zero, false
+	}
+
+	var relationship rawCompoundRelationship
+	if err := json.Unmarshal(raw, &relationship); err != nil {
+		return zero, false
+	}
+	return relationship, true
+}
+
+func compoundRelationshipIsComplete(meta json.RawMessage, linkedCount int) bool {
+	if len(bytes.TrimSpace(meta)) == 0 || bytes.Equal(bytes.TrimSpace(meta), []byte("null")) {
+		return linkedCount < compoundLocalizationLimit
+	}
+
+	var paging struct {
+		Paging struct {
+			Total      *int   `json:"total"`
+			NextCursor string `json:"nextCursor"`
+		} `json:"paging"`
+	}
+	if err := json.Unmarshal(meta, &paging); err != nil {
+		return false
+	}
+	if strings.TrimSpace(paging.Paging.NextCursor) != "" {
+		return false
+	}
+	if paging.Paging.Total == nil {
+		return linkedCount < compoundLocalizationLimit
+	}
+	return *paging.Paging.Total == linkedCount
+}
+
+func mapReviewDetails(resource asc.Resource[asc.AppStoreReviewDetailAttributes]) *validation.ReviewDetails {
+	attrs := resource.Attributes
+	return &validation.ReviewDetails{
+		ID:                  resource.ID,
+		ContactFirstName:    attrs.ContactFirstName,
+		ContactLastName:     attrs.ContactLastName,
+		ContactEmail:        attrs.ContactEmail,
+		ContactPhone:        attrs.ContactPhone,
+		DemoAccountName:     attrs.DemoAccountName,
+		DemoAccountPassword: attrs.DemoAccountPassword,
+		DemoAccountRequired: attrs.DemoAccountRequired,
+		Notes:               attrs.Notes,
+	}
+}
+
+func mapBuild(resource asc.Resource[asc.BuildAttributes]) *validation.Build {
+	attrs := resource.Attributes
+	return &validation.Build{
+		ID:                      strings.TrimSpace(resource.ID),
+		Version:                 attrs.Version,
+		ProcessingState:         attrs.ProcessingState,
+		Expired:                 attrs.Expired,
+		UsesNonExemptEncryption: attrs.UsesNonExemptEncryption,
+	}
+}
+
+func copyBuild(build *validation.Build) *validation.Build {
+	if build == nil {
+		return nil
+	}
+	return &validation.Build{
+		ID:                            strings.TrimSpace(build.ID),
+		Version:                       build.Version,
+		ProcessingState:               build.ProcessingState,
+		Expired:                       build.Expired,
+		UsesNonExemptEncryption:       build.UsesNonExemptEncryption,
+		AppEncryptionDeclarationID:    strings.TrimSpace(build.AppEncryptionDeclarationID),
+		AppEncryptionDeclarationState: strings.TrimSpace(build.AppEncryptionDeclarationState),
+	}
+}

--- a/internal/cli/validate/concurrency.go
+++ b/internal/cli/validate/concurrency.go
@@ -1,0 +1,85 @@
+package validate
+
+import (
+	"context"
+	"sync"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+const readinessConcurrencyLimit = 4
+
+type readinessRequestGateKey struct{}
+
+type readinessRequestGate struct {
+	sem chan struct{}
+}
+
+type readinessTask func(context.Context) error
+
+func withReadinessRequestGate(ctx context.Context) context.Context {
+	if _, ok := ctx.Value(readinessRequestGateKey{}).(*readinessRequestGate); ok {
+		return ctx
+	}
+	return context.WithValue(ctx, readinessRequestGateKey{}, &readinessRequestGate{
+		sem: make(chan struct{}, readinessConcurrencyLimit),
+	})
+}
+
+func doReadinessRequest[T any](ctx context.Context, request func(context.Context) (T, error)) (T, error) {
+	var zero T
+	gate, _ := ctx.Value(readinessRequestGateKey{}).(*readinessRequestGate)
+	if gate != nil {
+		select {
+		case gate.sem <- struct{}{}:
+			defer func() { <-gate.sem }()
+		case <-ctx.Done():
+			return zero, ctx.Err()
+		}
+	}
+
+	requestCtx, cancel := shared.ContextWithTimeout(ctx)
+	defer cancel()
+	return request(requestCtx)
+}
+
+func runReadinessTasks(ctx context.Context, tasks ...readinessTask) error {
+	if len(tasks) == 0 {
+		return nil
+	}
+
+	groupCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	limit := min(readinessConcurrencyLimit, len(tasks))
+	sem := make(chan struct{}, limit)
+	var wg sync.WaitGroup
+	var firstErr error
+	var errOnce sync.Once
+
+	for _, task := range tasks {
+		if task == nil {
+			continue
+		}
+		wg.Add(1)
+		go func(task readinessTask) {
+			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-groupCtx.Done():
+				return
+			}
+
+			if err := task(groupCtx); err != nil {
+				errOnce.Do(func() {
+					firstErr = err
+					cancel()
+				})
+			}
+		}(task)
+	}
+
+	wg.Wait()
+	return firstErr
+}

--- a/internal/cli/validate/concurrency_test.go
+++ b/internal/cli/validate/concurrency_test.go
@@ -1,0 +1,315 @@
+package validate
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+type requestConcurrencyTracker struct {
+	active atomic.Int32
+	max    atomic.Int32
+}
+
+func (tracker *requestConcurrencyTracker) wait(ctx context.Context, delay time.Duration) error {
+	active := tracker.active.Add(1)
+	defer tracker.active.Add(-1)
+	for {
+		previous := tracker.max.Load()
+		if active <= previous || tracker.max.CompareAndSwap(previous, active) {
+			break
+		}
+	}
+
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func TestFetchScreenshotSets_OverlapsRequestsWithinCapAndSortsDeterministically(t *testing.T) {
+	const delay = 100 * time.Millisecond
+	tracker := &requestConcurrencyTracker{}
+	client := newBuildsTestClient(t, buildsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if err := tracker.wait(req.Context(), delay); err != nil {
+			return nil, err
+		}
+
+		switch {
+		case strings.HasPrefix(req.URL.Path, "/v1/appStoreVersionLocalizations/") && strings.HasSuffix(req.URL.Path, "/appScreenshotSets"):
+			localizationID := strings.TrimSuffix(strings.TrimPrefix(req.URL.Path, "/v1/appStoreVersionLocalizations/"), "/appScreenshotSets")
+			return buildsJSONResponse(http.StatusOK, fmt.Sprintf(`{"data":[{"type":"appScreenshotSets","id":"set-%s","attributes":{"screenshotDisplayType":"APP_IPHONE_65"}}]}`, localizationID))
+		case strings.HasPrefix(req.URL.Path, "/v1/appScreenshotSets/") && strings.HasSuffix(req.URL.Path, "/appScreenshots"):
+			setID := strings.TrimSuffix(strings.TrimPrefix(req.URL.Path, "/v1/appScreenshotSets/"), "/appScreenshots")
+			return buildsJSONResponse(http.StatusOK, fmt.Sprintf(`{"data":[{"type":"appScreenshots","id":"shot-%s","attributes":{"fileName":"%s.png","imageAsset":{"width":1242,"height":2688}}}]}`, setID, setID))
+		default:
+			return buildsJSONResponse(http.StatusNotFound, `{"errors":[{"status":"404"}]}`)
+		}
+	}))
+
+	localizationIDs := []string{"loc-z", "loc-b", "loc-y", "loc-a", "loc-x", "loc-c"}
+	localizations := make([]asc.Resource[asc.AppStoreVersionLocalizationAttributes], 0, len(localizationIDs))
+	for _, id := range localizationIDs {
+		localizations = append(localizations, asc.Resource[asc.AppStoreVersionLocalizationAttributes]{
+			Type: asc.ResourceTypeAppStoreVersionLocalizations,
+			ID:   id,
+			Attributes: asc.AppStoreVersionLocalizationAttributes{
+				Locale: "locale-" + id,
+			},
+		})
+	}
+
+	started := time.Now()
+	sets, err := fetchScreenshotSets(context.Background(), client, localizations)
+	elapsed := time.Since(started)
+	if err != nil {
+		t.Fatalf("fetchScreenshotSets() error = %v", err)
+	}
+	if got := tracker.max.Load(); got > readinessConcurrencyLimit {
+		t.Fatalf("maximum in-flight requests = %d, want <= %d", got, readinessConcurrencyLimit)
+	} else if got < 2 {
+		t.Fatalf("maximum in-flight requests = %d, expected overlap", got)
+	}
+	if elapsed >= 900*time.Millisecond {
+		t.Fatalf("bounded fan-out took %s; serial fixture time is %s", elapsed, time.Duration(len(localizations)*2)*delay)
+	}
+	if len(sets) != len(localizationIDs) {
+		t.Fatalf("got %d screenshot sets, want %d", len(sets), len(localizationIDs))
+	}
+	wantLocalizationIDs := []string{"loc-a", "loc-b", "loc-c", "loc-x", "loc-y", "loc-z"}
+	for index, localizationID := range wantLocalizationIDs {
+		if got := sets[index].LocalizationID; got != localizationID {
+			t.Fatalf("set %d localization = %q, want %q", index, got, localizationID)
+		}
+		if got := sets[index].ID; got != "set-"+localizationID {
+			t.Fatalf("set %d ID = %q, want %q", index, got, "set-"+localizationID)
+		}
+		if len(sets[index].Screenshots) != 1 || sets[index].Screenshots[0].ID != "shot-set-"+localizationID {
+			t.Fatalf("set %d screenshots = %+v", index, sets[index].Screenshots)
+		}
+	}
+}
+
+func TestBuildReadinessReport_OverlapsFiveIndependentReadGroups(t *testing.T) {
+	const (
+		slowDelay  = 300 * time.Millisecond
+		shortDelay = 100 * time.Millisecond
+	)
+	delays := map[string]time.Duration{
+		"/v1/apps/app-1/appPriceSchedule":                              slowDelay,
+		"/v1/apps/app-1/appAvailabilityV2":                             shortDelay,
+		"/v1/appStoreVersionLocalizations/ver-loc-1/appScreenshotSets": shortDelay,
+		"/v1/apps/app-1/subscriptionGroups":                            shortDelay,
+		"/v1/apps/app-1/inAppPurchasesV2":                              shortDelay,
+	}
+	serialDelay := slowDelay + 4*shortDelay
+
+	tracker := &requestConcurrencyTracker{}
+	var mu sync.Mutex
+	requestCounts := make(map[string]int)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if delay, ok := delays[req.URL.Path]; ok {
+			mu.Lock()
+			requestCounts[req.URL.Path]++
+			mu.Unlock()
+			if err := tracker.wait(req.Context(), delay); err != nil {
+				return
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		switch req.URL.Path {
+		case "/v1/appStoreVersions/ver-1":
+			fmt.Fprint(w, `{
+				"data":{"type":"appStoreVersions","id":"ver-1","attributes":{"platform":"IOS","versionString":"1.0"},"relationships":{
+					"appStoreVersionLocalizations":{"data":[{"type":"appStoreVersionLocalizations","id":"ver-loc-1"}],"meta":{"paging":{"total":1,"limit":50}}},
+					"build":{"data":null},
+					"appStoreReviewDetail":{"data":null}
+				}},
+				"included":[{"type":"appStoreVersionLocalizations","id":"ver-loc-1","attributes":{"locale":"en-US"}}]
+			}`)
+		case "/v1/apps/app-1/appInfos":
+			fmt.Fprint(w, `{
+				"data":[{"type":"appInfos","id":"info-1","attributes":{"state":"PREPARE_FOR_SUBMISSION"},"relationships":{
+					"app":{"data":{"type":"apps","id":"app-1"}},
+					"ageRatingDeclaration":{"data":null},
+					"appInfoLocalizations":{"data":[],"meta":{"paging":{"total":0,"limit":50}}},
+					"primaryCategory":{"data":null}
+				}}],
+				"included":[{"type":"apps","id":"app-1","attributes":{"primaryLocale":"en-US"}}]
+			}`)
+		case "/v1/apps/app-1/appPriceSchedule":
+			fmt.Fprint(w, `{"data":{"type":"appPriceSchedules","id":"schedule-1"}}`)
+		case "/v1/apps/app-1/appAvailabilityV2":
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, `{"errors":[{"status":"404","code":"NOT_FOUND"}]}`)
+		case "/v1/appStoreVersionLocalizations/ver-loc-1/appScreenshotSets",
+			"/v1/apps/app-1/subscriptionGroups",
+			"/v1/apps/app-1/inAppPurchasesV2":
+			fmt.Fprint(w, `{"data":[]}`)
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintf(w, `{"errors":[{"status":"500","code":"UNEXPECTED_REQUEST","detail":%q}]}`, req.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	target, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse fixture URL: %v", err)
+	}
+	transport := buildsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		fixtureReq := req.Clone(req.Context())
+		fixtureReq.URL.Scheme = target.Scheme
+		fixtureReq.URL.Host = target.Host
+		fixtureReq.Host = target.Host
+		return server.Client().Transport.RoundTrip(fixtureReq)
+	})
+	client := newBuildsTestClient(t, transport)
+	restoreClient := SetClientFactory(func() (*asc.Client, error) { return client, nil })
+	t.Cleanup(restoreClient)
+
+	started := time.Now()
+	if _, err := BuildReadinessReport(context.Background(), ReadinessOptions{AppID: "app-1", VersionID: "ver-1"}); err != nil {
+		t.Fatalf("BuildReadinessReport() error = %v", err)
+	}
+	elapsed := time.Since(started)
+
+	mu.Lock()
+	defer mu.Unlock()
+	for path := range delays {
+		if got := requestCounts[path]; got != 1 {
+			t.Fatalf("request count for %s = %d, want 1", path, got)
+		}
+	}
+	if got := tracker.max.Load(); got != readinessConcurrencyLimit {
+		t.Fatalf("maximum in-flight top-level reads = %d, want %d", got, readinessConcurrencyLimit)
+	}
+	if elapsed >= 550*time.Millisecond {
+		t.Fatalf("five independent read groups took %s; slowest group is %s and serial fixture time is %s", elapsed, slowDelay, serialDelay)
+	}
+	t.Logf("five independent read groups completed in %s (slowest=%s, serial=%s, max-in-flight=%d)", elapsed, slowDelay, serialDelay, tracker.max.Load())
+}
+
+func TestBuildReadinessReport_CancelsSiblingCompoundReadOnHardError(t *testing.T) {
+	appInfoStarted := make(chan struct{})
+	appInfoCanceled := make(chan struct{})
+	var startedOnce sync.Once
+	var canceledOnce sync.Once
+
+	client := newBuildsTestClient(t, buildsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/v1/apps/app-1/appInfos":
+			startedOnce.Do(func() { close(appInfoStarted) })
+			<-req.Context().Done()
+			canceledOnce.Do(func() { close(appInfoCanceled) })
+			return nil, req.Context().Err()
+		case "/v1/appStoreVersions/ver-1":
+			<-appInfoStarted
+			return buildsJSONResponse(http.StatusBadRequest, `{"errors":[{"status":"400","code":"INVALID_REQUEST","title":"Invalid Request"}]}`)
+		default:
+			return buildsJSONResponse(http.StatusNotFound, `{"errors":[{"status":"404"}]}`)
+		}
+	}))
+	restoreClient := SetClientFactory(func() (*asc.Client, error) { return client, nil })
+	t.Cleanup(restoreClient)
+
+	_, err := BuildReadinessReport(context.Background(), ReadinessOptions{AppID: "app-1", VersionID: "ver-1"})
+	if err == nil || !strings.Contains(err.Error(), "failed to fetch app store version") {
+		t.Fatalf("BuildReadinessReport() error = %v", err)
+	}
+	select {
+	case <-appInfoCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("app-info compound request was not canceled after sibling hard error")
+	}
+}
+
+func TestBuildReadinessReport_SharedGateCapsNestedSubscriptionRequests(t *testing.T) {
+	tracker := &requestConcurrencyTracker{}
+	client := newBuildsTestClient(t, buildsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		delay := 10 * time.Millisecond
+		switch req.URL.Path {
+		case "/v1/apps/app-1/appPriceSchedule", "/v1/apps/app-1/appAvailabilityV2", "/v1/apps/app-1/inAppPurchasesV2":
+			delay = 200 * time.Millisecond
+		case "/v1/apps/app-1/subscriptionGroups":
+			delay = 20 * time.Millisecond
+		case "/v1/subscriptionGroups/group-1/subscriptions",
+			"/v1/subscriptionGroups/group-2/subscriptions",
+			"/v1/subscriptionGroups/group-3/subscriptions",
+			"/v1/subscriptionGroups/group-4/subscriptions":
+			delay = 100 * time.Millisecond
+		}
+		if err := tracker.wait(req.Context(), delay); err != nil {
+			return nil, err
+		}
+
+		switch req.URL.Path {
+		case "/v1/appStoreVersions/ver-1":
+			return buildsJSONResponse(http.StatusOK, `{
+				"data":{"type":"appStoreVersions","id":"ver-1","attributes":{"platform":"IOS","versionString":"1.0"},"relationships":{
+					"appStoreVersionLocalizations":{"data":[],"meta":{"paging":{"total":0,"limit":50}}},
+					"build":{"data":null},
+					"appStoreReviewDetail":{"data":null}
+				}},
+				"included":[]
+			}`)
+		case "/v1/apps/app-1/appInfos":
+			return buildsJSONResponse(http.StatusOK, `{
+				"data":[{"type":"appInfos","id":"info-1","attributes":{"state":"PREPARE_FOR_SUBMISSION"},"relationships":{
+					"app":{"data":{"type":"apps","id":"app-1"}},
+					"ageRatingDeclaration":{"data":null},
+					"appInfoLocalizations":{"data":[],"meta":{"paging":{"total":0,"limit":50}}},
+					"primaryCategory":{"data":null}
+				}}],
+				"included":[{"type":"apps","id":"app-1","attributes":{"primaryLocale":"en-US"}}]
+			}`)
+		case "/v1/apps/app-1/appPriceSchedule", "/v1/apps/app-1/appAvailabilityV2":
+			return buildsJSONResponse(http.StatusNotFound, `{"errors":[{"status":"404","code":"NOT_FOUND"}]}`)
+		case "/v1/apps/app-1/inAppPurchasesV2":
+			return buildsJSONResponse(http.StatusOK, `{"data":[]}`)
+		case "/v1/apps/app-1/subscriptionGroups":
+			return buildsJSONResponse(http.StatusOK, `{"data":[
+				{"type":"subscriptionGroups","id":"group-1","attributes":{"referenceName":"One"}},
+				{"type":"subscriptionGroups","id":"group-2","attributes":{"referenceName":"Two"}},
+				{"type":"subscriptionGroups","id":"group-3","attributes":{"referenceName":"Three"}},
+				{"type":"subscriptionGroups","id":"group-4","attributes":{"referenceName":"Four"}}
+			]}`)
+		case "/v1/subscriptionGroups/group-1/subscriptions",
+			"/v1/subscriptionGroups/group-2/subscriptions",
+			"/v1/subscriptionGroups/group-3/subscriptions",
+			"/v1/subscriptionGroups/group-4/subscriptions":
+			groupID := strings.TrimSuffix(strings.TrimPrefix(req.URL.Path, "/v1/subscriptionGroups/"), "/subscriptions")
+			return buildsJSONResponse(http.StatusOK, fmt.Sprintf(`{"data":[{"type":"subscriptions","id":"sub-%s","attributes":{"name":"%s","productId":"%s","state":"REMOVED_FROM_SALE"}}]}`, groupID, groupID, groupID))
+		case "/v1/subscriptions/sub-group-1/images",
+			"/v1/subscriptions/sub-group-2/images",
+			"/v1/subscriptions/sub-group-3/images",
+			"/v1/subscriptions/sub-group-4/images":
+			return buildsJSONResponse(http.StatusOK, `{"data":[]}`)
+		default:
+			return buildsJSONResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"UNEXPECTED_REQUEST"}]}`)
+		}
+	}))
+	restoreClient := SetClientFactory(func() (*asc.Client, error) { return client, nil })
+	t.Cleanup(restoreClient)
+
+	if _, err := BuildReadinessReport(context.Background(), ReadinessOptions{AppID: "app-1", VersionID: "ver-1"}); err != nil {
+		t.Fatalf("BuildReadinessReport() error = %v", err)
+	}
+	if got := tracker.max.Load(); got != readinessConcurrencyLimit {
+		t.Fatalf("maximum in-flight requests = %d, want exactly %d across nested tasks", got, readinessConcurrencyLimit)
+	}
+}

--- a/internal/cli/validate/iap_fetch.go
+++ b/internal/cli/validate/iap_fetch.go
@@ -3,28 +3,28 @@ package validate
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
-	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/validation"
 )
 
 var fetchIAPsFn = fetchIAPs
 
 func fetchIAPs(ctx context.Context, client *asc.Client, appID string) ([]validation.IAP, error) {
-	firstCtx, firstCancel := shared.ContextWithTimeout(ctx)
-	defer firstCancel()
-
-	firstPage, err := client.GetInAppPurchasesV2(firstCtx, strings.TrimSpace(appID), asc.WithIAPLimit(200))
+	ctx = withReadinessRequestGate(ctx)
+	firstPage, err := doReadinessRequest(ctx, func(requestCtx context.Context) (*asc.InAppPurchasesV2Response, error) {
+		return client.GetInAppPurchasesV2(requestCtx, strings.TrimSpace(appID), asc.WithIAPLimit(200))
+	})
 	if err != nil {
 		return nil, err
 	}
 
 	paginated, err := asc.PaginateAll(ctx, firstPage, func(_ context.Context, nextURL string) (asc.PaginatedResponse, error) {
-		pageCtx, pageCancel := shared.ContextWithTimeout(ctx)
-		defer pageCancel()
-		return client.GetInAppPurchasesV2(pageCtx, strings.TrimSpace(appID), asc.WithIAPNextURL(nextURL))
+		return doReadinessRequest(ctx, func(requestCtx context.Context) (asc.PaginatedResponse, error) {
+			return client.GetInAppPurchasesV2(requestCtx, strings.TrimSpace(appID), asc.WithIAPNextURL(nextURL))
+		})
 	})
 	if err != nil {
 		return nil, err
@@ -54,6 +54,12 @@ func mapIAPsResponse(paginated asc.PaginatedResponse) ([]validation.IAP, error) 
 			State:     attrs.State,
 		})
 	}
+	sort.SliceStable(iaps, func(i, j int) bool {
+		if iaps[i].ProductID != iaps[j].ProductID {
+			return iaps[i].ProductID < iaps[j].ProductID
+		}
+		return iaps[i].ID < iaps[j].ID
+	})
 
 	return iaps, nil
 }

--- a/internal/cli/validate/iap_fetch_test.go
+++ b/internal/cli/validate/iap_fetch_test.go
@@ -11,6 +11,15 @@ func TestMapIAPsResponse_MapsItems(t *testing.T) {
 	iaps, err := mapIAPsResponse(&asc.InAppPurchasesV2Response{
 		Data: []asc.Resource[asc.InAppPurchaseV2Attributes]{
 			{
+				ID: "iap-2",
+				Attributes: asc.InAppPurchaseV2Attributes{
+					Name:              "Gems",
+					ProductID:         "com.example.gems",
+					InAppPurchaseType: "CONSUMABLE",
+					State:             "READY_TO_SUBMIT",
+				},
+			},
+			{
 				ID: "iap-1",
 				Attributes: asc.InAppPurchaseV2Attributes{
 					Name:              "Coins",
@@ -24,11 +33,14 @@ func TestMapIAPsResponse_MapsItems(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if len(iaps) != 1 {
-		t.Fatalf("expected 1 IAP, got %d", len(iaps))
+	if len(iaps) != 2 {
+		t.Fatalf("expected 2 IAPs, got %d", len(iaps))
 	}
 	if iaps[0].ID != "iap-1" || iaps[0].Name != "Coins" || iaps[0].ProductID != "com.example.coins" || iaps[0].Type != "CONSUMABLE" || iaps[0].State != "MISSING_METADATA" {
 		t.Fatalf("unexpected mapped IAP: %+v", iaps[0])
+	}
+	if iaps[1].ID != "iap-2" || iaps[1].ProductID != "com.example.gems" {
+		t.Fatalf("IAPs are not stably sorted: %+v", iaps)
 	}
 }
 

--- a/internal/cli/validate/readiness.go
+++ b/internal/cli/validate/readiness.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"sort"
 	"strings"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
@@ -29,181 +30,148 @@ func BuildReadinessReport(ctx context.Context, opts ReadinessOptions) (validatio
 	if err != nil {
 		return validation.Report{}, err
 	}
-
-	requestCtx, cancel := shared.ContextWithTimeout(ctx)
-	defer func() {
-		if cancel != nil {
-			cancel()
-		}
-	}()
-
-	refreshRequestCtx := func() {
-		if cancel != nil {
-			cancel()
-		}
-		requestCtx, cancel = shared.ContextWithTimeout(ctx)
-	}
+	ctx = withReadinessRequestGate(ctx)
 
 	resolvedVersionID := strings.TrimSpace(opts.VersionID)
 	if resolvedVersionID == "" {
-		resolvedVersionID, err = resolveVersionID(requestCtx, client, strings.TrimSpace(opts.AppID), strings.TrimSpace(opts.Version), strings.TrimSpace(opts.Platform))
+		resolvedVersionID, err = doReadinessRequest(ctx, func(requestCtx context.Context) (string, error) {
+			return resolveVersionID(requestCtx, client, strings.TrimSpace(opts.AppID), strings.TrimSpace(opts.Version), strings.TrimSpace(opts.Platform))
+		})
 		if err != nil {
 			return validation.Report{}, err
 		}
 	}
 
-	versionResp, err := client.GetAppStoreVersion(requestCtx, resolvedVersionID)
-	if err != nil {
-		return validation.Report{}, fmt.Errorf("failed to fetch app store version: %w", err)
-	}
-
-	appResp, err := client.GetApp(requestCtx, opts.AppID)
-	if err != nil {
-		return validation.Report{}, fmt.Errorf("failed to fetch app: %w", err)
-	}
-
-	var contentRightsDeclaration *string
-	if appResp.Data.Attributes.ContentRightsDeclaration != nil {
-		value := strings.TrimSpace(string(*appResp.Data.Attributes.ContentRightsDeclaration))
-		contentRightsDeclaration = &value
-	}
-
-	versionLocsResp, err := client.GetAppStoreVersionLocalizations(requestCtx, resolvedVersionID)
-	if err != nil {
-		return validation.Report{}, fmt.Errorf("failed to fetch version localizations: %w", err)
-	}
-
-	appInfosResp, err := client.GetAppInfos(requestCtx, opts.AppID)
-	if err != nil {
-		return validation.Report{}, fmt.Errorf("failed to fetch app info: %w", err)
-	}
-
-	appInfoID := shared.SelectBestAppInfoID(appInfosResp)
-	if strings.TrimSpace(appInfoID) == "" {
-		return validation.Report{}, fmt.Errorf("failed to select app info for app")
-	}
-
-	appInfoLocsResp, err := client.GetAppInfoLocalizations(requestCtx, appInfoID)
-	if err != nil {
-		return validation.Report{}, fmt.Errorf("failed to fetch app info localizations: %w", err)
-	}
-
-	primaryCategoryID := ""
-	primaryCategoryResp, err := client.GetAppInfoPrimaryCategoryRelationship(requestCtx, appInfoID)
-	if err != nil {
-		if !asc.IsNotFound(err) {
-			return validation.Report{}, fmt.Errorf("failed to fetch app primary category: %w", err)
-		}
-	} else {
-		primaryCategoryID = primaryCategoryResp.Data.ID
-	}
-
-	var ageRatingDecl *validation.AgeRatingDeclaration
-	ageRatingResp, err := client.GetAgeRatingDeclarationForAppStoreVersion(requestCtx, resolvedVersionID)
-	if err != nil {
-		if !asc.IsNotFound(err) {
-			return validation.Report{}, fmt.Errorf("failed to fetch age rating declaration: %w", err)
-		}
-	} else {
-		ageRatingDecl = mapAgeRatingDeclaration(ageRatingResp.Data.Attributes)
-	}
-
-	var reviewDetails *validation.ReviewDetails
-	reviewDetailsResp, err := client.GetAppStoreReviewDetailForVersion(requestCtx, resolvedVersionID)
-	if err != nil {
-		if !asc.IsNotFound(err) {
-			return validation.Report{}, fmt.Errorf("failed to fetch review details: %w", err)
-		}
-	} else {
-		attrs := reviewDetailsResp.Data.Attributes
-		reviewDetails = &validation.ReviewDetails{
-			ID:                  reviewDetailsResp.Data.ID,
-			ContactFirstName:    attrs.ContactFirstName,
-			ContactLastName:     attrs.ContactLastName,
-			ContactEmail:        attrs.ContactEmail,
-			ContactPhone:        attrs.ContactPhone,
-			DemoAccountName:     attrs.DemoAccountName,
-			DemoAccountPassword: attrs.DemoAccountPassword,
-			DemoAccountRequired: attrs.DemoAccountRequired,
-			Notes:               attrs.Notes,
-		}
-	}
-
-	var attachedBuild *validation.Build
-	if opts.Build != nil {
-		attachedBuild = &validation.Build{
-			ID:                            strings.TrimSpace(opts.Build.ID),
-			Version:                       opts.Build.Version,
-			ProcessingState:               opts.Build.ProcessingState,
-			Expired:                       opts.Build.Expired,
-			UsesNonExemptEncryption:       opts.Build.UsesNonExemptEncryption,
-			AppEncryptionDeclarationID:    strings.TrimSpace(opts.Build.AppEncryptionDeclarationID),
-			AppEncryptionDeclarationState: strings.TrimSpace(opts.Build.AppEncryptionDeclarationState),
-		}
-	} else {
-		buildResp, err := client.GetAppStoreVersionBuild(requestCtx, resolvedVersionID)
-		if err != nil {
-			if !asc.IsNotFound(err) {
-				return validation.Report{}, fmt.Errorf("failed to fetch attached build: %w", err)
-			}
-		} else if strings.TrimSpace(buildResp.Data.ID) != "" {
-			attrs := buildResp.Data.Attributes
-			attachedBuild = &validation.Build{
-				ID:                      buildResp.Data.ID,
-				Version:                 attrs.Version,
-				ProcessingState:         attrs.ProcessingState,
-				Expired:                 attrs.Expired,
-				UsesNonExemptEncryption: attrs.UsesNonExemptEncryption,
-			}
-		}
-	}
-	if err := populateBuildEncryptionDeclaration(requestCtx, client, attachedBuild); err != nil {
+	var versionData versionReadinessData
+	var appInfoData appInfoReadinessData
+	if err := runReadinessTasks(
+		ctx,
+		func(taskCtx context.Context) error {
+			var fetchErr error
+			versionData, fetchErr = fetchVersionReadinessData(taskCtx, client, resolvedVersionID, opts.Build)
+			return fetchErr
+		},
+		func(taskCtx context.Context) error {
+			var fetchErr error
+			appInfoData, fetchErr = fetchAppInfoReadinessData(taskCtx, client, strings.TrimSpace(opts.AppID))
+			return fetchErr
+		},
+	); err != nil {
 		return validation.Report{}, err
 	}
 
-	priceScheduleID := ""
-	pricingFetchSkipReason := ""
-	priceScheduleResp, err := client.GetAppPriceSchedule(requestCtx, opts.AppID)
-	if err != nil {
-		if asc.IsNotFound(err) {
-			// Leave priceScheduleID empty so validation reports a missing schedule.
-		} else if reason, ok := readinessPricingSkipReason(err); ok {
-			pricingFetchSkipReason = reason
-			if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
-				refreshRequestCtx()
-			}
-		} else {
-			return validation.Report{}, fmt.Errorf("failed to fetch app price schedule: %w", err)
-		}
-	} else {
-		priceScheduleID = priceScheduleResp.Data.ID
+	var contentRightsDeclaration *string
+	if appInfoData.app.Attributes.ContentRightsDeclaration != nil {
+		value := strings.TrimSpace(string(*appInfoData.app.Attributes.ContentRightsDeclaration))
+		contentRightsDeclaration = &value
 	}
 
+	attachedBuild := versionData.build
+	priceScheduleID := ""
+	pricingFetchSkipReason := ""
 	availabilityID := ""
 	appAvailableTerritories := []string(nil)
 	availableTerritories := 0
 	availabilityFetchSkipReason := ""
 	pricingCoverageSkipReason := ""
-	availabilityID, appAvailableTerritories, availableTerritories, err = fetchAvailableTerritoryDetailsFn(requestCtx, client, opts.AppID)
-	if err != nil {
-		if reason, ok := readinessAvailabilitySkipReason(err); ok {
-			availabilityFetchSkipReason = reason
-			availabilityID = ""
-			appAvailableTerritories = nil
-			availableTerritories = 0
-			if coverageReason, coverageOK := availabilityCheckSkipReason(err); coverageOK {
-				pricingCoverageSkipReason = coverageReason
+	var screenshotSets []validation.ScreenshotSet
+	var subscriptions []validation.Subscription
+	subscriptionFetchSkipReason := ""
+	var iaps []validation.IAP
+	iapFetchSkipReason := ""
+
+	if err := runReadinessTasks(
+		ctx,
+		func(taskCtx context.Context) error {
+			return resolveMultipleAppInfoAgeRating(
+				taskCtx,
+				client,
+				&appInfoData,
+				opts.AppID,
+				shared.ResolveAppStoreVersionState(versionData.response.Data.Attributes),
+			)
+		},
+		func(taskCtx context.Context) error {
+			return populateBuildEncryptionDeclaration(taskCtx, client, attachedBuild)
+		},
+		func(taskCtx context.Context) error {
+			priceScheduleResp, fetchErr := doReadinessRequest(taskCtx, func(requestCtx context.Context) (*asc.AppPriceScheduleResponse, error) {
+				return client.GetAppPriceSchedule(requestCtx, opts.AppID)
+			})
+			if fetchErr != nil {
+				if asc.IsNotFound(fetchErr) {
+					return nil
+				}
+				if reason, ok := readinessPricingSkipReason(fetchErr); ok {
+					pricingFetchSkipReason = reason
+					return nil
+				}
+				return fmt.Errorf("failed to fetch app price schedule: %w", fetchErr)
 			}
-			if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
-				refreshRequestCtx()
+			priceScheduleID = priceScheduleResp.Data.ID
+			return nil
+		},
+		func(taskCtx context.Context) error {
+			var fetchErr error
+			availabilityID, appAvailableTerritories, availableTerritories, fetchErr = fetchAvailableTerritoryDetailsFn(taskCtx, client, opts.AppID)
+			if fetchErr == nil {
+				return nil
 			}
-		} else {
-			return validation.Report{}, err
-		}
+			if reason, ok := readinessAvailabilitySkipReason(fetchErr); ok {
+				availabilityFetchSkipReason = reason
+				availabilityID = ""
+				appAvailableTerritories = nil
+				availableTerritories = 0
+				if coverageReason, coverageOK := availabilityCheckSkipReason(fetchErr); coverageOK {
+					pricingCoverageSkipReason = coverageReason
+				}
+				return nil
+			}
+			return fetchErr
+		},
+		func(taskCtx context.Context) error {
+			var fetchErr error
+			screenshotSets, fetchErr = fetchScreenshotSetsFn(taskCtx, client, versionData.localizations)
+			return fetchErr
+		},
+		func(taskCtx context.Context) error {
+			fetchedSubscriptions, fetchErr := fetchSubscriptionsFn(taskCtx, client, opts.AppID)
+			if fetchErr != nil {
+				switch {
+				case errors.Is(fetchErr, asc.ErrForbidden) || asc.IsUnauthorized(fetchErr):
+					subscriptionFetchSkipReason = "Subscription readiness checks were skipped because this App Store Connect account cannot read subscription resources"
+				case asc.IsRetryable(fetchErr):
+					subscriptionFetchSkipReason = "Subscription readiness checks were skipped because the App Store Connect subscription endpoints were temporarily unavailable or rate limited"
+				default:
+					return fmt.Errorf("failed to fetch subscriptions: %w", fetchErr)
+				}
+				return nil
+			}
+			subscriptions = fetchedSubscriptions
+			return nil
+		},
+		func(taskCtx context.Context) error {
+			fetchedIAPs, fetchErr := fetchIAPsFn(taskCtx, client, opts.AppID)
+			if fetchErr != nil {
+				switch {
+				case errors.Is(fetchErr, asc.ErrForbidden) || asc.IsUnauthorized(fetchErr):
+					iapFetchSkipReason = "IAP readiness checks were skipped because this App Store Connect account cannot read in-app purchase resources"
+				case asc.IsRetryable(fetchErr):
+					iapFetchSkipReason = "IAP readiness checks were skipped because the App Store Connect IAP endpoints were temporarily unavailable or rate limited"
+				default:
+					return fmt.Errorf("failed to fetch in-app purchases: %w", fetchErr)
+				}
+				return nil
+			}
+			iaps = fetchedIAPs
+			return nil
+		},
+	); err != nil {
+		return validation.Report{}, err
 	}
 
-	versionLocalizations := make([]validation.VersionLocalization, 0, len(versionLocsResp.Data))
-	for _, loc := range versionLocsResp.Data {
+	versionLocalizations := make([]validation.VersionLocalization, 0, len(versionData.localizations))
+	for _, loc := range versionData.localizations {
 		attrs := loc.Attributes
 		versionLocalizations = append(versionLocalizations, validation.VersionLocalization{
 			ID:              loc.ID,
@@ -216,9 +184,15 @@ func BuildReadinessReport(ctx context.Context, opts ReadinessOptions) (validatio
 			MarketingURL:    attrs.MarketingURL,
 		})
 	}
+	sort.SliceStable(versionLocalizations, func(i, j int) bool {
+		if versionLocalizations[i].Locale != versionLocalizations[j].Locale {
+			return versionLocalizations[i].Locale < versionLocalizations[j].Locale
+		}
+		return versionLocalizations[i].ID < versionLocalizations[j].ID
+	})
 
-	appInfoLocalizations := make([]validation.AppInfoLocalization, 0, len(appInfoLocsResp.Data))
-	for _, loc := range appInfoLocsResp.Data {
+	appInfoLocalizations := make([]validation.AppInfoLocalization, 0, len(appInfoData.localizations))
+	for _, loc := range appInfoData.localizations {
 		attrs := loc.Attributes
 		appInfoLocalizations = append(appInfoLocalizations, validation.AppInfoLocalization{
 			ID:                loc.ID,
@@ -229,61 +203,30 @@ func BuildReadinessReport(ctx context.Context, opts ReadinessOptions) (validatio
 			PrivacyChoicesURL: attrs.PrivacyChoicesURL,
 		})
 	}
-
-	screenshotSets, err := fetchScreenshotSetsFn(requestCtx, client, versionLocsResp.Data)
-	if err != nil {
-		return validation.Report{}, err
-	}
-
-	subscriptions := make([]validation.Subscription, 0)
-	subscriptionFetchSkipReason := ""
-	fetchedSubscriptions, err := fetchSubscriptionsFn(ctx, client, opts.AppID)
-	if err != nil {
-		switch {
-		case errors.Is(err, asc.ErrForbidden) || asc.IsUnauthorized(err):
-			subscriptionFetchSkipReason = "Subscription readiness checks were skipped because this App Store Connect account cannot read subscription resources"
-		case asc.IsRetryable(err):
-			subscriptionFetchSkipReason = "Subscription readiness checks were skipped because the App Store Connect subscription endpoints were temporarily unavailable or rate limited"
-		default:
-			return validation.Report{}, fmt.Errorf("failed to fetch subscriptions: %w", err)
+	sort.SliceStable(appInfoLocalizations, func(i, j int) bool {
+		if appInfoLocalizations[i].Locale != appInfoLocalizations[j].Locale {
+			return appInfoLocalizations[i].Locale < appInfoLocalizations[j].Locale
 		}
-	} else {
-		subscriptions = fetchedSubscriptions
-	}
-
-	iaps := make([]validation.IAP, 0)
-	iapFetchSkipReason := ""
-	fetchedIAPs, err := fetchIAPsFn(ctx, client, opts.AppID)
-	if err != nil {
-		switch {
-		case errors.Is(err, asc.ErrForbidden) || asc.IsUnauthorized(err):
-			iapFetchSkipReason = "IAP readiness checks were skipped because this App Store Connect account cannot read in-app purchase resources"
-		case asc.IsRetryable(err):
-			iapFetchSkipReason = "IAP readiness checks were skipped because the App Store Connect IAP endpoints were temporarily unavailable or rate limited"
-		default:
-			return validation.Report{}, fmt.Errorf("failed to fetch in-app purchases: %w", err)
-		}
-	} else {
-		iaps = fetchedIAPs
-	}
+		return appInfoLocalizations[i].ID < appInfoLocalizations[j].ID
+	})
 
 	platform := strings.TrimSpace(opts.Platform)
 	if platform == "" {
-		platform = string(versionResp.Data.Attributes.Platform)
+		platform = string(versionData.response.Data.Attributes.Platform)
 	}
 
 	report := validation.Validate(validation.Input{
 		AppID:                       opts.AppID,
-		AppInfoID:                   appInfoID,
+		AppInfoID:                   appInfoData.appInfoID,
 		VersionID:                   resolvedVersionID,
-		VersionString:               versionResp.Data.Attributes.VersionString,
-		VersionState:                shared.ResolveAppStoreVersionState(versionResp.Data.Attributes),
+		VersionString:               versionData.response.Data.Attributes.VersionString,
+		VersionState:                shared.ResolveAppStoreVersionState(versionData.response.Data.Attributes),
 		Platform:                    platform,
-		PrimaryLocale:               appResp.Data.Attributes.PrimaryLocale,
+		PrimaryLocale:               appInfoData.app.Attributes.PrimaryLocale,
 		VersionLocalizations:        versionLocalizations,
 		AppInfoLocalizations:        appInfoLocalizations,
-		ReviewDetails:               reviewDetails,
-		PrimaryCategoryID:           primaryCategoryID,
+		ReviewDetails:               versionData.reviewDetails,
+		PrimaryCategoryID:           appInfoData.primaryCategoryID,
 		ContentRightsDeclaration:    contentRightsDeclaration,
 		Build:                       attachedBuild,
 		PriceScheduleID:             priceScheduleID,
@@ -298,10 +241,10 @@ func BuildReadinessReport(ctx context.Context, opts ReadinessOptions) (validatio
 		SubscriptionFetchSkipReason: subscriptionFetchSkipReason,
 		IAPs:                        iaps,
 		IAPFetchSkipReason:          iapFetchSkipReason,
-		AgeRatingDeclaration:        ageRatingDecl,
-		ReleaseType:                 versionResp.Data.Attributes.ReleaseType,
-		EarliestReleaseDate:         versionResp.Data.Attributes.EarliestReleaseDate,
-		Copyright:                   versionResp.Data.Attributes.Copyright,
+		AgeRatingDeclaration:        appInfoData.ageRatingDeclaration,
+		ReleaseType:                 versionData.response.Data.Attributes.ReleaseType,
+		EarliestReleaseDate:         versionData.response.Data.Attributes.EarliestReleaseDate,
+		Copyright:                   versionData.response.Data.Attributes.Copyright,
 	}, opts.Strict)
 
 	return report, nil
@@ -318,7 +261,9 @@ func populateBuildEncryptionDeclaration(ctx context.Context, client *asc.Client,
 		return nil
 	}
 
-	declarationResp, err := client.GetBuildAppEncryptionDeclaration(ctx, strings.TrimSpace(build.ID))
+	declarationResp, err := doReadinessRequest(ctx, func(requestCtx context.Context) (*asc.AppEncryptionDeclarationResponse, error) {
+		return client.GetBuildAppEncryptionDeclaration(requestCtx, strings.TrimSpace(build.ID))
+	})
 	if err != nil {
 		if asc.IsNotFound(err) {
 			return nil

--- a/internal/cli/validate/readiness_compound.go
+++ b/internal/cli/validate/readiness_compound.go
@@ -1,0 +1,324 @@
+package validate
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/validation"
+)
+
+type versionReadinessData struct {
+	response      *asc.AppStoreVersionResponse
+	localizations []asc.Resource[asc.AppStoreVersionLocalizationAttributes]
+	reviewDetails *validation.ReviewDetails
+	build         *validation.Build
+}
+
+type appInfoReadinessData struct {
+	appInfoID            string
+	app                  asc.Resource[asc.AppAttributes]
+	localizations        []asc.Resource[asc.AppInfoLocalizationAttributes]
+	primaryCategoryID    string
+	ageRatingDeclaration *validation.AgeRatingDeclaration
+	response             *asc.AppInfosResponse
+	included             includedResourceIndex
+}
+
+func fetchVersionReadinessData(ctx context.Context, client *asc.Client, versionID string, suppliedBuild *validation.Build) (versionReadinessData, error) {
+	response, err := doReadinessRequest(ctx, func(requestCtx context.Context) (*asc.AppStoreVersionResponse, error) {
+		return client.GetAppStoreVersion(
+			requestCtx,
+			versionID,
+			asc.WithAppStoreVersionInclude([]string{"appStoreVersionLocalizations", "build", "appStoreReviewDetail"}),
+			asc.WithAppStoreVersionLocalizationsIncludeLimit(compoundLocalizationLimit),
+		)
+	})
+	if err != nil {
+		return versionReadinessData{}, fmt.Errorf("failed to fetch app store version: %w", err)
+	}
+
+	result := versionReadinessData{response: response, build: copyBuild(suppliedBuild)}
+	included := newIncludedResourceIndex(response.Included)
+
+	localizations, localizationsResolved := resolveCompoundToMany[asc.AppStoreVersionLocalizationAttributes](
+		response.Data.Relationships,
+		included,
+		"appStoreVersionLocalizations",
+		asc.ResourceTypeAppStoreVersionLocalizations,
+	)
+	if localizationsResolved {
+		result.localizations = localizations
+	}
+
+	reviewResource, reviewState := resolveCompoundToOne[asc.AppStoreReviewDetailAttributes](
+		response.Data.Relationships,
+		included,
+		"appStoreReviewDetail",
+		asc.ResourceTypeAppStoreReviewDetails,
+	)
+	if reviewState == compoundLinkageResolved {
+		result.reviewDetails = mapReviewDetails(reviewResource)
+	}
+
+	buildState := compoundLinkageResolved
+	if suppliedBuild == nil {
+		buildResource, state := resolveCompoundToOne[asc.BuildAttributes](
+			response.Data.Relationships,
+			included,
+			"build",
+			asc.ResourceTypeBuilds,
+		)
+		buildState = state
+		if state == compoundLinkageResolved {
+			result.build = mapBuild(buildResource)
+		}
+	}
+
+	tasks := make([]readinessTask, 0, 3)
+	if !localizationsResolved {
+		tasks = append(tasks, func(taskCtx context.Context) error {
+			localizationsResponse, err := doReadinessRequest(taskCtx, func(requestCtx context.Context) (*asc.AppStoreVersionLocalizationsResponse, error) {
+				return client.GetAppStoreVersionLocalizations(requestCtx, versionID)
+			})
+			if err != nil {
+				return fmt.Errorf("failed to fetch version localizations: %w", err)
+			}
+			result.localizations = localizationsResponse.Data
+			return nil
+		})
+	}
+	if reviewState == compoundLinkageFallback {
+		tasks = append(tasks, func(taskCtx context.Context) error {
+			reviewResponse, err := doReadinessRequest(taskCtx, func(requestCtx context.Context) (*asc.AppStoreReviewDetailResponse, error) {
+				return client.GetAppStoreReviewDetailForVersion(requestCtx, versionID)
+			})
+			if err != nil {
+				if asc.IsNotFound(err) {
+					return nil
+				}
+				return fmt.Errorf("failed to fetch review details: %w", err)
+			}
+			result.reviewDetails = mapReviewDetails(reviewResponse.Data)
+			return nil
+		})
+	}
+	if suppliedBuild == nil && buildState == compoundLinkageFallback {
+		tasks = append(tasks, func(taskCtx context.Context) error {
+			buildResponse, err := doReadinessRequest(taskCtx, func(requestCtx context.Context) (*asc.BuildResponse, error) {
+				return client.GetAppStoreVersionBuild(requestCtx, versionID)
+			})
+			if err != nil {
+				if asc.IsNotFound(err) {
+					return nil
+				}
+				return fmt.Errorf("failed to fetch attached build: %w", err)
+			}
+			if strings.TrimSpace(buildResponse.Data.ID) != "" {
+				result.build = mapBuild(buildResponse.Data)
+			}
+			return nil
+		})
+	}
+
+	if err := runReadinessTasks(ctx, tasks...); err != nil {
+		return versionReadinessData{}, err
+	}
+	return result, nil
+}
+
+func fetchAppInfoReadinessData(ctx context.Context, client *asc.Client, appID string) (appInfoReadinessData, error) {
+	response, err := doReadinessRequest(ctx, func(requestCtx context.Context) (*asc.AppInfosResponse, error) {
+		return client.GetAppInfos(
+			requestCtx,
+			appID,
+			asc.WithAppInfoInclude([]string{"app", "ageRatingDeclaration", "appInfoLocalizations", "primaryCategory"}),
+			asc.WithAppInfoLocalizationsIncludeLimit(compoundLocalizationLimit),
+		)
+	})
+	if err != nil {
+		return appInfoReadinessData{}, fmt.Errorf("failed to fetch app info: %w", err)
+	}
+
+	appInfoID := shared.SelectBestAppInfoID(response)
+	if strings.TrimSpace(appInfoID) == "" {
+		return appInfoReadinessData{}, fmt.Errorf("failed to select app info for app")
+	}
+
+	result := appInfoReadinessData{
+		appInfoID: appInfoID,
+		response:  response,
+		included:  newIncludedResourceIndex(response.Included),
+	}
+	selected, selectedOK := selectAppInfoResource(response.Data, appInfoID)
+
+	appState := compoundLinkageFallback
+	ageRatingState := compoundLinkageFallback
+	resolveAgeRatingNow := len(response.Data) == 1
+	localizationsResolved := false
+	primaryCategoryState := compoundLinkageFallback
+	if selectedOK {
+		appResource, state := resolveCompoundToOne[asc.AppAttributes](selected.Relationships, result.included, "app", asc.ResourceTypeApps)
+		appState = state
+		if state == compoundLinkageResolved && strings.TrimSpace(appResource.ID) == strings.TrimSpace(appID) {
+			result.app = appResource
+		} else if state == compoundLinkageResolved {
+			appState = compoundLinkageFallback
+		}
+
+		if resolveAgeRatingNow {
+			ageRatingResource, state := resolveCompoundToOne[asc.AgeRatingDeclarationAttributes](
+				selected.Relationships,
+				result.included,
+				"ageRatingDeclaration",
+				asc.ResourceTypeAgeRatingDeclarations,
+			)
+			ageRatingState = state
+			if state == compoundLinkageResolved {
+				result.ageRatingDeclaration = mapAgeRatingDeclaration(ageRatingResource.Attributes)
+			}
+		}
+
+		result.localizations, localizationsResolved = resolveCompoundToMany[asc.AppInfoLocalizationAttributes](
+			selected.Relationships,
+			result.included,
+			"appInfoLocalizations",
+			asc.ResourceTypeAppInfoLocalizations,
+		)
+
+		categoryResource, state := resolveCompoundToOne[asc.AppCategoryAttributes](
+			selected.Relationships,
+			result.included,
+			"primaryCategory",
+			asc.ResourceTypeAppCategories,
+		)
+		primaryCategoryState = state
+		if state == compoundLinkageResolved {
+			result.primaryCategoryID = strings.TrimSpace(categoryResource.ID)
+		}
+	}
+
+	tasks := make([]readinessTask, 0, 4)
+	if appState != compoundLinkageResolved {
+		tasks = append(tasks, func(taskCtx context.Context) error {
+			appResponse, err := doReadinessRequest(taskCtx, func(requestCtx context.Context) (*asc.AppResponse, error) {
+				return client.GetApp(requestCtx, appID)
+			})
+			if err != nil {
+				return fmt.Errorf("failed to fetch app: %w", err)
+			}
+			result.app = appResponse.Data
+			return nil
+		})
+	}
+	if !localizationsResolved {
+		tasks = append(tasks, func(taskCtx context.Context) error {
+			localizationsResponse, err := doReadinessRequest(taskCtx, func(requestCtx context.Context) (*asc.AppInfoLocalizationsResponse, error) {
+				return client.GetAppInfoLocalizations(requestCtx, appInfoID)
+			})
+			if err != nil {
+				return fmt.Errorf("failed to fetch app info localizations: %w", err)
+			}
+			result.localizations = localizationsResponse.Data
+			return nil
+		})
+	}
+	if primaryCategoryState == compoundLinkageFallback {
+		tasks = append(tasks, func(taskCtx context.Context) error {
+			categoryResponse, err := doReadinessRequest(taskCtx, func(requestCtx context.Context) (*asc.AppInfoPrimaryCategoryLinkageResponse, error) {
+				return client.GetAppInfoPrimaryCategoryRelationship(requestCtx, appInfoID)
+			})
+			if err != nil {
+				if asc.IsNotFound(err) {
+					return nil
+				}
+				return fmt.Errorf("failed to fetch app primary category: %w", err)
+			}
+			result.primaryCategoryID = strings.TrimSpace(categoryResponse.Data.ID)
+			return nil
+		})
+	}
+	if resolveAgeRatingNow && ageRatingState == compoundLinkageFallback {
+		tasks = append(tasks, func(taskCtx context.Context) error {
+			ageRatingResponse, err := doReadinessRequest(taskCtx, func(requestCtx context.Context) (*asc.AgeRatingDeclarationResponse, error) {
+				return client.GetAgeRatingDeclarationForAppInfo(requestCtx, appInfoID)
+			})
+			if err != nil {
+				if asc.IsNotFound(err) {
+					return nil
+				}
+				return fmt.Errorf("failed to fetch age rating declaration: %w", err)
+			}
+			result.ageRatingDeclaration = mapAgeRatingDeclaration(ageRatingResponse.Data.Attributes)
+			return nil
+		})
+	}
+
+	if err := runReadinessTasks(ctx, tasks...); err != nil {
+		return appInfoReadinessData{}, err
+	}
+	return result, nil
+}
+
+func resolveMultipleAppInfoAgeRating(ctx context.Context, client *asc.Client, result *appInfoReadinessData, appID, versionState string) error {
+	if result == nil || result.response == nil || len(result.response.Data) <= 1 {
+		return nil
+	}
+
+	candidates := asc.AppInfoCandidates(result.response.Data)
+	ageRatingAppInfoID, ok := asc.AutoResolveAppInfoIDByVersionState(candidates, versionState)
+	if !ok {
+		return fmt.Errorf(
+			"failed to fetch age rating declaration: multiple app infos found for app %q (%s); run `asc apps info list --app %q` to inspect candidates and use the app-info based age-rating flow explicitly",
+			strings.TrimSpace(appID),
+			asc.FormatAppInfoCandidates(candidates),
+			strings.TrimSpace(appID),
+		)
+	}
+
+	resource, unique := selectAppInfoResource(result.response.Data, ageRatingAppInfoID)
+	if unique {
+		ageRatingResource, state := resolveCompoundToOne[asc.AgeRatingDeclarationAttributes](
+			resource.Relationships,
+			result.included,
+			"ageRatingDeclaration",
+			asc.ResourceTypeAgeRatingDeclarations,
+		)
+		switch state {
+		case compoundLinkageEmpty:
+			result.ageRatingDeclaration = nil
+			return nil
+		case compoundLinkageResolved:
+			result.ageRatingDeclaration = mapAgeRatingDeclaration(ageRatingResource.Attributes)
+			return nil
+		}
+	}
+
+	ageRatingResponse, err := doReadinessRequest(ctx, func(requestCtx context.Context) (*asc.AgeRatingDeclarationResponse, error) {
+		return client.GetAgeRatingDeclarationForAppInfo(requestCtx, ageRatingAppInfoID)
+	})
+	if err != nil {
+		if asc.IsNotFound(err) {
+			result.ageRatingDeclaration = nil
+			return nil
+		}
+		return fmt.Errorf("failed to fetch age rating declaration: %w", err)
+	}
+	result.ageRatingDeclaration = mapAgeRatingDeclaration(ageRatingResponse.Data.Attributes)
+	return nil
+}
+
+func selectAppInfoResource(resources []asc.Resource[asc.AppInfoAttributes], appInfoID string) (asc.Resource[asc.AppInfoAttributes], bool) {
+	var selected asc.Resource[asc.AppInfoAttributes]
+	matches := 0
+	for _, resource := range resources {
+		if strings.TrimSpace(resource.ID) != strings.TrimSpace(appInfoID) {
+			continue
+		}
+		selected = resource
+		matches++
+	}
+	return selected, matches == 1
+}

--- a/internal/cli/validate/readiness_compound_test.go
+++ b/internal/cli/validate/readiness_compound_test.go
@@ -1,0 +1,363 @@
+package validate
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/validation"
+)
+
+func TestBuildReadinessReport_UsesCompoundReadsWithoutFallbacks(t *testing.T) {
+	var mu sync.Mutex
+	requests := make(map[string]int)
+	queries := make(map[string]string)
+
+	client := newBuildsTestClient(t, buildsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		mu.Lock()
+		requests[req.URL.Path]++
+		queries[req.URL.Path] = req.URL.Query().Encode()
+		mu.Unlock()
+
+		switch req.URL.Path {
+		case "/v1/appStoreVersions/ver-1":
+			return buildsJSONResponse(http.StatusOK, `{
+				"data": {
+					"type": "appStoreVersions",
+					"id": "ver-1",
+					"attributes": {"platform":"IOS","versionString":"1.0","appVersionState":"PREPARE_FOR_SUBMISSION","copyright":"2026 Test"},
+					"relationships": {
+						"app": {"data":{"type":"apps","id":"app-1"}},
+						"appStoreVersionLocalizations": {"data":[{"type":"appStoreVersionLocalizations","id":"ver-loc-1"}],"meta":{"paging":{"total":1,"limit":50}}},
+						"build": {"data":{"type":"builds","id":"build-1"}},
+						"appStoreReviewDetail": {"data":{"type":"appStoreReviewDetails","id":"review-1"}}
+					}
+				},
+				"included": [
+					{"type":"appStoreVersionLocalizations","id":"ver-loc-1","attributes":{"locale":"en-US","description":"Description","keywords":"keyword","whatsNew":"Notes","supportUrl":"https://example.com/support"}},
+					{"type":"builds","id":"build-1","attributes":{"version":"1.0","processingState":"VALID","expired":false,"usesNonExemptEncryption":false}},
+					{"type":"appStoreReviewDetails","id":"review-1","attributes":{"contactFirstName":"A","contactLastName":"B","contactEmail":"a@example.com","contactPhone":"123"}}
+				]
+			}`)
+		case "/v1/apps/app-1/appInfos":
+			return buildsJSONResponse(http.StatusOK, `{
+				"data": [{
+					"type": "appInfos",
+					"id": "info-1",
+					"attributes": {"state":"PREPARE_FOR_SUBMISSION"},
+					"relationships": {
+						"app": {"data":{"type":"apps","id":"app-1"}},
+						"ageRatingDeclaration": {"data":{"type":"ageRatingDeclarations","id":"age-1"}},
+						"appInfoLocalizations": {"data":[{"type":"appInfoLocalizations","id":"info-loc-1"}],"meta":{"paging":{"total":1,"limit":50}}},
+						"primaryCategory": {"data":{"type":"appCategories","id":"cat-1"}}
+					}
+				}],
+				"included": [
+					{"type":"apps","id":"app-1","attributes":{"primaryLocale":"en-US","contentRightsDeclaration":"DOES_NOT_USE_THIRD_PARTY_CONTENT"}},
+					{"type":"ageRatingDeclarations","id":"age-1","attributes":{"advertising":false}},
+					{"type":"appInfoLocalizations","id":"info-loc-1","attributes":{"locale":"en-US","name":"My App","privacyPolicyUrl":"https://example.com/privacy"}},
+					{"type":"appCategories","id":"cat-1","attributes":{}}
+				]
+			}`)
+		case "/v1/apps/app-1/appPriceSchedule":
+			return buildsJSONResponse(http.StatusOK, `{"data":{"type":"appPriceSchedules","id":"schedule-1"}}`)
+		case "/v1/apps/app-1":
+			return buildsJSONResponse(http.StatusOK, `{"data":{"type":"apps","id":"app-1","attributes":{"primaryLocale":"en-US","contentRightsDeclaration":"DOES_NOT_USE_THIRD_PARTY_CONTENT"}}}`)
+		case "/v1/appStoreVersions/ver-1/appStoreVersionLocalizations":
+			return buildsJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersionLocalizations","id":"ver-loc-1","attributes":{"locale":"en-US"}}]}`)
+		case "/v1/appInfos/info-1/appInfoLocalizations":
+			return buildsJSONResponse(http.StatusOK, `{"data":[{"type":"appInfoLocalizations","id":"info-loc-1","attributes":{"locale":"en-US"}}]}`)
+		case "/v1/appInfos/info-1/relationships/primaryCategory":
+			return buildsJSONResponse(http.StatusOK, `{"data":{"type":"appCategories","id":"cat-1"}}`)
+		case "/v1/appInfos/info-1/ageRatingDeclaration":
+			return buildsJSONResponse(http.StatusOK, `{"data":{"type":"ageRatingDeclarations","id":"age-1","attributes":{"advertising":false}}}`)
+		case "/v1/appStoreVersions/ver-1/appStoreReviewDetail":
+			return buildsJSONResponse(http.StatusOK, `{"data":{"type":"appStoreReviewDetails","id":"review-1","attributes":{}}}`)
+		case "/v1/appStoreVersions/ver-1/build":
+			return buildsJSONResponse(http.StatusOK, `{"data":{"type":"builds","id":"build-1","attributes":{"usesNonExemptEncryption":false}}}`)
+		default:
+			return buildsJSONResponse(http.StatusNotFound, `{"errors":[{"status":"404","code":"NOT_FOUND"}]}`)
+		}
+	}))
+
+	restoreClient := SetClientFactory(func() (*asc.Client, error) { return client, nil })
+	t.Cleanup(restoreClient)
+	restoreAvailability := SetFetchAvailableTerritoriesFunc(func(context.Context, *asc.Client, string) (string, int, error) {
+		return "availability-1", 1, nil
+	})
+	t.Cleanup(restoreAvailability)
+	restoreScreenshots := SetFetchScreenshotSetsFunc(func(context.Context, *asc.Client, []asc.Resource[asc.AppStoreVersionLocalizationAttributes]) ([]validation.ScreenshotSet, error) {
+		return nil, nil
+	})
+	t.Cleanup(restoreScreenshots)
+	restoreSubscriptions := SetFetchSubscriptionsFunc(func(context.Context, *asc.Client, string) ([]validation.Subscription, error) {
+		return nil, nil
+	})
+	t.Cleanup(restoreSubscriptions)
+	restoreIAPs := SetFetchIAPsFunc(func(context.Context, *asc.Client, string) ([]validation.IAP, error) {
+		return nil, nil
+	})
+	t.Cleanup(restoreIAPs)
+
+	if _, err := BuildReadinessReport(context.Background(), ReadinessOptions{AppID: "app-1", VersionID: "ver-1"}); err != nil {
+		t.Fatalf("BuildReadinessReport() error = %v", err)
+	}
+
+	if got := queries["/v1/appStoreVersions/ver-1"]; got != "include=appStoreVersionLocalizations%2Cbuild%2CappStoreReviewDetail&limit%5BappStoreVersionLocalizations%5D=50" {
+		t.Fatalf("unexpected version compound query: %q", got)
+	}
+	if got := queries["/v1/apps/app-1/appInfos"]; got != "include=app%2CageRatingDeclaration%2CappInfoLocalizations%2CprimaryCategory&limit%5BappInfoLocalizations%5D=50" {
+		t.Fatalf("unexpected app-info compound query: %q", got)
+	}
+	totalRequests := 0
+	for _, count := range requests {
+		totalRequests += count
+	}
+	if totalRequests != 3 {
+		t.Fatalf("compound readiness request count = %d, want 3 (version, app infos, price schedule)", totalRequests)
+	}
+
+	for _, path := range []string{
+		"/v1/apps/app-1",
+		"/v1/appStoreVersions/ver-1/appStoreVersionLocalizations",
+		"/v1/appInfos/info-1/appInfoLocalizations",
+		"/v1/appInfos/info-1/relationships/primaryCategory",
+		"/v1/appInfos/info-1/ageRatingDeclaration",
+		"/v1/appStoreVersions/ver-1/appStoreReviewDetail",
+		"/v1/appStoreVersions/ver-1/build",
+	} {
+		if got := requests[path]; got != 0 {
+			t.Fatalf("expected compound response to avoid %s, got %d request(s)", path, got)
+		}
+	}
+}
+
+func TestFetchVersionReadinessData_MissingOrAmbiguousMemberFallsBackOnlyForReviewDetails(t *testing.T) {
+	tests := []struct {
+		name     string
+		included string
+	}{
+		{name: "missing included member", included: `[]`},
+		{
+			name: "duplicate included member",
+			included: `[
+				{"type":"appStoreReviewDetails","id":"review-1","attributes":{}},
+				{"type":"appStoreReviewDetails","id":"review-1","attributes":{}}
+			]`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var mu sync.Mutex
+			requests := make(map[string]int)
+			queries := make(map[string]string)
+			client := newBuildsTestClient(t, buildsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				mu.Lock()
+				requests[req.URL.Path]++
+				queries[req.URL.Path] = req.URL.Query().Encode()
+				mu.Unlock()
+
+				switch req.URL.Path {
+				case "/v1/appStoreVersions/ver-1":
+					return buildsJSONResponse(http.StatusOK, fmt.Sprintf(`{
+						"data": {
+							"type":"appStoreVersions",
+							"id":"ver-1",
+							"attributes":{"platform":"IOS","versionString":"1.0"},
+							"relationships": {
+								"appStoreVersionLocalizations":{"data":[],"meta":{"paging":{"total":0,"limit":50}}},
+								"build":{"data":null},
+								"appStoreReviewDetail":{"data":{"type":"appStoreReviewDetails","id":"review-1"}}
+							}
+						},
+						"included": %s
+					}`, test.included))
+				case "/v1/appStoreVersions/ver-1/appStoreReviewDetail":
+					return buildsJSONResponse(http.StatusNotFound, `{"errors":[{"status":"404","code":"NOT_FOUND"}]}`)
+				default:
+					return buildsJSONResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"UNEXPECTED_REQUEST"}]}`)
+				}
+			}))
+
+			result, err := fetchVersionReadinessData(withReadinessRequestGate(context.Background()), client, "ver-1", nil)
+			if err != nil {
+				t.Fatalf("fetchVersionReadinessData() error = %v", err)
+			}
+			if result.reviewDetails != nil {
+				t.Fatalf("expected NotFound fallback to preserve absent review details, got %+v", result.reviewDetails)
+			}
+			if got := queries["/v1/appStoreVersions/ver-1"]; got != "include=appStoreVersionLocalizations%2Cbuild%2CappStoreReviewDetail&limit%5BappStoreVersionLocalizations%5D=50" {
+				t.Fatalf("unexpected version compound query: %q", got)
+			}
+			if got := requests["/v1/appStoreVersions/ver-1/appStoreReviewDetail"]; got != 1 {
+				t.Fatalf("expected one review-detail fallback, got %d", got)
+			}
+			for _, path := range []string{
+				"/v1/appStoreVersions/ver-1/appStoreVersionLocalizations",
+				"/v1/appStoreVersions/ver-1/build",
+			} {
+				if got := requests[path]; got != 0 {
+					t.Fatalf("expected no unrelated fallback for %s, got %d request(s)", path, got)
+				}
+			}
+		})
+	}
+}
+
+func TestFetchAppInfoReadinessData_MissingIncludedAgeRatingFallsBackOnlyForAgeRating(t *testing.T) {
+	var mu sync.Mutex
+	requests := make(map[string]int)
+	queries := make(map[string]string)
+	client := newBuildsTestClient(t, buildsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		mu.Lock()
+		requests[req.URL.Path]++
+		queries[req.URL.Path] = req.URL.Query().Encode()
+		mu.Unlock()
+
+		switch req.URL.Path {
+		case "/v1/apps/app-1/appInfos":
+			return buildsJSONResponse(http.StatusOK, `{
+				"data": [{
+					"type":"appInfos",
+					"id":"info-1",
+					"attributes":{"state":"PREPARE_FOR_SUBMISSION"},
+					"relationships": {
+						"app":{"data":{"type":"apps","id":"app-1"}},
+						"ageRatingDeclaration":{"data":{"type":"ageRatingDeclarations","id":"age-1"}},
+						"appInfoLocalizations":{"data":[],"meta":{"paging":{"total":0,"limit":50}}},
+						"primaryCategory":{"data":null}
+					}
+				}],
+				"included":[{"type":"apps","id":"app-1","attributes":{"primaryLocale":"en-US"}}]
+			}`)
+		case "/v1/appInfos/info-1/ageRatingDeclaration":
+			return buildsJSONResponse(http.StatusOK, `{"data":{"type":"ageRatingDeclarations","id":"age-1","attributes":{"advertising":false}}}`)
+		default:
+			return buildsJSONResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"UNEXPECTED_REQUEST"}]}`)
+		}
+	}))
+
+	result, err := fetchAppInfoReadinessData(withReadinessRequestGate(context.Background()), client, "app-1")
+	if err != nil {
+		t.Fatalf("fetchAppInfoReadinessData() error = %v", err)
+	}
+	if result.ageRatingDeclaration == nil || result.ageRatingDeclaration.Advertising == nil || *result.ageRatingDeclaration.Advertising {
+		t.Fatalf("expected age-rating fallback data, got %+v", result.ageRatingDeclaration)
+	}
+	if got := queries["/v1/apps/app-1/appInfos"]; got != "include=app%2CageRatingDeclaration%2CappInfoLocalizations%2CprimaryCategory&limit%5BappInfoLocalizations%5D=50" {
+		t.Fatalf("unexpected app-info compound query: %q", got)
+	}
+	if got := requests["/v1/appInfos/info-1/ageRatingDeclaration"]; got != 1 {
+		t.Fatalf("expected one age-rating fallback, got %d", got)
+	}
+	for _, path := range []string{
+		"/v1/apps/app-1",
+		"/v1/appInfos/info-1/appInfoLocalizations",
+		"/v1/appInfos/info-1/relationships/primaryCategory",
+	} {
+		if got := requests[path]; got != 0 {
+			t.Fatalf("expected no unrelated fallback for %s, got %d request(s)", path, got)
+		}
+	}
+}
+
+func TestFetchVersionReadinessData_TruncatedLocalizationIncludeFallsBackOnlyForLocalizations(t *testing.T) {
+	var mu sync.Mutex
+	requests := make(map[string]int)
+	client := newBuildsTestClient(t, buildsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		mu.Lock()
+		requests[req.URL.Path]++
+		mu.Unlock()
+
+		switch req.URL.Path {
+		case "/v1/appStoreVersions/ver-1":
+			return buildsJSONResponse(http.StatusOK, `{
+				"data":{"type":"appStoreVersions","id":"ver-1","attributes":{"platform":"IOS","versionString":"1.0"},"relationships":{
+					"appStoreVersionLocalizations":{"data":[{"type":"appStoreVersionLocalizations","id":"loc-1"}],"meta":{"paging":{"total":2,"limit":50,"nextCursor":"next"}}},
+					"build":{"data":null},
+					"appStoreReviewDetail":{"data":null}
+				}},
+				"included":[{"type":"appStoreVersionLocalizations","id":"loc-1","attributes":{"locale":"en-US"}}]
+			}`)
+		case "/v1/appStoreVersions/ver-1/appStoreVersionLocalizations":
+			return buildsJSONResponse(http.StatusOK, `{"data":[
+				{"type":"appStoreVersionLocalizations","id":"loc-1","attributes":{"locale":"en-US"}},
+				{"type":"appStoreVersionLocalizations","id":"loc-2","attributes":{"locale":"fr-FR"}}
+			]}`)
+		default:
+			return buildsJSONResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"UNEXPECTED_REQUEST"}]}`)
+		}
+	}))
+
+	result, err := fetchVersionReadinessData(withReadinessRequestGate(context.Background()), client, "ver-1", nil)
+	if err != nil {
+		t.Fatalf("fetchVersionReadinessData() error = %v", err)
+	}
+	if len(result.localizations) != 2 || result.localizations[0].ID != "loc-1" || result.localizations[1].ID != "loc-2" {
+		t.Fatalf("unexpected fallback localizations: %+v", result.localizations)
+	}
+	if got := requests["/v1/appStoreVersions/ver-1/appStoreVersionLocalizations"]; got != 1 {
+		t.Fatalf("expected one localization fallback, got %d", got)
+	}
+	for _, path := range []string{
+		"/v1/appStoreVersions/ver-1/build",
+		"/v1/appStoreVersions/ver-1/appStoreReviewDetail",
+	} {
+		if got := requests[path]; got != 0 {
+			t.Fatalf("expected no unrelated fallback for %s, got %d request(s)", path, got)
+		}
+	}
+}
+
+func TestResolveMultipleAppInfoAgeRating_UsesVersionStateSelection(t *testing.T) {
+	requests := 0
+	client := newBuildsTestClient(t, buildsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		if req.URL.Path != "/v1/apps/app-1/appInfos" {
+			return buildsJSONResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"UNEXPECTED_REQUEST"}]}`)
+		}
+		return buildsJSONResponse(http.StatusOK, `{
+			"data":[
+				{"type":"appInfos","id":"info-draft","attributes":{"state":"PREPARE_FOR_SUBMISSION"},"relationships":{
+					"app":{"data":{"type":"apps","id":"app-1"}},
+					"ageRatingDeclaration":{"data":{"type":"ageRatingDeclarations","id":"age-draft"}},
+					"appInfoLocalizations":{"data":[],"meta":{"paging":{"total":0,"limit":50}}},
+					"primaryCategory":{"data":null}
+				}},
+				{"type":"appInfos","id":"info-live","attributes":{"state":"READY_FOR_DISTRIBUTION"},"relationships":{
+					"ageRatingDeclaration":{"data":{"type":"ageRatingDeclarations","id":"age-live"}}
+				}}
+			],
+			"included":[
+				{"type":"apps","id":"app-1","attributes":{"primaryLocale":"en-US"}},
+				{"type":"ageRatingDeclarations","id":"age-draft","attributes":{"advertising":false}},
+				{"type":"ageRatingDeclarations","id":"age-live","attributes":{"advertising":true}}
+			]
+		}`)
+	}))
+
+	ctx := withReadinessRequestGate(context.Background())
+	result, err := fetchAppInfoReadinessData(ctx, client, "app-1")
+	if err != nil {
+		t.Fatalf("fetchAppInfoReadinessData() error = %v", err)
+	}
+	if result.appInfoID != "info-draft" {
+		t.Fatalf("metadata app info = %q, want info-draft", result.appInfoID)
+	}
+	if result.ageRatingDeclaration != nil {
+		t.Fatalf("expected multi-app-info age rating to remain deferred, got %+v", result.ageRatingDeclaration)
+	}
+	if err := resolveMultipleAppInfoAgeRating(ctx, client, &result, "app-1", "READY_FOR_SALE"); err != nil {
+		t.Fatalf("resolveMultipleAppInfoAgeRating() error = %v", err)
+	}
+	if result.ageRatingDeclaration == nil || result.ageRatingDeclaration.Advertising == nil || !*result.ageRatingDeclaration.Advertising {
+		t.Fatalf("expected live app-info age rating, got %+v", result.ageRatingDeclaration)
+	}
+	if requests != 1 {
+		t.Fatalf("request count = %d, want only the compound app-info request", requests)
+	}
+}

--- a/internal/cli/validate/subscription_fetch.go
+++ b/internal/cli/validate/subscription_fetch.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"net"
 	"slices"
+	"sort"
 	"strings"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
-	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/validation"
 )
 
@@ -28,17 +28,18 @@ type metadataCheckStatus struct {
 var fetchSubscriptionsFn = fetchSubscriptions
 
 func fetchSubscriptions(ctx context.Context, client *asc.Client, appID string) ([]validation.Subscription, error) {
-	groupsCtx, groupsCancel := shared.ContextWithTimeout(ctx)
-	groupsResp, err := client.GetSubscriptionGroups(groupsCtx, appID, asc.WithSubscriptionGroupsLimit(200))
-	groupsCancel()
+	ctx = withReadinessRequestGate(ctx)
+	groupsResp, err := doReadinessRequest(ctx, func(requestCtx context.Context) (*asc.SubscriptionGroupsResponse, error) {
+		return client.GetSubscriptionGroups(requestCtx, appID, asc.WithSubscriptionGroupsLimit(200))
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch subscription groups: %w", err)
 	}
 
 	paginatedGroups, err := asc.PaginateAll(ctx, groupsResp, func(_ context.Context, nextURL string) (asc.PaginatedResponse, error) {
-		pageCtx, pageCancel := shared.ContextWithTimeout(ctx)
-		defer pageCancel()
-		return client.GetSubscriptionGroups(pageCtx, appID, asc.WithSubscriptionGroupsNextURL(nextURL))
+		return doReadinessRequest(ctx, func(requestCtx context.Context) (asc.PaginatedResponse, error) {
+			return client.GetSubscriptionGroups(requestCtx, appID, asc.WithSubscriptionGroupsNextURL(nextURL))
+		})
 	})
 	if err != nil {
 		return nil, fmt.Errorf("paginate subscription groups: %w", err)
@@ -49,153 +50,277 @@ func fetchSubscriptions(ctx context.Context, client *asc.Client, appID string) (
 		return nil, fmt.Errorf("unexpected subscription groups response type %T", paginatedGroups)
 	}
 
-	groupLocalizations := make(map[string][]validation.SubscriptionGroupLocalizationInfo)
-	groupLocalizationStatuses := make(map[string]metadataCheckStatus)
-	groupNames := make(map[string]string)
-	for _, group := range groups.Data {
-		groupID := strings.TrimSpace(group.ID)
-		if groupID == "" {
-			continue
-		}
-		groupNames[groupID] = strings.TrimSpace(group.Attributes.ReferenceName)
+	type groupSubscriptions struct {
+		id            string
+		name          string
+		subscriptions []asc.Resource[asc.SubscriptionAttributes]
 	}
-
-	subscriptions := make([]validation.Subscription, 0)
-	for _, group := range groups.Data {
+	groupResults := make([]groupSubscriptions, len(groups.Data))
+	groupTasks := make([]readinessTask, 0, len(groups.Data))
+	for index, group := range groups.Data {
 		groupID := strings.TrimSpace(group.ID)
+		groupResults[index] = groupSubscriptions{id: groupID, name: strings.TrimSpace(group.Attributes.ReferenceName)}
 		if groupID == "" {
 			continue
 		}
-
-		subsCtx, subsCancel := shared.ContextWithTimeout(ctx)
-		subsResp, err := client.GetSubscriptions(subsCtx, groupID, asc.WithSubscriptionsLimit(200))
-		subsCancel()
-		if err != nil {
-			return nil, fmt.Errorf("failed to fetch subscriptions for group %s: %w", groupID, err)
-		}
-
-		paginatedSubs, err := asc.PaginateAll(ctx, subsResp, func(_ context.Context, nextURL string) (asc.PaginatedResponse, error) {
-			pageCtx, pageCancel := shared.ContextWithTimeout(ctx)
-			defer pageCancel()
-			return client.GetSubscriptions(pageCtx, groupID, asc.WithSubscriptionsNextURL(nextURL))
+		index := index
+		groupTasks = append(groupTasks, func(taskCtx context.Context) error {
+			subscriptions, fetchErr := fetchSubscriptionsForGroup(taskCtx, client, groupID)
+			if fetchErr != nil {
+				return fetchErr
+			}
+			groupResults[index].subscriptions = subscriptions
+			return nil
 		})
-		if err != nil {
-			return nil, fmt.Errorf("paginate subscriptions: %w", err)
-		}
+	}
+	if err := runReadinessTasks(ctx, groupTasks...); err != nil {
+		return nil, err
+	}
 
-		subsResult, ok := paginatedSubs.(*asc.SubscriptionsResponse)
-		if !ok {
-			return nil, fmt.Errorf("unexpected subscriptions response type %T", paginatedSubs)
-		}
-
-		for _, sub := range subsResult.Data {
-			imageStatus, err := subscriptionHasImage(ctx, client, sub.ID)
-			if err != nil {
-				return nil, fmt.Errorf("fetch subscription images for %s: %w", strings.TrimSpace(sub.ID), err)
-			}
-
-			attrs := sub.Attributes
-			valSub := validation.Subscription{
-				ID:                   sub.ID,
-				Name:                 attrs.Name,
-				ProductID:            attrs.ProductID,
-				State:                attrs.State,
-				GroupID:              groupID,
-				GroupName:            groupNames[groupID],
-				HasImage:             imageStatus.HasImage,
-				ImageCheckSkipped:    !imageStatus.Verified,
-				ImageCheckSkipReason: imageStatus.SkipReason,
-			}
-
-			// Fetch price count for all active subscriptions (used for both
-			// diagnostics and territory coverage checks).
-			state := strings.ToUpper(strings.TrimSpace(attrs.State))
-			if state != "REMOVED_FROM_SALE" && state != "DEVELOPER_REMOVED_FROM_SALE" {
-				priceTerritories, priceStatus, err := fetchSubscriptionPriceTerritories(ctx, client, sub.ID)
-				if err != nil {
-					return nil, fmt.Errorf("fetch subscription prices for %s: %w", strings.TrimSpace(sub.ID), err)
-				}
-				valSub.PriceTerritories = priceTerritories
-				valSub.PriceCount = len(priceTerritories)
-				valSub.PriceCheckSkipped = !priceStatus.Verified
-				valSub.PriceCheckSkipReason = priceStatus.SkipReason
-
-				if strings.EqualFold(state, "MISSING_METADATA") {
-					if _, ok := groupLocalizationStatuses[groupID]; !ok {
-						locs, status, err := fetchGroupLocalizations(ctx, client, groupID)
-						if err != nil {
-							return nil, fmt.Errorf("fetch subscription group localizations for group %s: %w", groupID, err)
-						}
-						groupLocalizations[groupID] = locs
-						groupLocalizationStatuses[groupID] = status
-					}
-					groupLocalizationStatus := groupLocalizationStatuses[groupID]
-					valSub.GroupLocalizations = groupLocalizations[groupID]
-					valSub.GroupLocalizationCheckSkipped = !groupLocalizationStatus.Verified
-					valSub.GroupLocalizationCheckReason = groupLocalizationStatus.SkipReason
-
-					localizations, localizationStatus, err := fetchSubscriptionLocalizations(ctx, client, sub.ID)
-					if err != nil {
-						return nil, fmt.Errorf("fetch subscription localizations for %s: %w", strings.TrimSpace(sub.ID), err)
-					}
-					valSub.Localizations = localizations
-					valSub.LocalizationCheckSkipped = !localizationStatus.Verified
-					valSub.LocalizationCheckSkipReason = localizationStatus.SkipReason
-
-					reviewScreenshotID, reviewScreenshotStatus, err := fetchSubscriptionReviewScreenshot(ctx, client, sub.ID)
-					if err != nil {
-						return nil, fmt.Errorf("fetch subscription review screenshot for %s: %w", strings.TrimSpace(sub.ID), err)
-					}
-					valSub.ReviewScreenshotID = reviewScreenshotID
-					valSub.ReviewScreenshotCheckSkipped = !reviewScreenshotStatus.Verified
-					valSub.ReviewScreenshotCheckReason = reviewScreenshotStatus.SkipReason
-
-					availabilityID, availabilityTerritories, availabilityStatus, err := fetchSubscriptionAvailabilityTerritories(ctx, client, sub.ID)
-					if err != nil {
-						return nil, fmt.Errorf("fetch subscription availability for %s: %w", strings.TrimSpace(sub.ID), err)
-					}
-					valSub.AvailabilityID = availabilityID
-					valSub.AvailabilityTerritories = availabilityTerritories
-					valSub.AvailabilityCheckSkipped = !availabilityStatus.Verified
-					valSub.AvailabilityCheckSkipReason = availabilityStatus.SkipReason
-
-					introOfferCount, introStatus, err := fetchSubscriptionIntroductoryOfferCount(ctx, client, sub.ID)
-					if err != nil {
-						return nil, fmt.Errorf("fetch subscription introductory offers for %s: %w", strings.TrimSpace(sub.ID), err)
-					}
-					valSub.IntroductoryOfferCount = introOfferCount
-					valSub.IntroductoryOfferCheckSkipped = !introStatus.Verified
-					valSub.IntroductoryOfferCheckReason = introStatus.SkipReason
-
-					promoOfferCount, promoStatus, err := fetchSubscriptionPromotionalOfferCount(ctx, client, sub.ID)
-					if err != nil {
-						return nil, fmt.Errorf("fetch subscription promotional offers for %s: %w", strings.TrimSpace(sub.ID), err)
-					}
-					valSub.PromotionalOfferCount = promoOfferCount
-					valSub.PromotionalOfferCheckSkipped = !promoStatus.Verified
-					valSub.PromotionalOfferCheckReason = promoStatus.SkipReason
-
-					winBackOfferCount, winBackStatus, err := fetchSubscriptionWinBackOfferCount(ctx, client, sub.ID)
-					if err != nil {
-						return nil, fmt.Errorf("fetch subscription win-back offers for %s: %w", strings.TrimSpace(sub.ID), err)
-					}
-					valSub.WinBackOfferCount = winBackOfferCount
-					valSub.WinBackOfferCheckSkipped = !winBackStatus.Verified
-					valSub.WinBackOfferCheckReason = winBackStatus.SkipReason
-				}
-			}
-
-			subscriptions = append(subscriptions, valSub)
+	type subscriptionRef struct {
+		groupIndex int
+		groupID    string
+		groupName  string
+		resource   asc.Resource[asc.SubscriptionAttributes]
+	}
+	refs := make([]subscriptionRef, 0)
+	for groupIndex, group := range groupResults {
+		for _, subscription := range group.subscriptions {
+			refs = append(refs, subscriptionRef{
+				groupIndex: groupIndex,
+				groupID:    group.id,
+				groupName:  group.name,
+				resource:   subscription,
+			})
 		}
 	}
+
+	enrichments := make([]subscriptionEnrichment, len(refs))
+	groupMetadata := make([]subscriptionGroupMetadata, len(groupResults))
+	groupMetadataScheduled := make([]bool, len(groupResults))
+	metadataTasks := make([]readinessTask, 0, len(refs)*3)
+	for index := range refs {
+		index := index
+		ref := refs[index]
+		subscriptionID := strings.TrimSpace(ref.resource.ID)
+		metadataTasks = append(metadataTasks, func(taskCtx context.Context) error {
+			status, fetchErr := subscriptionHasImage(taskCtx, client, subscriptionID)
+			if fetchErr != nil {
+				return fmt.Errorf("fetch subscription images for %s: %w", subscriptionID, fetchErr)
+			}
+			enrichments[index].image = status
+			return nil
+		})
+
+		state := strings.ToUpper(strings.TrimSpace(ref.resource.Attributes.State))
+		if state == "REMOVED_FROM_SALE" || state == "DEVELOPER_REMOVED_FROM_SALE" {
+			continue
+		}
+		metadataTasks = append(metadataTasks, func(taskCtx context.Context) error {
+			territories, status, fetchErr := fetchSubscriptionPriceTerritories(taskCtx, client, subscriptionID)
+			if fetchErr != nil {
+				return fmt.Errorf("fetch subscription prices for %s: %w", subscriptionID, fetchErr)
+			}
+			enrichments[index].priceTerritories = territories
+			enrichments[index].priceStatus = status
+			return nil
+		})
+
+		if state != "MISSING_METADATA" {
+			continue
+		}
+		if !groupMetadataScheduled[ref.groupIndex] {
+			groupMetadataScheduled[ref.groupIndex] = true
+			groupIndex := ref.groupIndex
+			groupID := ref.groupID
+			metadataTasks = append(metadataTasks, func(taskCtx context.Context) error {
+				localizations, status, fetchErr := fetchGroupLocalizations(taskCtx, client, groupID)
+				if fetchErr != nil {
+					return fmt.Errorf("fetch subscription group localizations for group %s: %w", groupID, fetchErr)
+				}
+				groupMetadata[groupIndex] = subscriptionGroupMetadata{localizations: localizations, status: status}
+				return nil
+			})
+		}
+
+		metadataTasks = append(
+			metadataTasks,
+			func(taskCtx context.Context) error {
+				localizations, status, fetchErr := fetchSubscriptionLocalizations(taskCtx, client, subscriptionID)
+				if fetchErr != nil {
+					return fmt.Errorf("fetch subscription localizations for %s: %w", subscriptionID, fetchErr)
+				}
+				enrichments[index].localizations = localizations
+				enrichments[index].localizationStatus = status
+				return nil
+			},
+			func(taskCtx context.Context) error {
+				id, status, fetchErr := fetchSubscriptionReviewScreenshot(taskCtx, client, subscriptionID)
+				if fetchErr != nil {
+					return fmt.Errorf("fetch subscription review screenshot for %s: %w", subscriptionID, fetchErr)
+				}
+				enrichments[index].reviewScreenshotID = id
+				enrichments[index].reviewScreenshotStatus = status
+				return nil
+			},
+			func(taskCtx context.Context) error {
+				id, territories, status, fetchErr := fetchSubscriptionAvailabilityTerritories(taskCtx, client, subscriptionID)
+				if fetchErr != nil {
+					return fmt.Errorf("fetch subscription availability for %s: %w", subscriptionID, fetchErr)
+				}
+				enrichments[index].availabilityID = id
+				enrichments[index].availabilityTerritories = territories
+				enrichments[index].availabilityStatus = status
+				return nil
+			},
+			func(taskCtx context.Context) error {
+				count, status, fetchErr := fetchSubscriptionIntroductoryOfferCount(taskCtx, client, subscriptionID)
+				if fetchErr != nil {
+					return fmt.Errorf("fetch subscription introductory offers for %s: %w", subscriptionID, fetchErr)
+				}
+				enrichments[index].introductoryOfferCount = count
+				enrichments[index].introductoryOfferStatus = status
+				return nil
+			},
+			func(taskCtx context.Context) error {
+				count, status, fetchErr := fetchSubscriptionPromotionalOfferCount(taskCtx, client, subscriptionID)
+				if fetchErr != nil {
+					return fmt.Errorf("fetch subscription promotional offers for %s: %w", subscriptionID, fetchErr)
+				}
+				enrichments[index].promotionalOfferCount = count
+				enrichments[index].promotionalOfferStatus = status
+				return nil
+			},
+			func(taskCtx context.Context) error {
+				count, status, fetchErr := fetchSubscriptionWinBackOfferCount(taskCtx, client, subscriptionID)
+				if fetchErr != nil {
+					return fmt.Errorf("fetch subscription win-back offers for %s: %w", subscriptionID, fetchErr)
+				}
+				enrichments[index].winBackOfferCount = count
+				enrichments[index].winBackOfferStatus = status
+				return nil
+			},
+		)
+	}
+	if err := runReadinessTasks(ctx, metadataTasks...); err != nil {
+		return nil, err
+	}
+
+	subscriptions := make([]validation.Subscription, 0, len(refs))
+	for index, ref := range refs {
+		attrs := ref.resource.Attributes
+		enrichment := enrichments[index]
+		valSub := validation.Subscription{
+			ID:                   ref.resource.ID,
+			Name:                 attrs.Name,
+			ProductID:            attrs.ProductID,
+			State:                attrs.State,
+			GroupID:              ref.groupID,
+			GroupName:            ref.groupName,
+			HasImage:             enrichment.image.HasImage,
+			ImageCheckSkipped:    !enrichment.image.Verified,
+			ImageCheckSkipReason: enrichment.image.SkipReason,
+		}
+
+		state := strings.ToUpper(strings.TrimSpace(attrs.State))
+		if state != "REMOVED_FROM_SALE" && state != "DEVELOPER_REMOVED_FROM_SALE" {
+			valSub.PriceTerritories = enrichment.priceTerritories
+			valSub.PriceCount = len(enrichment.priceTerritories)
+			valSub.PriceCheckSkipped = !enrichment.priceStatus.Verified
+			valSub.PriceCheckSkipReason = enrichment.priceStatus.SkipReason
+
+			if state == "MISSING_METADATA" {
+				group := groupMetadata[ref.groupIndex]
+				valSub.GroupLocalizations = group.localizations
+				valSub.GroupLocalizationCheckSkipped = !group.status.Verified
+				valSub.GroupLocalizationCheckReason = group.status.SkipReason
+				valSub.Localizations = enrichment.localizations
+				valSub.LocalizationCheckSkipped = !enrichment.localizationStatus.Verified
+				valSub.LocalizationCheckSkipReason = enrichment.localizationStatus.SkipReason
+				valSub.ReviewScreenshotID = enrichment.reviewScreenshotID
+				valSub.ReviewScreenshotCheckSkipped = !enrichment.reviewScreenshotStatus.Verified
+				valSub.ReviewScreenshotCheckReason = enrichment.reviewScreenshotStatus.SkipReason
+				valSub.AvailabilityID = enrichment.availabilityID
+				valSub.AvailabilityTerritories = enrichment.availabilityTerritories
+				valSub.AvailabilityCheckSkipped = !enrichment.availabilityStatus.Verified
+				valSub.AvailabilityCheckSkipReason = enrichment.availabilityStatus.SkipReason
+				valSub.IntroductoryOfferCount = enrichment.introductoryOfferCount
+				valSub.IntroductoryOfferCheckSkipped = !enrichment.introductoryOfferStatus.Verified
+				valSub.IntroductoryOfferCheckReason = enrichment.introductoryOfferStatus.SkipReason
+				valSub.PromotionalOfferCount = enrichment.promotionalOfferCount
+				valSub.PromotionalOfferCheckSkipped = !enrichment.promotionalOfferStatus.Verified
+				valSub.PromotionalOfferCheckReason = enrichment.promotionalOfferStatus.SkipReason
+				valSub.WinBackOfferCount = enrichment.winBackOfferCount
+				valSub.WinBackOfferCheckSkipped = !enrichment.winBackOfferStatus.Verified
+				valSub.WinBackOfferCheckReason = enrichment.winBackOfferStatus.SkipReason
+			}
+		}
+		subscriptions = append(subscriptions, valSub)
+	}
+	sort.SliceStable(subscriptions, func(i, j int) bool {
+		if subscriptions[i].GroupID != subscriptions[j].GroupID {
+			return subscriptions[i].GroupID < subscriptions[j].GroupID
+		}
+		if subscriptions[i].ProductID != subscriptions[j].ProductID {
+			return subscriptions[i].ProductID < subscriptions[j].ProductID
+		}
+		return subscriptions[i].ID < subscriptions[j].ID
+	})
 
 	return subscriptions, nil
 }
 
+type subscriptionGroupMetadata struct {
+	localizations []validation.SubscriptionGroupLocalizationInfo
+	status        metadataCheckStatus
+}
+
+type subscriptionEnrichment struct {
+	image                   subscriptionImageStatus
+	priceTerritories        []string
+	priceStatus             metadataCheckStatus
+	localizations           []validation.SubscriptionLocalizationInfo
+	localizationStatus      metadataCheckStatus
+	reviewScreenshotID      string
+	reviewScreenshotStatus  metadataCheckStatus
+	availabilityID          string
+	availabilityTerritories []string
+	availabilityStatus      metadataCheckStatus
+	introductoryOfferCount  int
+	introductoryOfferStatus metadataCheckStatus
+	promotionalOfferCount   int
+	promotionalOfferStatus  metadataCheckStatus
+	winBackOfferCount       int
+	winBackOfferStatus      metadataCheckStatus
+}
+
+func fetchSubscriptionsForGroup(ctx context.Context, client *asc.Client, groupID string) ([]asc.Resource[asc.SubscriptionAttributes], error) {
+	response, err := doReadinessRequest(ctx, func(requestCtx context.Context) (*asc.SubscriptionsResponse, error) {
+		return client.GetSubscriptions(requestCtx, groupID, asc.WithSubscriptionsLimit(200))
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch subscriptions for group %s: %w", groupID, err)
+	}
+
+	paginated, err := asc.PaginateAll(ctx, response, func(_ context.Context, nextURL string) (asc.PaginatedResponse, error) {
+		return doReadinessRequest(ctx, func(requestCtx context.Context) (asc.PaginatedResponse, error) {
+			return client.GetSubscriptions(requestCtx, groupID, asc.WithSubscriptionsNextURL(nextURL))
+		})
+	})
+	if err != nil {
+		return nil, fmt.Errorf("paginate subscriptions: %w", err)
+	}
+	typed, ok := paginated.(*asc.SubscriptionsResponse)
+	if !ok {
+		return nil, fmt.Errorf("unexpected subscriptions response type %T", paginated)
+	}
+	return typed.Data, nil
+}
+
 func fetchGroupLocalizations(ctx context.Context, client *asc.Client, groupID string) ([]validation.SubscriptionGroupLocalizationInfo, metadataCheckStatus, error) {
-	reqCtx, cancel := shared.ContextWithTimeout(ctx)
-	resp, err := client.GetSubscriptionGroupLocalizations(reqCtx, strings.TrimSpace(groupID), asc.WithSubscriptionGroupLocalizationsLimit(200))
-	cancel()
+	resp, err := doReadinessRequest(ctx, func(requestCtx context.Context) (*asc.SubscriptionGroupLocalizationsResponse, error) {
+		return client.GetSubscriptionGroupLocalizations(requestCtx, strings.TrimSpace(groupID), asc.WithSubscriptionGroupLocalizationsLimit(200))
+	})
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			return nil, metadataCheckStatus{}, err
@@ -207,9 +332,9 @@ func fetchGroupLocalizations(ctx context.Context, client *asc.Client, groupID st
 	}
 
 	paginated, err := asc.PaginateAll(ctx, resp, func(_ context.Context, nextURL string) (asc.PaginatedResponse, error) {
-		pageCtx, pageCancel := shared.ContextWithTimeout(ctx)
-		defer pageCancel()
-		return client.GetSubscriptionGroupLocalizations(pageCtx, strings.TrimSpace(groupID), asc.WithSubscriptionGroupLocalizationsNextURL(nextURL))
+		return doReadinessRequest(ctx, func(requestCtx context.Context) (asc.PaginatedResponse, error) {
+			return client.GetSubscriptionGroupLocalizations(requestCtx, strings.TrimSpace(groupID), asc.WithSubscriptionGroupLocalizationsNextURL(nextURL))
+		})
 	})
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
@@ -233,14 +358,20 @@ func fetchGroupLocalizations(ctx context.Context, client *asc.Client, groupID st
 			Name:   strings.TrimSpace(loc.Attributes.Name),
 		})
 	}
+	sort.SliceStable(locs, func(i, j int) bool {
+		if locs[i].Locale != locs[j].Locale {
+			return locs[i].Locale < locs[j].Locale
+		}
+		return locs[i].Name < locs[j].Name
+	})
 	return locs, metadataCheckStatus{Verified: true}, nil
 }
 
 // fetchSubscriptionLocalizations fetches localization info for a subscription.
 func fetchSubscriptionLocalizations(ctx context.Context, client *asc.Client, subscriptionID string) ([]validation.SubscriptionLocalizationInfo, metadataCheckStatus, error) {
-	reqCtx, cancel := shared.ContextWithTimeout(ctx)
-	resp, err := client.GetSubscriptionLocalizations(reqCtx, strings.TrimSpace(subscriptionID), asc.WithSubscriptionLocalizationsLimit(200))
-	cancel()
+	resp, err := doReadinessRequest(ctx, func(requestCtx context.Context) (*asc.SubscriptionLocalizationsResponse, error) {
+		return client.GetSubscriptionLocalizations(requestCtx, strings.TrimSpace(subscriptionID), asc.WithSubscriptionLocalizationsLimit(200))
+	})
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			return nil, metadataCheckStatus{}, err
@@ -252,9 +383,9 @@ func fetchSubscriptionLocalizations(ctx context.Context, client *asc.Client, sub
 	}
 
 	paginated, err := asc.PaginateAll(ctx, resp, func(_ context.Context, nextURL string) (asc.PaginatedResponse, error) {
-		pageCtx, pageCancel := shared.ContextWithTimeout(ctx)
-		defer pageCancel()
-		return client.GetSubscriptionLocalizations(pageCtx, strings.TrimSpace(subscriptionID), asc.WithSubscriptionLocalizationsNextURL(nextURL))
+		return doReadinessRequest(ctx, func(requestCtx context.Context) (asc.PaginatedResponse, error) {
+			return client.GetSubscriptionLocalizations(requestCtx, strings.TrimSpace(subscriptionID), asc.WithSubscriptionLocalizationsNextURL(nextURL))
+		})
 	})
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
@@ -279,6 +410,15 @@ func fetchSubscriptionLocalizations(ctx context.Context, client *asc.Client, sub
 			Description: strings.TrimSpace(loc.Attributes.Description),
 		})
 	}
+	sort.SliceStable(locs, func(i, j int) bool {
+		if locs[i].Locale != locs[j].Locale {
+			return locs[i].Locale < locs[j].Locale
+		}
+		if locs[i].Name != locs[j].Name {
+			return locs[i].Name < locs[j].Name
+		}
+		return locs[i].Description < locs[j].Description
+	})
 	return locs, metadataCheckStatus{Verified: true}, nil
 }
 
@@ -286,14 +426,14 @@ func fetchSubscriptionLocalizations(ctx context.Context, client *asc.Client, sub
 // configured for a subscription. It paginates all price resources so scheduled
 // price changes for the same territory don't inflate coverage.
 func fetchSubscriptionPriceTerritories(ctx context.Context, client *asc.Client, subscriptionID string) ([]string, metadataCheckStatus, error) {
-	reqCtx, cancel := shared.ContextWithTimeout(ctx)
-	resp, err := client.GetSubscriptionPrices(
-		reqCtx,
-		strings.TrimSpace(subscriptionID),
-		asc.WithSubscriptionPricesInclude([]string{"territory"}),
-		asc.WithSubscriptionPricesLimit(200),
-	)
-	cancel()
+	resp, err := doReadinessRequest(ctx, func(requestCtx context.Context) (*asc.SubscriptionPricesResponse, error) {
+		return client.GetSubscriptionPrices(
+			requestCtx,
+			strings.TrimSpace(subscriptionID),
+			asc.WithSubscriptionPricesInclude([]string{"territory"}),
+			asc.WithSubscriptionPricesLimit(200),
+		)
+	})
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			return nil, metadataCheckStatus{}, err
@@ -305,9 +445,9 @@ func fetchSubscriptionPriceTerritories(ctx context.Context, client *asc.Client, 
 	}
 
 	paginated, err := asc.PaginateAll(ctx, resp, func(_ context.Context, nextURL string) (asc.PaginatedResponse, error) {
-		pageCtx, pageCancel := shared.ContextWithTimeout(ctx)
-		defer pageCancel()
-		return client.GetSubscriptionPrices(pageCtx, strings.TrimSpace(subscriptionID), asc.WithSubscriptionPricesNextURL(nextURL))
+		return doReadinessRequest(ctx, func(requestCtx context.Context) (asc.PaginatedResponse, error) {
+			return client.GetSubscriptionPrices(requestCtx, strings.TrimSpace(subscriptionID), asc.WithSubscriptionPricesNextURL(nextURL))
+		})
 	})
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
@@ -362,9 +502,9 @@ func subscriptionPriceTerritoryID(raw json.RawMessage) (string, error) {
 }
 
 func fetchSubscriptionReviewScreenshot(ctx context.Context, client *asc.Client, subscriptionID string) (string, metadataCheckStatus, error) {
-	reqCtx, cancel := shared.ContextWithTimeout(ctx)
-	resp, err := client.GetSubscriptionAppStoreReviewScreenshotForSubscription(reqCtx, strings.TrimSpace(subscriptionID))
-	cancel()
+	resp, err := doReadinessRequest(ctx, func(requestCtx context.Context) (*asc.SubscriptionAppStoreReviewScreenshotResponse, error) {
+		return client.GetSubscriptionAppStoreReviewScreenshotForSubscription(requestCtx, strings.TrimSpace(subscriptionID))
+	})
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			return "", metadataCheckStatus{}, err
@@ -384,9 +524,9 @@ func fetchSubscriptionReviewScreenshot(ctx context.Context, client *asc.Client, 
 }
 
 func fetchSubscriptionAvailabilityTerritories(ctx context.Context, client *asc.Client, subscriptionID string) (string, []string, metadataCheckStatus, error) {
-	reqCtx, cancel := shared.ContextWithTimeout(ctx)
-	resp, err := client.GetSubscriptionAvailabilityForSubscription(reqCtx, strings.TrimSpace(subscriptionID))
-	cancel()
+	resp, err := doReadinessRequest(ctx, func(requestCtx context.Context) (*asc.SubscriptionAvailabilityResponse, error) {
+		return client.GetSubscriptionAvailabilityForSubscription(requestCtx, strings.TrimSpace(subscriptionID))
+	})
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			return "", nil, metadataCheckStatus{}, err
@@ -408,14 +548,13 @@ func fetchSubscriptionAvailabilityTerritories(ctx context.Context, client *asc.C
 	allTerritories := make([]string, 0)
 	nextURL := ""
 	for {
-		pageCtx, pageCancel := shared.ContextWithTimeout(ctx)
-		var territoryResp *asc.TerritoriesResponse
-		if strings.TrimSpace(nextURL) != "" {
-			territoryResp, err = client.GetSubscriptionAvailabilityAvailableTerritories(pageCtx, availabilityID, asc.WithSubscriptionAvailabilityTerritoriesNextURL(nextURL))
-		} else {
-			territoryResp, err = client.GetSubscriptionAvailabilityAvailableTerritories(pageCtx, availabilityID, asc.WithSubscriptionAvailabilityTerritoriesLimit(200))
-		}
-		pageCancel()
+		territoryResp, requestErr := doReadinessRequest(ctx, func(requestCtx context.Context) (*asc.TerritoriesResponse, error) {
+			if strings.TrimSpace(nextURL) != "" {
+				return client.GetSubscriptionAvailabilityAvailableTerritories(requestCtx, availabilityID, asc.WithSubscriptionAvailabilityTerritoriesNextURL(nextURL))
+			}
+			return client.GetSubscriptionAvailabilityAvailableTerritories(requestCtx, availabilityID, asc.WithSubscriptionAvailabilityTerritoriesLimit(200))
+		})
+		err = requestErr
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
 				return "", nil, metadataCheckStatus{}, err
@@ -440,9 +579,9 @@ func fetchSubscriptionAvailabilityTerritories(ctx context.Context, client *asc.C
 }
 
 func fetchSubscriptionIntroductoryOfferCount(ctx context.Context, client *asc.Client, subscriptionID string) (int, metadataCheckStatus, error) {
-	reqCtx, cancel := shared.ContextWithTimeout(ctx)
-	resp, err := client.GetSubscriptionIntroductoryOffers(reqCtx, strings.TrimSpace(subscriptionID), asc.WithSubscriptionIntroductoryOffersLimit(1))
-	cancel()
+	resp, err := doReadinessRequest(ctx, func(requestCtx context.Context) (*asc.SubscriptionIntroductoryOffersResponse, error) {
+		return client.GetSubscriptionIntroductoryOffers(requestCtx, strings.TrimSpace(subscriptionID), asc.WithSubscriptionIntroductoryOffersLimit(1))
+	})
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			return 0, metadataCheckStatus{}, err
@@ -456,9 +595,9 @@ func fetchSubscriptionIntroductoryOfferCount(ctx context.Context, client *asc.Cl
 }
 
 func fetchSubscriptionPromotionalOfferCount(ctx context.Context, client *asc.Client, subscriptionID string) (int, metadataCheckStatus, error) {
-	reqCtx, cancel := shared.ContextWithTimeout(ctx)
-	resp, err := client.GetSubscriptionPromotionalOffers(reqCtx, strings.TrimSpace(subscriptionID), asc.WithSubscriptionPromotionalOffersLimit(1))
-	cancel()
+	resp, err := doReadinessRequest(ctx, func(requestCtx context.Context) (*asc.SubscriptionPromotionalOffersResponse, error) {
+		return client.GetSubscriptionPromotionalOffers(requestCtx, strings.TrimSpace(subscriptionID), asc.WithSubscriptionPromotionalOffersLimit(1))
+	})
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			return 0, metadataCheckStatus{}, err
@@ -472,9 +611,9 @@ func fetchSubscriptionPromotionalOfferCount(ctx context.Context, client *asc.Cli
 }
 
 func fetchSubscriptionWinBackOfferCount(ctx context.Context, client *asc.Client, subscriptionID string) (int, metadataCheckStatus, error) {
-	reqCtx, cancel := shared.ContextWithTimeout(ctx)
-	resp, err := client.GetSubscriptionWinBackOffers(reqCtx, strings.TrimSpace(subscriptionID), asc.WithWinBackOffersLimit(1))
-	cancel()
+	resp, err := doReadinessRequest(ctx, func(requestCtx context.Context) (*asc.WinBackOffersResponse, error) {
+		return client.GetSubscriptionWinBackOffers(requestCtx, strings.TrimSpace(subscriptionID), asc.WithWinBackOffersLimit(1))
+	})
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			return 0, metadataCheckStatus{}, err
@@ -488,10 +627,9 @@ func fetchSubscriptionWinBackOfferCount(ctx context.Context, client *asc.Client,
 }
 
 func subscriptionHasImage(ctx context.Context, client *asc.Client, subscriptionID string) (subscriptionImageStatus, error) {
-	requestCtx, cancel := shared.ContextWithTimeout(ctx)
-	defer cancel()
-
-	resp, err := client.GetSubscriptionImages(requestCtx, strings.TrimSpace(subscriptionID), asc.WithSubscriptionImagesLimit(1))
+	resp, err := doReadinessRequest(ctx, func(requestCtx context.Context) (*asc.SubscriptionImagesResponse, error) {
+		return client.GetSubscriptionImages(requestCtx, strings.TrimSpace(subscriptionID), asc.WithSubscriptionImagesLimit(1))
+	})
 	if err != nil {
 		if asc.IsNotFound(err) {
 			return subscriptionImageStatus{Verified: true}, nil

--- a/internal/cli/validate/subscription_fetch_test.go
+++ b/internal/cli/validate/subscription_fetch_test.go
@@ -5,7 +5,66 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 )
+
+func TestFetchSubscriptions_BoundsGroupAndMetadataFanOutAndSortsDeterministically(t *testing.T) {
+	const delay = 50 * time.Millisecond
+	tracker := &requestConcurrencyTracker{}
+	client := newBuildsTestClient(t, buildsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path == "/v1/apps/app-1/subscriptionGroups" {
+			return buildsJSONResponse(http.StatusOK, `{"data":[
+				{"type":"subscriptionGroups","id":"group-z","attributes":{"referenceName":"Group Z"}},
+				{"type":"subscriptionGroups","id":"group-a","attributes":{"referenceName":"Group A"}}
+			]}`)
+		}
+		if err := tracker.wait(req.Context(), delay); err != nil {
+			return nil, err
+		}
+
+		switch {
+		case strings.HasPrefix(req.URL.Path, "/v1/subscriptionGroups/") && strings.HasSuffix(req.URL.Path, "/subscriptions"):
+			groupID := strings.TrimSuffix(strings.TrimPrefix(req.URL.Path, "/v1/subscriptionGroups/"), "/subscriptions")
+			subscriptionID := strings.TrimPrefix(groupID, "group-")
+			return buildsJSONResponse(http.StatusOK, `{"data":[{"type":"subscriptions","id":"sub-`+subscriptionID+`","attributes":{"name":"Subscription `+subscriptionID+`","productId":"product.`+subscriptionID+`","state":"MISSING_METADATA"}}]}`)
+		case strings.HasPrefix(req.URL.Path, "/v1/subscriptionGroups/") && strings.HasSuffix(req.URL.Path, "/subscriptionGroupLocalizations"):
+			return buildsJSONResponse(http.StatusOK, `{"data":[]}`)
+		case strings.HasSuffix(req.URL.Path, "/appStoreReviewScreenshot"), strings.HasSuffix(req.URL.Path, "/subscriptionAvailability"):
+			return buildsJSONResponse(http.StatusNotFound, `{"errors":[{"status":"404","code":"NOT_FOUND"}]}`)
+		case strings.HasSuffix(req.URL.Path, "/images"),
+			strings.HasSuffix(req.URL.Path, "/prices"),
+			strings.HasSuffix(req.URL.Path, "/subscriptionLocalizations"),
+			strings.HasSuffix(req.URL.Path, "/introductoryOffers"),
+			strings.HasSuffix(req.URL.Path, "/promotionalOffers"),
+			strings.HasSuffix(req.URL.Path, "/winBackOffers"):
+			return buildsJSONResponse(http.StatusOK, `{"data":[]}`)
+		default:
+			return buildsJSONResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"UNEXPECTED_REQUEST"}]}`)
+		}
+	}))
+
+	started := time.Now()
+	subscriptions, err := fetchSubscriptions(context.Background(), client, "app-1")
+	elapsed := time.Since(started)
+	if err != nil {
+		t.Fatalf("fetchSubscriptions() error = %v", err)
+	}
+	if got := tracker.max.Load(); got != readinessConcurrencyLimit {
+		t.Fatalf("maximum in-flight requests = %d, want exactly %d", got, readinessConcurrencyLimit)
+	}
+	if elapsed >= 800*time.Millisecond {
+		t.Fatalf("bounded subscription fan-out took %s; serial delayed fixture time is %s", elapsed, 20*delay)
+	}
+	if len(subscriptions) != 2 {
+		t.Fatalf("got %d subscriptions, want 2", len(subscriptions))
+	}
+	if subscriptions[0].ID != "sub-a" || subscriptions[0].GroupID != "group-a" {
+		t.Fatalf("first subscription is not stably sorted: %+v", subscriptions[0])
+	}
+	if subscriptions[1].ID != "sub-z" || subscriptions[1].GroupID != "group-z" {
+		t.Fatalf("second subscription is not stably sorted: %+v", subscriptions[1])
+	}
+}
 
 func TestFetchSubscriptionPriceTerritories_DeduplicatesAndSortsTerritories(t *testing.T) {
 	client := newBuildsTestClient(t, buildsRoundTripFunc(func(req *http.Request) (*http.Response, error) {

--- a/internal/cli/validate/subscriptions.go
+++ b/internal/cli/validate/subscriptions.go
@@ -2,7 +2,6 @@ package validate
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -69,30 +68,36 @@ func runValidateSubscriptions(ctx context.Context, opts validateSubscriptionsOpt
 		return fmt.Errorf("validate subscriptions: %w", err)
 	}
 
-	requestCtx, cancel := shared.ContextWithTimeout(ctx)
-	defer func() { cancel() }()
-
-	refreshRequestCtx := func() {
-		cancel()
-		requestCtx, cancel = shared.ContextWithTimeout(ctx)
-	}
-
+	ctx = withReadinessRequestGate(ctx)
 	pricingCoverageSkipReason := ""
-	_, appAvailableTerritories, availableTerritories, err := fetchAvailableTerritoryDetailsFn(requestCtx, client, opts.AppID)
-	if err != nil {
-		if reason, ok := availabilityCheckSkipReason(err); ok {
-			pricingCoverageSkipReason = reason
-			if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
-				refreshRequestCtx()
+	var appAvailableTerritories []string
+	availableTerritories := 0
+	var subs []validation.Subscription
+	if err := runReadinessTasks(
+		ctx,
+		func(taskCtx context.Context) error {
+			_, territories, count, fetchErr := fetchAvailableTerritoryDetailsFn(taskCtx, client, opts.AppID)
+			if fetchErr != nil {
+				if reason, ok := availabilityCheckSkipReason(fetchErr); ok {
+					pricingCoverageSkipReason = reason
+					return nil
+				}
+				return fmt.Errorf("validate subscriptions: %w", fetchErr)
 			}
-		} else {
-			return fmt.Errorf("validate subscriptions: %w", err)
-		}
-	}
-
-	subs, err := fetchSubscriptionsFn(ctx, client, opts.AppID)
-	if err != nil {
-		return fmt.Errorf("validate subscriptions: %w", err)
+			appAvailableTerritories = territories
+			availableTerritories = count
+			return nil
+		},
+		func(taskCtx context.Context) error {
+			var fetchErr error
+			subs, fetchErr = fetchSubscriptionsFn(taskCtx, client, opts.AppID)
+			if fetchErr != nil {
+				return fmt.Errorf("validate subscriptions: %w", fetchErr)
+			}
+			return nil
+		},
+	); err != nil {
+		return err
 	}
 
 	buildCount := 0
@@ -101,8 +106,7 @@ func runValidateSubscriptions(ctx context.Context, opts validateSubscriptionsOpt
 	var buildStatus metadataCheckStatus
 	for _, sub := range subs {
 		if strings.EqualFold(strings.TrimSpace(sub.State), "MISSING_METADATA") {
-			refreshRequestCtx()
-			buildCount, buildStatus, err = fetchAppBuildCountFn(requestCtx, client, opts.AppID)
+			buildCount, buildStatus, err = fetchAppBuildCountFn(ctx, client, opts.AppID)
 			if err != nil {
 				return fmt.Errorf("validate subscriptions: %w", err)
 			}
@@ -111,11 +115,6 @@ func runValidateSubscriptions(ctx context.Context, opts validateSubscriptionsOpt
 			break
 		}
 	}
-
-	// No further network calls use the request-scoped timeout context beyond this point.
-	// Cancel it eagerly so slow report rendering cannot race the refreshed context into
-	// DeadlineExceeded after the build probe already succeeded.
-	cancel()
 
 	report := validation.ValidateSubscriptions(validation.SubscriptionsInput{
 		AppID:                     opts.AppID,

--- a/internal/cli/validate/test_hooks.go
+++ b/internal/cli/validate/test_hooks.go
@@ -51,6 +51,7 @@ func SetFetchIAPsFunc(fn func(context.Context, *asc.Client, string) ([]validatio
 }
 
 // SetFetchAvailableTerritoriesFunc replaces the availability fetcher for tests.
+// The legacy hook models one outbound probe and receives a fresh request context.
 // It returns a restore function to reset the previous handler.
 func SetFetchAvailableTerritoriesFunc(fn func(context.Context, *asc.Client, string) (string, int, error)) func() {
 	previousDetails := fetchAvailableTerritoryDetailsFn
@@ -58,8 +59,15 @@ func SetFetchAvailableTerritoriesFunc(fn func(context.Context, *asc.Client, stri
 		fetchAvailableTerritoryDetailsFn = fetchAvailableTerritoryDetails
 	} else {
 		fetchAvailableTerritoryDetailsFn = func(ctx context.Context, client *asc.Client, appID string) (string, []string, int, error) {
-			availabilityID, availableTerritories, err := fn(ctx, client, appID)
-			return availabilityID, nil, availableTerritories, err
+			type result struct {
+				availabilityID       string
+				availableTerritories int
+			}
+			value, err := doReadinessRequest(ctx, func(requestCtx context.Context) (result, error) {
+				availabilityID, availableTerritories, requestErr := fn(requestCtx, client, appID)
+				return result{availabilityID: availabilityID, availableTerritories: availableTerritories}, requestErr
+			})
+			return value.availabilityID, nil, value.availableTerritories, err
 		}
 	}
 	return func() {
@@ -68,6 +76,7 @@ func SetFetchAvailableTerritoriesFunc(fn func(context.Context, *asc.Client, stri
 }
 
 // SetFetchAppBuildCountFunc replaces the app build-count fetcher for tests.
+// The hook models one outbound probe and receives a fresh request context.
 // It returns a restore function to reset the previous handler.
 func SetFetchAppBuildCountFunc(fn func(context.Context, *asc.Client, string) (int, bool, string, error)) func() {
 	previous := fetchAppBuildCountFn
@@ -75,8 +84,16 @@ func SetFetchAppBuildCountFunc(fn func(context.Context, *asc.Client, string) (in
 		fetchAppBuildCountFn = fetchAppBuildCount
 	} else {
 		fetchAppBuildCountFn = func(ctx context.Context, client *asc.Client, appID string) (int, metadataCheckStatus, error) {
-			count, verified, skipReason, err := fn(ctx, client, appID)
-			return count, metadataCheckStatus{Verified: verified, SkipReason: skipReason}, err
+			type result struct {
+				count      int
+				verified   bool
+				skipReason string
+			}
+			value, err := doReadinessRequest(ctx, func(requestCtx context.Context) (result, error) {
+				count, verified, skipReason, requestErr := fn(requestCtx, client, appID)
+				return result{count: count, verified: verified, skipReason: skipReason}, requestErr
+			})
+			return value.count, metadataCheckStatus{Verified: value.verified, SkipReason: value.skipReason}, err
 		}
 	}
 	return func() {

--- a/internal/cli/validate/validate.go
+++ b/internal/cli/validate/validate.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
@@ -248,19 +249,56 @@ func resolveVersionID(ctx context.Context, client *asc.Client, appID, version, p
 }
 
 func fetchScreenshotSets(ctx context.Context, client *asc.Client, localizations []asc.Resource[asc.AppStoreVersionLocalizationAttributes]) ([]validation.ScreenshotSet, error) {
-	var sets []validation.ScreenshotSet
-	for _, loc := range localizations {
-		resp, err := client.GetAppStoreVersionLocalizationScreenshotSets(ctx, loc.ID)
-		if err != nil {
-			return nil, fmt.Errorf("validate: failed to fetch screenshot sets for %s: %w", loc.ID, err)
-		}
-		for _, set := range resp.Data {
-			screenshotsResp, err := client.GetAppScreenshots(ctx, set.ID)
+	ctx = withReadinessRequestGate(ctx)
+	setsByLocalization := make([][]asc.Resource[asc.AppScreenshotSetAttributes], len(localizations))
+	setTasks := make([]readinessTask, 0, len(localizations))
+	for index := range localizations {
+		index := index
+		setTasks = append(setTasks, func(taskCtx context.Context) error {
+			localization := localizations[index]
+			response, err := doReadinessRequest(taskCtx, func(requestCtx context.Context) (*asc.AppScreenshotSetsResponse, error) {
+				return client.GetAppStoreVersionLocalizationScreenshotSets(requestCtx, localization.ID)
+			})
 			if err != nil {
-				return nil, fmt.Errorf("validate: failed to fetch screenshots for %s: %w", set.ID, err)
+				return fmt.Errorf("validate: failed to fetch screenshot sets for %s: %w", localization.ID, err)
 			}
-			screenshots := make([]validation.Screenshot, 0, len(screenshotsResp.Data))
-			for _, shot := range screenshotsResp.Data {
+			setsByLocalization[index] = response.Data
+			return nil
+		})
+	}
+	if err := runReadinessTasks(ctx, setTasks...); err != nil {
+		return nil, err
+	}
+
+	type screenshotSetRef struct {
+		localization asc.Resource[asc.AppStoreVersionLocalizationAttributes]
+		set          asc.Resource[asc.AppScreenshotSetAttributes]
+	}
+	setRefs := make([]screenshotSetRef, 0)
+	for localizationIndex, localizationSets := range setsByLocalization {
+		for _, set := range localizationSets {
+			setRefs = append(setRefs, screenshotSetRef{
+				localization: localizations[localizationIndex],
+				set:          set,
+			})
+		}
+	}
+
+	screenshotsBySet := make([][]validation.Screenshot, len(setRefs))
+	screenshotTasks := make([]readinessTask, 0, len(setRefs))
+	for index := range setRefs {
+		index := index
+		screenshotTasks = append(screenshotTasks, func(taskCtx context.Context) error {
+			set := setRefs[index].set
+			response, err := doReadinessRequest(taskCtx, func(requestCtx context.Context) (*asc.AppScreenshotsResponse, error) {
+				return client.GetAppScreenshots(requestCtx, set.ID)
+			})
+			if err != nil {
+				return fmt.Errorf("validate: failed to fetch screenshots for %s: %w", set.ID, err)
+			}
+
+			screenshots := make([]validation.Screenshot, 0, len(response.Data))
+			for _, shot := range response.Data {
 				width := 0
 				height := 0
 				if shot.Attributes.ImageAsset != nil {
@@ -274,15 +312,42 @@ func fetchScreenshotSets(ctx context.Context, client *asc.Client, localizations 
 					Height:   height,
 				})
 			}
-			sets = append(sets, validation.ScreenshotSet{
-				ID:             set.ID,
-				DisplayType:    set.Attributes.ScreenshotDisplayType,
-				Locale:         loc.Attributes.Locale,
-				LocalizationID: loc.ID,
-				Screenshots:    screenshots,
+			sort.SliceStable(screenshots, func(i, j int) bool {
+				if screenshots[i].FileName != screenshots[j].FileName {
+					return screenshots[i].FileName < screenshots[j].FileName
+				}
+				return screenshots[i].ID < screenshots[j].ID
 			})
-		}
+			screenshotsBySet[index] = screenshots
+			return nil
+		})
 	}
+	if err := runReadinessTasks(ctx, screenshotTasks...); err != nil {
+		return nil, err
+	}
+
+	sets := make([]validation.ScreenshotSet, 0, len(setRefs))
+	for index, ref := range setRefs {
+		sets = append(sets, validation.ScreenshotSet{
+			ID:             ref.set.ID,
+			DisplayType:    ref.set.Attributes.ScreenshotDisplayType,
+			Locale:         ref.localization.Attributes.Locale,
+			LocalizationID: ref.localization.ID,
+			Screenshots:    screenshotsBySet[index],
+		})
+	}
+	sort.SliceStable(sets, func(i, j int) bool {
+		if sets[i].Locale != sets[j].Locale {
+			return sets[i].Locale < sets[j].Locale
+		}
+		if sets[i].LocalizationID != sets[j].LocalizationID {
+			return sets[i].LocalizationID < sets[j].LocalizationID
+		}
+		if sets[i].DisplayType != sets[j].DisplayType {
+			return sets[i].DisplayType < sets[j].DisplayType
+		}
+		return sets[i].ID < sets[j].ID
+	})
 	return sets, nil
 }
 


### PR DESCRIPTION
## What changed

- Collapse app-store-version reads with `appStoreVersionLocalizations,build,appStoreReviewDetail` and `limit[appStoreVersionLocalizations]=50`.
- Collapse app-info reads with `app,ageRatingDeclaration,appInfoLocalizations,primaryCategory` and `limit[appInfoLocalizations]=50`; decode included resources by exact type and ID, then fall back only for the missing or ambiguous relationship.
- Route readiness HTTP calls through one four-request gate, create a fresh timeout context for each request, cancel sibling work on hard errors, and keep cursor pages serial.
- Run independent top-level, screenshot, subscription-group, and subscription-metadata reads concurrently; stable-sort every concurrently collected output before validation.

## Evidence

- The compound HTTP fixture makes 3 requests total (version, app infos, and price schedule) and asserts that all 7 legacy dependent endpoints receive zero requests.
- Exact query tests cover both include lists and both OpenAPI-supported related-resource limits. Missing, duplicate, and truncated included data tests assert one relationship-specific fallback rather than a full reread.
- The delayed `BuildReadinessReport` fixture completes the five independent read groups in 0.30-0.40s versus a 0.70s serial fixture, with max in-flight fixed at 4. Screenshot and subscription fan-outs also overlap under the same cap.
- `go test -race ./internal/cli/validate`, focused client and CLI tests, `make format`, `make check-docs`, `make lint`, and `ASC_BYPASS_KEYCHAIN=1 make test` pass. `/tmp/asc-validate` preserves help and usage exits; fixture-backed JSON was byte-identical across repeated runs.

## Compatibility

No flags, JSON fields, table output, exit codes, findings, or skip behavior changed. NotFound relationship reads still mean absent data, permission and retryable reads still downgrade to the existing informational skips, and ambiguous compound data takes the explicit fallback path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Readiness checks now use compound API responses to retrieve related app, version, localization, build, and review data more efficiently.
  * Added configurable localization limits when requesting included data.
  * Readiness validation now performs independent checks concurrently with bounded request limits.

* **Improvements**
  * Results for localizations, subscriptions, in-app purchases, territories, and screenshots are consistently ordered.
  * Missing or incomplete related data now triggers targeted follow-up requests.

* **Bug Fixes**
  * Improved cancellation of related requests when a readiness check encounters an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->