### PR TITLE
fix(validate): correct subscription availability remediation

### DIFF
--- a/internal/validation/subscriptions_diagnostics.go
+++ b/internal/validation/subscriptions_diagnostics.go
@@ -528,7 +528,7 @@ func buildSubscriptionAvailabilityDiagnosticRow(sub Subscription) SubscriptionDi
 	if strings.TrimSpace(sub.AvailabilityID) == "" {
 		row.Status = DiagnosticStatusNo
 		row.Evidence = "none"
-		row.Remediation = fmt.Sprintf("Configure subscription availability with `asc subscriptions availability edit --subscription-id %q --territories \"USA\"`.", fallbackString(strings.TrimSpace(sub.ID), "SUB_ID"))
+		row.Remediation = fmt.Sprintf("Configure subscription availability with `asc subscriptions pricing availability edit --subscription-id %q --territories \"USA\"`.", fallbackString(strings.TrimSpace(sub.ID), "SUB_ID"))
 		return row
 	}
 
@@ -536,7 +536,7 @@ func buildSubscriptionAvailabilityDiagnosticRow(sub Subscription) SubscriptionDi
 	if len(territories) == 0 {
 		row.Status = DiagnosticStatusNo
 		row.Evidence = fmt.Sprintf("id=%s territories=none", strings.TrimSpace(sub.AvailabilityID))
-		row.Remediation = fmt.Sprintf("Add at least one available territory with `asc subscriptions availability edit --subscription-id %q --territories \"USA\"`.", fallbackString(strings.TrimSpace(sub.ID), "SUB_ID"))
+		row.Remediation = fmt.Sprintf("Add at least one available territory with `asc subscriptions pricing availability edit --subscription-id %q --territories \"USA\"`.", fallbackString(strings.TrimSpace(sub.ID), "SUB_ID"))
 		return row
 	}
 

--- a/internal/validation/subscriptions_validate.go
+++ b/internal/validation/subscriptions_validate.go
@@ -558,7 +558,7 @@ func subscriptionMetadataDiagnostics(subs []Subscription) []CheckResult {
 				ResourceType: "subscription",
 				ResourceID:   strings.TrimSpace(sub.ID),
 				Message:      fmt.Sprintf("%s has no subscription availability configured", label),
-				Remediation:  "Configure subscription availability via `asc subscriptions availability edit`",
+				Remediation:  "Configure subscription availability via `asc subscriptions pricing availability edit`",
 			})
 		} else if len(sortedUniqueNonEmpty(sub.AvailabilityTerritories)) == 0 {
 			checks = append(checks, CheckResult{
@@ -568,7 +568,7 @@ func subscriptionMetadataDiagnostics(subs []Subscription) []CheckResult {
 				ResourceType: "subscription",
 				ResourceID:   strings.TrimSpace(sub.ID),
 				Message:      fmt.Sprintf("%s has subscription availability configured but no available territories", label),
-				Remediation:  "Enable at least one subscription availability territory via `asc subscriptions availability edit`",
+				Remediation:  "Enable at least one subscription availability territory via `asc subscriptions pricing availability edit`",
 			})
 		}
 

--- a/internal/validation/subscriptions_validate_test.go
+++ b/internal/validation/subscriptions_validate_test.go
@@ -317,6 +317,48 @@ func TestSubscriptionMetadataDiagnostics_UsesInfoChecksWhenLocalizationVerificat
 	}
 }
 
+func TestSubscriptionMetadataDiagnostics_UsesCanonicalAvailabilityCommand(t *testing.T) {
+	tests := []struct {
+		name         string
+		subscription Subscription
+		checkID      string
+		want         string
+	}{
+		{
+			name:         "missing availability record",
+			subscription: Subscription{ID: "sub-1", State: "MISSING_METADATA"},
+			checkID:      "subscriptions.diagnostics.availability_missing",
+			want:         "Configure subscription availability via `asc subscriptions pricing availability edit`",
+		},
+		{
+			name: "availability has no territories",
+			subscription: Subscription{
+				ID:             "sub-1",
+				State:          "MISSING_METADATA",
+				AvailabilityID: "availability-1",
+			},
+			checkID: "subscriptions.diagnostics.availability_territories_missing",
+			want:    "Enable at least one subscription availability territory via `asc subscriptions pricing availability edit`",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checks := subscriptionMetadataDiagnostics([]Subscription{tt.subscription})
+			for _, check := range checks {
+				if check.ID != tt.checkID {
+					continue
+				}
+				if check.Remediation != tt.want {
+					t.Fatalf("remediation = %q, want %q", check.Remediation, tt.want)
+				}
+				return
+			}
+			t.Fatalf("missing check %q in %+v", tt.checkID, checks)
+		})
+	}
+}
+
 func TestValidateIncludesPricingCoverageCheck(t *testing.T) {
 	report := Validate(Input{
 		AppID:                "app-1",

--- a/internal/validation/subscriptions_validate_test.go
+++ b/internal/validation/subscriptions_validate_test.go
@@ -359,6 +359,47 @@ func TestSubscriptionMetadataDiagnostics_UsesCanonicalAvailabilityCommand(t *tes
 	}
 }
 
+func TestValidateSubscriptionsDiagnosticsUseCanonicalAvailabilityCommand(t *testing.T) {
+	tests := []struct {
+		name         string
+		subscription Subscription
+		want         string
+	}{
+		{
+			name:         "missing availability record",
+			subscription: Subscription{ID: "sub-1", State: "MISSING_METADATA"},
+			want:         "Configure subscription availability with `asc subscriptions pricing availability edit --subscription-id \"sub-1\" --territories \"USA\"`.",
+		},
+		{
+			name: "availability has no territories",
+			subscription: Subscription{
+				ID:             "sub-1",
+				State:          "MISSING_METADATA",
+				AvailabilityID: "availability-1",
+			},
+			want: "Add at least one available territory with `asc subscriptions pricing availability edit --subscription-id \"sub-1\" --territories \"USA\"`.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := ValidateSubscriptions(SubscriptionsInput{
+				Subscriptions: []Subscription{tt.subscription},
+			}, false)
+			if len(report.Diagnostics) != 1 {
+				t.Fatalf("diagnostics = %+v, want one entry", report.Diagnostics)
+			}
+			row, ok := findSubscriptionDiagnosticRow(report.Diagnostics[0].Rows, "subscription_availability")
+			if !ok {
+				t.Fatalf("missing subscription_availability row in %+v", report.Diagnostics[0].Rows)
+			}
+			if row.Remediation != tt.want {
+				t.Fatalf("remediation = %q, want %q", row.Remediation, tt.want)
+			}
+		})
+	}
+}
+
 func TestValidateIncludesPricingCoverageCheck(t *testing.T) {
 	report := Validate(Input{
 		AppID:                "app-1",


### PR DESCRIPTION
## Summary

- point subscription availability diagnostics to the canonical `asc subscriptions pricing availability edit` command
- cover both missing availability records and records with no territories with regression tests

## Root cause and impact

`asc validate subscriptions` emitted `asc subscriptions availability edit`, but that command path is not registered and exits with usage code 2. Users following the diagnostic could not apply the suggested remediation.

The corrected path matches current built-in help and the external ASC workflow skills.

## Validation

- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- built-binary help check: canonical path exits 0; old path exits 2

Closes #1770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated subscription validation/remediation guidance to reference the correct command for configuring subscription pricing availability.
  * Adjusted remediation text for cases with missing availability and for availability configured with no available territories.

* **Tests**
  * Added/extended coverage to ensure validation diagnostics emit the canonical pricing-availability edit command for both scenarios (missing availability and no territories).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->