### PR TITLE
feat(validate): add deterministic metadata content and URL checks

### DIFF
--- a/commands/validate.mdx
+++ b/commands/validate.mdx
@@ -38,6 +38,7 @@ The validation process checks:
 * An eligible build is attached, processed, and ready for encryption review
 * Localized listing fields do not contain unmistakable template markers such as
   `Lorem ipsum`, `TODO`, `TBD`, or `FIXME`
+* App names and keyword fields satisfy deterministic content-quality checks
 
 Placeholder findings cover app names, subtitles, descriptions, keywords,
 promotional text, and What's New copy. The canonical `Lorem ipsum dolor sit
@@ -47,6 +48,30 @@ punctuation such as a colon or dash so ordinary localized wording is not
 flagged. Findings include the locale, field, matched text, resource type and ID,
 and a remediation step. They are warnings by default and become blocking with
 `--strict`.
+
+The canonical validator also reports warning-only metadata-quality findings for
+app names shorter than two Unicode characters and for empty keyword segments,
+non-canonical separators, repeated phrases, or terms already present in the
+localized app name or subtitle. These checks do not classify editorial copy,
+use user-supplied blocked terms, or expose keyword values in the canonical
+report.
+
+## Check public metadata URL destinations
+
+URL syntax is checked offline by default. The experimental `--check-urls` flag
+opts into bounded, read-only HTTP checks for populated support, marketing,
+privacy-policy, and privacy-choices URLs:
+
+```bash  theme={null}
+asc validate --app "123456789" --version-id "VERSION_ID" --check-urls
+```
+
+The checker follows at most ten HTTP(S) redirects, rejects private or otherwise
+non-public network destinations, disables proxies, deduplicates identical
+URLs, and does not read response bodies. Destination failures, changed hosts,
+and site-root results are warnings; use `--strict` when warnings must block.
+The command never prints the URL, host, IP address, response body, or transport
+details in a finding. No URL request is made unless `--check-urls` is present.
 
 ## Check Apple's web-only blockers
 
@@ -136,7 +161,13 @@ table or Markdown output. The ordinary output shape doesn't change when
 </ParamField>
 
 <ParamField path="--strict" type="boolean">
-  Treat warnings, including placeholder findings, as blocking validation issues
+  Treat warnings, including metadata-quality and placeholder findings, as
+  blocking validation issues
+</ParamField>
+
+<ParamField path="--check-urls" type="boolean">
+  Experimental. Fetch populated metadata URL destinations with bounded,
+  privacy-safe public HTTP checks. Network checks are disabled by default.
 </ParamField>
 
 <ParamField path="--deep" type="boolean">

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -194,6 +194,7 @@ asc status --app "123456789"
 
 # Canonical readiness and lower-level submission lifecycle flow
 asc validate --app "123456789" --version "1.2.3"
+asc validate --app "123456789" --version "1.2.3" --check-urls
 asc submit status --version-id "VERSION_ID"
 asc submit cancel --version-id "VERSION_ID" --confirm
 

--- a/docs/design/validate-metadata-content-and-url-checks.md
+++ b/docs/design/validate-metadata-content-and-url-checks.md
@@ -109,7 +109,18 @@ ASC_BYPASS_KEYCHAIN=1 make test
 
 Because help changes, regenerate `docs/COMMANDS.md`. If credentials are
 available, run one read-only built-binary smoke test against an existing app
-and version; do not mutate App Store Connect data and redact all identifiers.
+and version with `ASC_BYPASS_KEYCHAIN=1`; do not mutate App Store Connect data
+and redact all identifiers.
+
+## Unresolved risks
+
+1. The new offline warnings raise the warning count for existing apps. Pipelines
+   that already run `--strict` can begin to fail without a metadata change.
+2. `--check-urls` depends on destination availability, so repeated runs can
+   report different results for unchanged metadata.
+3. Live App Store Connect smoke verification remains environment-dependent and
+   is not a substitute for the deterministic API fixtures and URL-server tests
+   above.
 
 ## Alternatives considered
 

--- a/docs/design/validate-metadata-content-and-url-checks.md
+++ b/docs/design/validate-metadata-content-and-url-checks.md
@@ -1,0 +1,124 @@
+# Validate metadata content and URL destinations
+
+Status: proposed for 4.12.0
+
+## Placement and current command contract
+
+This change extends the existing top-level `asc validate` readiness report. It
+does not add a command or an App Store Connect API operation. On the 4.11.0
+baseline, `asc validate --help` accepts `--app`, `--version`, `--version-id`,
+`--platform`, `--strict`, `--deep`, `--apple-id`, `--output`, and `--pretty`.
+The new `--check-urls` flag is top-level and experimental:
+
+```text
+asc validate --app APP_ID --version-id VERSION_ID --check-urls
+```
+
+It can be combined with `--strict` and `--deep`; it is rejected on
+`validate testflight`, `validate iap`, and `validate subscriptions`.
+
+## Current source and API boundary
+
+`internal/validation/report.go` builds the canonical `validation.Report` from
+already-fetched version and app-info localizations. The report already checks
+URL syntax and narrow, high-confidence placeholder markers. The existing
+`internal/cli/metadata/url_checks.go` checker performs bounded public-URL
+requests for the offline metadata validator. This feature extracts that
+request/security implementation into a shared internal helper and maps its
+results into the canonical report. No new App Store Connect endpoint,
+OpenAPI operation, request schema, or response schema is needed.
+
+The static checks reuse the existing validation data types and keyword audit
+normalization. They do not run the user-supplied blocked-term list or expose
+keyword values in the canonical report.
+
+## Behavior and output
+
+Static checks run offline with the existing validator. They add warning-only
+findings for an app name shorter than two Unicode runes and the existing
+deterministic keyword hygiene cases: empty segments, non-canonical separators,
+locale duplicates, name overlap, and subtitle overlap. Existing length,
+required-field, and narrow placeholder checks remain authoritative and are not
+duplicated.
+
+With `--check-urls`, populated syntax-valid `supportUrl`, `marketingUrl`,
+`privacyPolicyUrl`, and `privacyChoicesUrl` fields are checked. Identical
+trimmed URLs are requested once; findings are projected back to every affected
+field and localization. Requests use a fixed timeout and bounded concurrency,
+follow at most ten HTTP(S) redirects, disable proxies, and reject private,
+loopback, link-local, reserved, or unspecified addresses at every dial and
+redirect. Response bodies are closed without being read.
+
+Findings are appended to the existing `Report.Checks` array with stable IDs and
+the existing `CheckResult` fields. No new top-level output shape is introduced.
+The command recomputes `Summary` and `Remediation` with the existing helpers.
+Output remains TTY-aware (`table` for terminals and minified `json` for pipes),
+and explicit `--output` continues to win. Finding order is deterministic.
+
+New URL IDs are:
+
+- `legal.url.request_failed`
+- `legal.url.http_status`
+- `legal.url.redirected_host`
+- `legal.url.site_root`
+- `legal.url.unsafe_target`
+
+All new findings are warnings. They do not change non-strict exit behavior;
+`--strict` makes them blocking through the existing summary and validation
+error path. Ordinary URL failures do not need a new diagnostic code. Existing
+invalid-input diagnostics and exit code 2 remain unchanged, and invalid flag
+usage must not make a request.
+
+Messages are generic. They must not contain the raw URL, query, fragment,
+hostname, IP address, response body, headers, or transport/DNS details. The
+network operation is opt-in and read-only; no App Store Connect credentials,
+cookies, or mutation requests are used.
+
+## Compatibility and lifecycle
+
+`asc metadata validate --check-urls` keeps its current behavior and output. The
+shared checker may be extracted, but the existing metadata validator remains
+backward compatible. Without `--check-urls`, `asc validate` makes no additional
+network request and keeps its existing result shape apart from the new offline
+warning checks. The flag is experimental and can be promoted through the
+repository's normal `experimental` to `stable` lifecycle after operational
+feedback.
+
+The implementation must not scrape or interpret HTML, assess page semantics,
+verify contact information, classify editorial copy, add a generic description
+minimum, or make remote failures default errors.
+
+## RED-GREEN and verification plan
+
+Start with failing unit tests for Unicode app-name length, keyword hygiene,
+privacy-safe URL finding projection, deduplication, redirect/status/unsafe
+target outcomes, and unchanged placeholder behavior. Add command-level tests
+for flag parsing and rejection, warning versus strict exits, deterministic
+JSON/table/Markdown rendering, no requests without `--check-urls`, and generic
+redaction. Use `httptest` and an injected checker; no test calls a real site.
+
+Run focused package tests after each implementation step, then:
+
+```bash
+make build
+make format
+make check-docs
+make lint
+ASC_BYPASS_KEYCHAIN=1 make test
+```
+
+Because help changes, regenerate `docs/COMMANDS.md`. If credentials are
+available, run one read-only built-binary smoke test against an existing app
+and version; do not mutate App Store Connect data and redact all identifiers.
+
+## Alternatives considered
+
+1. Add only a separate metadata subcommand. This preserves the current split
+   and leaves the canonical readiness report incomplete, so it is rejected.
+2. Run network checks by default. This would make an ordinary readiness check
+   non-deterministic, leak operator-supplied destinations to network services,
+   and introduce avoidable SSRF risk, so explicit opt-in is preferred.
+3. Scrape destination pages for contact or policy content. Page semantics are
+   provider- and localization-dependent and cannot be proven safely by a
+   bounded CLI check; status, redirect, and address evidence are the narrower
+   supported contract.

--- a/internal/asc/output_validate_deep_test.go
+++ b/internal/asc/output_validate_deep_test.go
@@ -1,6 +1,7 @@
 package asc
 
 import (
+	"encoding/json"
 	"slices"
 	"strings"
 	"testing"
@@ -44,5 +45,57 @@ func TestValidationRowsAddResolutionColumnsOnlyForDeepReports(t *testing.T) {
 	deepHeaders, deepRows := validationDeepRows(base)
 	if len(deepHeaders) == 0 || len(deepRows) == 0 {
 		t.Fatalf("deep rows were not rendered: headers=%#v rows=%#v", deepHeaders, deepRows)
+	}
+}
+
+func TestValidationMetadataFindingsRenderAcrossOutputFormats(t *testing.T) {
+	report := &validation.Report{
+		AppID:     "app-1",
+		VersionID: "version-1",
+		Checks: []validation.CheckResult{
+			{
+				ID:           "metadata.minimum.name",
+				Severity:     validation.SeverityWarning,
+				Locale:       "en-US",
+				Field:        "name",
+				ResourceType: "appInfoLocalization",
+				ResourceID:   "app-info-loc-1",
+				Message:      "app name is shorter than 2 characters",
+				Remediation:  "Use an app name with at least 2 characters",
+			},
+			{
+				ID:           "legal.url.http_status",
+				Severity:     validation.SeverityWarning,
+				Locale:       "en-US",
+				Field:        "supportUrl",
+				ResourceType: "appStoreVersionLocalization",
+				ResourceID:   "version-loc-1",
+				Message:      "declared destination returned a non-success response",
+				Remediation:  "Verify that the declared destination returns a successful HTTP response",
+			},
+		},
+	}
+
+	jsonOutput := captureStdout(t, func() error { return PrintJSON(report) })
+	var decoded validation.Report
+	if err := json.Unmarshal([]byte(jsonOutput), &decoded); err != nil {
+		t.Fatalf("JSON output error: %v; output=%q", err, jsonOutput)
+	}
+	if len(decoded.Checks) != 2 || decoded.Checks[0].ID != "metadata.minimum.name" || decoded.Checks[1].ID != "legal.url.http_status" {
+		t.Fatalf("decoded checks = %+v, want both metadata findings", decoded.Checks)
+	}
+
+	for _, renderer := range []struct {
+		name string
+		fn   func(any) error
+	}{{name: "table", fn: PrintTable}, {name: "markdown", fn: PrintMarkdown}} {
+		t.Run(renderer.name, func(t *testing.T) {
+			output := captureStdout(t, func() error { return renderer.fn(report) })
+			for _, want := range []string{"metadata.minimum.name", "legal.url.http_status", "supportUrl", "non-success response"} {
+				if !strings.Contains(output, want) {
+					t.Fatalf("%s output missing %q: %s", renderer.name, want, output)
+				}
+			}
+		})
 	}
 }

--- a/internal/cli/metadata/url_checks.go
+++ b/internal/cli/metadata/url_checks.go
@@ -102,7 +102,7 @@ func metadataURLCheckMessages(target metadataURLTarget, outcome metadataURLCheck
 	messages := make([]string, 0, 2)
 	initialHost := strings.ToLower(initialURL.Hostname())
 	finalHost := strings.ToLower(outcome.result.FinalURL.Hostname())
-	if initialHost != finalHost {
+	if outcome.result.RedirectedHost || initialHost != finalHost {
 		messages = append(messages, fmt.Sprintf("%s redirects to a different host (%s -> %s)", target.label, initialHost, finalHost))
 	}
 	if outcome.result.StatusCode < http.StatusOK || outcome.result.StatusCode >= http.StatusMultipleChoices {

--- a/internal/cli/metadata/url_checks.go
+++ b/internal/cli/metadata/url_checks.go
@@ -6,30 +6,16 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"net/netip"
 	"net/url"
 	"strings"
-	"syscall"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/metadataurl"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/validation"
 )
 
-const (
-	metadataURLCheckConcurrency = metadataurl.CheckConcurrency
-	metadataURLCheckTimeout     = metadataurl.CheckTimeout
-	metadataURLMaxRedirects     = metadataurl.MaxRedirects
-)
-
-var errUnsafeMetadataURLTarget = metadataurl.ErrUnsafeTarget
-
-var newMetadataURLChecker = func() metadataURLChecker {
+var newMetadataURLChecker = func() metadataurl.Checker {
 	return newHTTPMetadataURLChecker()
 }
-
-type metadataURLCheckResult = metadataurl.Result
-
-type metadataURLChecker = metadataurl.Checker
 
 type metadataURLTarget struct {
 	rawURL  string
@@ -42,7 +28,7 @@ type metadataURLTarget struct {
 }
 
 type metadataURLCheckOutcome struct {
-	result metadataURLCheckResult
+	result metadataurl.Result
 	err    error
 }
 
@@ -66,7 +52,7 @@ func metadataURLTargets(scope, file, locale, version string, fields []metadataUR
 	return targets
 }
 
-func metadataURLCheckIssues(ctx context.Context, checker metadataURLChecker, targets []metadataURLTarget) ([]ValidateIssue, error) {
+func metadataURLCheckIssues(ctx context.Context, checker metadataurl.Checker, targets []metadataURLTarget) ([]ValidateIssue, error) {
 	urls := make([]string, 0, len(targets))
 	for _, target := range targets {
 		urls = append(urls, target.rawURL)
@@ -98,7 +84,7 @@ func metadataURLCheckIssues(ctx context.Context, checker metadataURLChecker, tar
 func metadataURLCheckMessages(target metadataURLTarget, outcome metadataURLCheckOutcome) []string {
 	if outcome.err != nil {
 		reason := "request failed"
-		if errors.Is(outcome.err, errUnsafeMetadataURLTarget) {
+		if errors.Is(outcome.err, metadataurl.ErrUnsafeTarget) {
 			reason = "target is not a public internet address"
 		} else if errors.Is(outcome.err, context.DeadlineExceeded) || isTimeoutError(outcome.err) {
 			reason = "request timed out"
@@ -142,18 +128,6 @@ func newHTTPMetadataURLChecker() *httpMetadataURLChecker {
 	return &httpMetadataURLChecker{client: metadataurl.NewHTTPClient()}
 }
 
-func (c *httpMetadataURLChecker) Check(ctx context.Context, rawURL string) (metadataURLCheckResult, error) {
+func (c *httpMetadataURLChecker) Check(ctx context.Context, rawURL string) (metadataurl.Result, error) {
 	return metadataurl.CheckWithClient(ctx, c.client, rawURL)
-}
-
-func metadataURLRedirectPolicy(req *http.Request, via []*http.Request) error {
-	return metadataurl.RedirectPolicy(req, via)
-}
-
-func publicMetadataURLDialControl(ctx context.Context, network, address string, conn syscall.RawConn) error {
-	return metadataurl.PublicDialControl(ctx, network, address, conn)
-}
-
-func isPublicMetadataIP(address netip.Addr) bool {
-	return metadataurl.IsPublicIP(address)
 }

--- a/internal/cli/metadata/url_checks.go
+++ b/internal/cli/metadata/url_checks.go
@@ -8,37 +8,28 @@ import (
 	"net/http"
 	"net/netip"
 	"net/url"
-	"sort"
 	"strings"
-	"sync"
 	"syscall"
-	"time"
 
-	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
-	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/metadataurl"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/validation"
 )
 
 const (
-	metadataURLCheckConcurrency = 4
-	metadataURLCheckTimeout     = 10 * time.Second
-	metadataURLMaxRedirects     = 10
+	metadataURLCheckConcurrency = metadataurl.CheckConcurrency
+	metadataURLCheckTimeout     = metadataurl.CheckTimeout
+	metadataURLMaxRedirects     = metadataurl.MaxRedirects
 )
 
-var errUnsafeMetadataURLTarget = errors.New("metadata URL target is not a public internet address")
+var errUnsafeMetadataURLTarget = metadataurl.ErrUnsafeTarget
 
 var newMetadataURLChecker = func() metadataURLChecker {
 	return newHTTPMetadataURLChecker()
 }
 
-type metadataURLCheckResult struct {
-	FinalURL   *url.URL
-	StatusCode int
-}
+type metadataURLCheckResult = metadataurl.Result
 
-type metadataURLChecker interface {
-	Check(context.Context, string) (metadataURLCheckResult, error)
-}
+type metadataURLChecker = metadataurl.Checker
 
 type metadataURLTarget struct {
 	rawURL  string
@@ -76,45 +67,19 @@ func metadataURLTargets(scope, file, locale, version string, fields []metadataUR
 }
 
 func metadataURLCheckIssues(ctx context.Context, checker metadataURLChecker, targets []metadataURLTarget) ([]ValidateIssue, error) {
-	uniqueURLs := make(map[string]struct{}, len(targets))
+	urls := make([]string, 0, len(targets))
 	for _, target := range targets {
-		uniqueURLs[target.rawURL] = struct{}{}
+		urls = append(urls, target.rawURL)
 	}
-	urls := make([]string, 0, len(uniqueURLs))
-	for rawURL := range uniqueURLs {
-		urls = append(urls, rawURL)
-	}
-	sort.Strings(urls)
-
-	outcomes := make(map[string]metadataURLCheckOutcome, len(urls))
-	var outcomesMu sync.Mutex
-	jobs := make(chan string)
-	var workers sync.WaitGroup
-	workerCount := min(metadataURLCheckConcurrency, len(urls))
-	workers.Add(workerCount)
-	for range workerCount {
-		go func() {
-			defer workers.Done()
-			for rawURL := range jobs {
-				result, err := checker.Check(ctx, rawURL)
-				outcomesMu.Lock()
-				outcomes[rawURL] = metadataURLCheckOutcome{result: result, err: err}
-				outcomesMu.Unlock()
-			}
-		}()
-	}
-	for _, rawURL := range urls {
-		jobs <- rawURL
-	}
-	close(jobs)
-	workers.Wait()
-	if err := ctx.Err(); err != nil {
+	outcomes, err := metadataurl.CheckAll(ctx, checker, urls)
+	if err != nil {
 		return nil, err
 	}
 
 	issues := make([]ValidateIssue, 0, len(targets))
 	for _, target := range targets {
-		outcome := outcomes[target.rawURL]
+		checked := outcomes[target.rawURL]
+		outcome := metadataURLCheckOutcome{result: checked.Result, err: checked.Err}
 		for _, message := range metadataURLCheckMessages(target, outcome) {
 			issues = append(issues, ValidateIssue{
 				Scope:    target.scope,
@@ -174,134 +139,21 @@ type httpMetadataURLChecker struct {
 }
 
 func newHTTPMetadataURLChecker() *httpMetadataURLChecker {
-	timeout := asc.ResolveTimeoutWithDefault(metadataURLCheckTimeout)
-	dialer := &net.Dialer{
-		Timeout:        timeout,
-		KeepAlive:      30 * time.Second,
-		ControlContext: publicMetadataURLDialControl,
-	}
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-	transport.Proxy = nil
-	transport.DialContext = dialer.DialContext
-	transport.DisableKeepAlives = true
-	transport.MaxConnsPerHost = metadataURLCheckConcurrency
-	transport.ResponseHeaderTimeout = timeout
-	transport.TLSHandshakeTimeout = timeout
-	transport.MaxResponseHeaderBytes = 1 << 20
-
-	return &httpMetadataURLChecker{client: &http.Client{
-		Transport:     transport,
-		Timeout:       timeout,
-		CheckRedirect: metadataURLRedirectPolicy,
-	}}
+	return &httpMetadataURLChecker{client: metadataurl.NewHTTPClient()}
 }
 
 func (c *httpMetadataURLChecker) Check(ctx context.Context, rawURL string) (metadataURLCheckResult, error) {
-	requestCtx, cancel := shared.ContextWithTimeout(ctx)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, rawURL, nil)
-	if err != nil {
-		return metadataURLCheckResult{}, err
-	}
-	req.Header.Set("User-Agent", "asc metadata validate")
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return metadataURLCheckResult{}, err
-	}
-	defer resp.Body.Close()
-	return metadataURLCheckResult{FinalURL: resp.Request.URL, StatusCode: resp.StatusCode}, nil
+	return metadataurl.CheckWithClient(ctx, c.client, rawURL)
 }
 
 func metadataURLRedirectPolicy(req *http.Request, via []*http.Request) error {
-	if len(via) >= metadataURLMaxRedirects {
-		return fmt.Errorf("metadata URL exceeded %d redirects", metadataURLMaxRedirects)
-	}
-	if !isHTTPMetadataURL(req.URL) {
-		return errUnsafeMetadataURLTarget
-	}
-	if ip, err := netip.ParseAddr(req.URL.Hostname()); err == nil && !isPublicMetadataIP(ip) {
-		return errUnsafeMetadataURLTarget
-	}
-	return nil
+	return metadataurl.RedirectPolicy(req, via)
 }
 
-func isHTTPMetadataURL(parsed *url.URL) bool {
-	if parsed == nil || parsed.Hostname() == "" {
-		return false
-	}
-	return parsed.Scheme == "http" || parsed.Scheme == "https"
-}
-
-func publicMetadataURLDialControl(_ context.Context, _, address string, _ syscall.RawConn) error {
-	host, _, err := net.SplitHostPort(address)
-	if err != nil {
-		return errUnsafeMetadataURLTarget
-	}
-	parsed, err := netip.ParseAddr(host)
-	if err != nil || !isPublicMetadataIP(parsed) {
-		return errUnsafeMetadataURLTarget
-	}
-	return nil
-}
-
-// These IANA special-purpose ranges can still satisfy netip.Addr.IsGlobalUnicast.
-// Translation prefixes stay blocked because they can encode non-public IPv4 targets.
-var reservedMetadataIPPrefixes = []netip.Prefix{
-	netip.MustParsePrefix("0.0.0.0/8"),
-	netip.MustParsePrefix("100.64.0.0/10"),
-	netip.MustParsePrefix("192.0.0.0/24"),
-	netip.MustParsePrefix("192.0.2.0/24"),
-	netip.MustParsePrefix("192.88.99.0/24"),
-	netip.MustParsePrefix("198.18.0.0/15"),
-	netip.MustParsePrefix("198.51.100.0/24"),
-	netip.MustParsePrefix("203.0.113.0/24"),
-	netip.MustParsePrefix("240.0.0.0/4"),
-	netip.MustParsePrefix("::ffff:0:0:0/96"),
-	netip.MustParsePrefix("64:ff9b::/96"),
-	netip.MustParsePrefix("64:ff9b:1::/48"),
-	netip.MustParsePrefix("100::/64"),
-	netip.MustParsePrefix("100:0:0:1::/64"),
-	netip.MustParsePrefix("2001::/23"),
-	netip.MustParsePrefix("2001::/32"),
-	netip.MustParsePrefix("2001:2::/48"),
-	netip.MustParsePrefix("2001:10::/28"),
-	netip.MustParsePrefix("2001:db8::/32"),
-	netip.MustParsePrefix("2002::/16"),
-	netip.MustParsePrefix("3ffe::/16"),
-	netip.MustParsePrefix("3fff::/20"),
-	netip.MustParsePrefix("5f00::/8"),
-	netip.MustParsePrefix("fec0::/10"),
-}
-
-// Check these IANA globally reachable allocations before their broader parent ranges.
-var globallyReachableMetadataIPExceptions = []netip.Prefix{
-	netip.MustParsePrefix("192.0.0.9/32"),
-	netip.MustParsePrefix("192.0.0.10/32"),
-	netip.MustParsePrefix("2001:1::1/128"),
-	netip.MustParsePrefix("2001:1::2/128"),
-	netip.MustParsePrefix("2001:1::3/128"),
-	netip.MustParsePrefix("2001:3::/32"),
-	netip.MustParsePrefix("2001:4:112::/48"),
-	netip.MustParsePrefix("2001:20::/28"),
-	netip.MustParsePrefix("2001:30::/28"),
+func publicMetadataURLDialControl(ctx context.Context, network, address string, conn syscall.RawConn) error {
+	return metadataurl.PublicDialControl(ctx, network, address, conn)
 }
 
 func isPublicMetadataIP(address netip.Addr) bool {
-	address = address.Unmap()
-	if !address.IsValid() || !address.IsGlobalUnicast() || address.IsPrivate() || address.IsLoopback() || address.IsLinkLocalUnicast() {
-		return false
-	}
-	for _, prefix := range globallyReachableMetadataIPExceptions {
-		if prefix.Contains(address) {
-			return true
-		}
-	}
-	for _, prefix := range reservedMetadataIPPrefixes {
-		if prefix.Contains(address) {
-			return false
-		}
-	}
-	return true
+	return metadataurl.IsPublicIP(address)
 }

--- a/internal/cli/metadata/url_checks.go
+++ b/internal/cli/metadata/url_checks.go
@@ -103,7 +103,11 @@ func metadataURLCheckMessages(target metadataURLTarget, outcome metadataURLCheck
 	initialHost := strings.ToLower(initialURL.Hostname())
 	finalHost := strings.ToLower(outcome.result.FinalURL.Hostname())
 	if outcome.result.RedirectedHost || initialHost != finalHost {
-		messages = append(messages, fmt.Sprintf("%s redirects to a different host (%s -> %s)", target.label, initialHost, finalHost))
+		if outcome.result.RedirectedHost && initialHost != "" && initialHost == finalHost {
+			messages = append(messages, fmt.Sprintf("%s redirects through a different host before returning to %s", target.label, initialHost))
+		} else {
+			messages = append(messages, fmt.Sprintf("%s redirects to a different host (%s -> %s)", target.label, initialHost, finalHost))
+		}
 	}
 	if outcome.result.StatusCode < http.StatusOK || outcome.result.StatusCode >= http.StatusMultipleChoices {
 		return append(messages, fmt.Sprintf("%s returned HTTP %d", target.label, outcome.result.StatusCode))

--- a/internal/cli/metadata/validate.go
+++ b/internal/cli/metadata/validate.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/metadataurl"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/validation"
 )
 
@@ -121,7 +122,7 @@ func validateDir(dir string) (ValidateResult, error) {
 type validateDirOptions struct {
 	checkURLs       bool
 	subscriptionApp bool
-	urlChecker      metadataURLChecker
+	urlChecker      metadataurl.Checker
 }
 
 func validateDirWithOptions(ctx context.Context, dir string, options validateDirOptions) (ValidateResult, error) {

--- a/internal/cli/metadata/validate_url_checks_test.go
+++ b/internal/cli/metadata/validate_url_checks_test.go
@@ -98,6 +98,27 @@ func TestValidateDirCheckURLsWarnsForRedirectedHostAndSiteRoot(t *testing.T) {
 	}
 }
 
+func TestMetadataURLCheckMessagesDescribesReturningHostWithoutAtoA(t *testing.T) {
+	message := metadataURLCheckMessages(metadataURLTarget{
+		rawURL: "https://support.example/help",
+		label:  "support URL",
+	}, metadataURLCheckOutcome{result: metadataurl.Result{
+		FinalURL:       mustParseMetadataURL(t, "https://support.example/final"),
+		StatusCode:     http.StatusOK,
+		RedirectedHost: true,
+	}})
+	if len(message) != 1 {
+		t.Fatalf("messages = %v, want one redirect warning", message)
+	}
+	want := "support URL redirects through a different host before returning to support.example"
+	if message[0] != want {
+		t.Fatalf("message = %q, want %q", message[0], want)
+	}
+	if strings.Contains(message[0], "support.example -> support.example") {
+		t.Fatalf("message contains contradictory A -> A transition: %q", message[0])
+	}
+}
+
 func TestValidateDirCheckURLsWarnsForStatusAndRequestFailure(t *testing.T) {
 	dir := writeMetadataURLFixtures(t, map[string]string{
 		filepath.Join(appInfoDirName, "en-US.json"):          `{"name":"Example App","privacyPolicyUrl":"https://app.example.com/privacy"}`,

--- a/internal/cli/metadata/validate_url_checks_test.go
+++ b/internal/cli/metadata/validate_url_checks_test.go
@@ -13,16 +13,18 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/metadataurl"
 )
 
 type fakeMetadataURLChecker struct {
 	mu      sync.Mutex
-	results map[string]metadataURLCheckResult
+	results map[string]metadataurl.Result
 	errors  map[string]error
 	calls   map[string]int
 }
 
-func (f *fakeMetadataURLChecker) Check(_ context.Context, rawURL string) (metadataURLCheckResult, error) {
+func (f *fakeMetadataURLChecker) Check(_ context.Context, rawURL string) (metadataurl.Result, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
@@ -31,7 +33,7 @@ func (f *fakeMetadataURLChecker) Check(_ context.Context, rawURL string) (metada
 	}
 	f.calls[rawURL]++
 	if err := f.errors[rawURL]; err != nil {
-		return metadataURLCheckResult{}, err
+		return metadataurl.Result{}, err
 	}
 	return f.results[rawURL], nil
 }
@@ -59,7 +61,7 @@ func TestValidateDirCheckURLsWarnsForRedirectedHostAndSiteRoot(t *testing.T) {
 		filepath.Join(appInfoDirName, "en-US.json"):          `{"name":"Example App","privacyPolicyUrl":"https://app.example.com/privacy"}`,
 		filepath.Join(versionDirName, "1.2.3", "en-US.json"): `{"description":"English app description","supportUrl":"https://support.example.com/help"}`,
 	})
-	checker := &fakeMetadataURLChecker{results: map[string]metadataURLCheckResult{
+	checker := &fakeMetadataURLChecker{results: map[string]metadataurl.Result{
 		"https://app.example.com/privacy": {
 			FinalURL:   mustParseMetadataURL(t, "https://app.example.com/"),
 			StatusCode: 200,
@@ -102,7 +104,7 @@ func TestValidateDirCheckURLsWarnsForStatusAndRequestFailure(t *testing.T) {
 		filepath.Join(versionDirName, "1.2.3", "en-US.json"): `{"description":"English app description","supportUrl":"https://support.example.com/help"}`,
 	})
 	checker := &fakeMetadataURLChecker{
-		results: map[string]metadataURLCheckResult{
+		results: map[string]metadataurl.Result{
 			"https://support.example.com/help": {
 				FinalURL:   mustParseMetadataURL(t, "https://parked.example.com/missing"),
 				StatusCode: 404,
@@ -145,7 +147,7 @@ func TestValidateDirCheckURLsCachesDuplicateURLs(t *testing.T) {
 		filepath.Join(versionDirName, "1.2.3", "en-US.json"): `{"description":"English app description","supportUrl":"` + supportURL + `"}`,
 		filepath.Join(versionDirName, "1.2.3", "fr-FR.json"): `{"description":"Description francaise complete","supportUrl":"` + supportURL + `"}`,
 	})
-	checker := &fakeMetadataURLChecker{results: map[string]metadataURLCheckResult{
+	checker := &fakeMetadataURLChecker{results: map[string]metadataurl.Result{
 		supportURL: {
 			FinalURL:   mustParseMetadataURL(t, "https://support.example.com/"),
 			StatusCode: 200,
@@ -172,7 +174,7 @@ func TestValidateDirRemainsOfflineWithoutCheckURLs(t *testing.T) {
 	dir := writeMetadataURLFixtures(t, map[string]string{
 		filepath.Join(versionDirName, "1.2.3", "en-US.json"): `{"description":"English app description","supportUrl":"` + supportURL + `"}`,
 	})
-	checker := &fakeMetadataURLChecker{results: map[string]metadataURLCheckResult{
+	checker := &fakeMetadataURLChecker{results: map[string]metadataurl.Result{
 		supportURL: {
 			FinalURL:   mustParseMetadataURL(t, "https://support.example.com/"),
 			StatusCode: 200,
@@ -218,14 +220,14 @@ func TestMetadataValidateCommandPrintsWarningsAndExitsSuccessfully(t *testing.T)
 	dir := writeMetadataURLFixtures(t, map[string]string{
 		filepath.Join(versionDirName, "1.2.3", "en-US.json"): `{"description":"English app description","supportUrl":"` + supportURL + `"}`,
 	})
-	checker := &fakeMetadataURLChecker{results: map[string]metadataURLCheckResult{
+	checker := &fakeMetadataURLChecker{results: map[string]metadataurl.Result{
 		supportURL: {
 			FinalURL:   mustParseMetadataURL(t, "https://support.example.com/"),
 			StatusCode: 200,
 		},
 	}}
 	originalFactory := newMetadataURLChecker
-	newMetadataURLChecker = func() metadataURLChecker { return checker }
+	newMetadataURLChecker = func() metadataurl.Checker { return checker }
 	t.Cleanup(func() { newMetadataURLChecker = originalFactory })
 
 	var runErr error
@@ -281,7 +283,7 @@ func TestMetadataURLCheckMessagesAllowsQueryAndFragmentRoutes(t *testing.T) {
 		"https://example.com/#/support",
 	} {
 		t.Run(finalURL, func(t *testing.T) {
-			messages := metadataURLCheckMessages(target, metadataURLCheckOutcome{result: metadataURLCheckResult{
+			messages := metadataURLCheckMessages(target, metadataURLCheckOutcome{result: metadataurl.Result{
 				FinalURL:   mustParseMetadataURL(t, finalURL),
 				StatusCode: http.StatusOK,
 			}})
@@ -297,7 +299,7 @@ func TestMetadataURLRedirectPolicy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRequest() error: %v", err)
 	}
-	if err := metadataURLRedirectPolicy(publicRequest, nil); err != nil {
+	if err := metadataurl.RedirectPolicy(publicRequest, nil); err != nil {
 		t.Fatalf("expected public HTTP redirect target to pass, got %v", err)
 	}
 
@@ -305,21 +307,21 @@ func TestMetadataURLRedirectPolicy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRequest() error: %v", err)
 	}
-	if err := metadataURLRedirectPolicy(privateRequest, nil); !errors.Is(err, errUnsafeMetadataURLTarget) {
+	if err := metadataurl.RedirectPolicy(privateRequest, nil); !errors.Is(err, metadataurl.ErrUnsafeTarget) {
 		t.Fatalf("expected private redirect target rejection, got %v", err)
 	}
 
-	via := make([]*http.Request, metadataURLMaxRedirects)
-	if err := metadataURLRedirectPolicy(publicRequest, via); err == nil || !strings.Contains(err.Error(), "exceeded") {
+	via := make([]*http.Request, metadataurl.MaxRedirects)
+	if err := metadataurl.RedirectPolicy(publicRequest, via); err == nil || !strings.Contains(err.Error(), "exceeded") {
 		t.Fatalf("expected redirect limit error, got %v", err)
 	}
 }
 
 func TestPublicMetadataURLDialControlRejectsPrivateAddresses(t *testing.T) {
-	if err := publicMetadataURLDialControl(context.Background(), "tcp4", "127.0.0.1:443", nil); !errors.Is(err, errUnsafeMetadataURLTarget) {
+	if err := metadataurl.PublicDialControl(context.Background(), "tcp4", "127.0.0.1:443", nil); !errors.Is(err, metadataurl.ErrUnsafeTarget) {
 		t.Fatalf("expected private address rejection, got %v", err)
 	}
-	if err := publicMetadataURLDialControl(context.Background(), "tcp4", "8.8.8.8:443", nil); err != nil {
+	if err := metadataurl.PublicDialControl(context.Background(), "tcp4", "8.8.8.8:443", nil); err != nil {
 		t.Fatalf("expected public address to pass, got %v", err)
 	}
 }
@@ -367,8 +369,8 @@ func TestIsPublicMetadataIP(t *testing.T) {
 	for rawIP, want := range tests {
 		t.Run(rawIP, func(t *testing.T) {
 			address := netip.MustParseAddr(rawIP)
-			if got := isPublicMetadataIP(address); got != want {
-				t.Fatalf("isPublicMetadataIP(%s) = %t, want %t", rawIP, got, want)
+			if got := metadataurl.IsPublicIP(address); got != want {
+				t.Fatalf("metadataurl.IsPublicIP(%s) = %t, want %t", rawIP, got, want)
 			}
 		})
 	}

--- a/internal/cli/validate/metadata_urls.go
+++ b/internal/cli/validate/metadata_urls.go
@@ -106,7 +106,7 @@ func validateURLCheckResults(target validateURLTarget, outcome metadataurl.Outco
 	checks := make([]validation.CheckResult, 0, 2)
 	initialHost := strings.ToLower(initialURL.Hostname())
 	finalHost := strings.ToLower(outcome.Result.FinalURL.Hostname())
-	if initialHost != "" && finalHost != "" && initialHost != finalHost {
+	if outcome.Result.RedirectedHost || (initialHost != "" && finalHost != "" && initialHost != finalHost) {
 		checks = append(checks, newValidateURLCheck(
 			"legal.url.redirected_host",
 			target,

--- a/internal/cli/validate/metadata_urls.go
+++ b/internal/cli/validate/metadata_urls.go
@@ -1,0 +1,186 @@
+package validate
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/metadataurl"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/validation"
+)
+
+type validateURLTarget struct {
+	RawURL       string
+	Locale       string
+	Field        string
+	ResourceType string
+	ResourceID   string
+}
+
+var newValidateURLChecker = metadataurl.NewChecker
+
+func validateURLTargets(versionLocs []validation.VersionLocalization, appInfoLocs []validation.AppInfoLocalization) []validateURLTarget {
+	targets := make([]validateURLTarget, 0, len(versionLocs)*2+len(appInfoLocs)*2)
+	for _, loc := range versionLocs {
+		targets = appendValidateURLTarget(targets, loc.SupportURL, loc.Locale, "supportUrl", "appStoreVersionLocalization", loc.ID)
+		targets = appendValidateURLTarget(targets, loc.MarketingURL, loc.Locale, "marketingUrl", "appStoreVersionLocalization", loc.ID)
+	}
+	for _, loc := range appInfoLocs {
+		targets = appendValidateURLTarget(targets, loc.PrivacyPolicyURL, loc.Locale, "privacyPolicyUrl", "appInfoLocalization", loc.ID)
+		targets = appendValidateURLTarget(targets, loc.PrivacyChoicesURL, loc.Locale, "privacyChoicesUrl", "appInfoLocalization", loc.ID)
+	}
+	sortValidateURLTargets(targets)
+	return targets
+}
+
+func appendValidateURLTarget(targets []validateURLTarget, rawURL, locale, field, resourceType, resourceID string) []validateURLTarget {
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" || !validation.IsValidHTTPURL(rawURL) {
+		return targets
+	}
+	return append(targets, validateURLTarget{
+		RawURL:       rawURL,
+		Locale:       locale,
+		Field:        field,
+		ResourceType: resourceType,
+		ResourceID:   resourceID,
+	})
+}
+
+func checkValidateURLs(ctx context.Context, checker metadataurl.Checker, targets []validateURLTarget) ([]validation.CheckResult, error) {
+	urls := make([]string, 0, len(targets))
+	for _, target := range targets {
+		urls = append(urls, target.RawURL)
+	}
+	outcomes, err := metadataurl.CheckAll(ctx, checker, urls)
+	if err != nil {
+		return nil, err
+	}
+
+	checks := make([]validation.CheckResult, 0, len(targets))
+	for _, target := range targets {
+		outcome, ok := outcomes[target.RawURL]
+		if !ok {
+			outcome.Err = errors.New("metadata URL check did not produce an outcome")
+		}
+		checks = append(checks, validateURLCheckResults(target, outcome)...)
+	}
+	sortValidationURLChecks(checks)
+	return checks, nil
+}
+
+func validateURLCheckResults(target validateURLTarget, outcome metadataurl.Outcome) []validation.CheckResult {
+	if outcome.Err != nil {
+		id := "legal.url.request_failed"
+		message := "declared destination could not be checked"
+		remediation := "Verify that the declared destination is reachable from a public network"
+		if errors.Is(outcome.Err, metadataurl.ErrUnsafeTarget) {
+			id = "legal.url.unsafe_target"
+			message = "declared destination could not be reached safely"
+			remediation = "Use an HTTP/HTTPS destination on the public internet"
+		}
+		return []validation.CheckResult{newValidateURLCheck(id, target, message, remediation)}
+	}
+	if outcome.Result.FinalURL == nil {
+		return []validation.CheckResult{newValidateURLCheck(
+			"legal.url.request_failed",
+			target,
+			"declared destination could not be checked",
+			"Verify that the declared destination is reachable from a public network",
+		)}
+	}
+
+	initialURL, err := url.Parse(target.RawURL)
+	if err != nil {
+		return []validation.CheckResult{newValidateURLCheck(
+			"legal.url.request_failed",
+			target,
+			"declared destination could not be checked",
+			"Provide a valid HTTP/HTTPS destination",
+		)}
+	}
+
+	checks := make([]validation.CheckResult, 0, 2)
+	initialHost := strings.ToLower(initialURL.Hostname())
+	finalHost := strings.ToLower(outcome.Result.FinalURL.Hostname())
+	if initialHost != "" && finalHost != "" && initialHost != finalHost {
+		checks = append(checks, newValidateURLCheck(
+			"legal.url.redirected_host",
+			target,
+			"declared destination redirects to a different host",
+			"Confirm that the redirect destination is intentional and stable",
+		))
+	}
+	if outcome.Result.StatusCode < http.StatusOK || outcome.Result.StatusCode >= http.StatusMultipleChoices {
+		checks = append(checks, newValidateURLCheck(
+			"legal.url.http_status",
+			target,
+			"declared destination returned a non-success response",
+			"Verify that the declared destination returns a successful HTTP response",
+		))
+		return checks
+	}
+	finalPath := outcome.Result.FinalURL.EscapedPath()
+	if (finalPath == "" || finalPath == "/") && outcome.Result.FinalURL.RawQuery == "" && outcome.Result.FinalURL.Fragment == "" {
+		checks = append(checks, newValidateURLCheck(
+			"legal.url.site_root",
+			target,
+			"declared destination resolves to a site root",
+			"Use a dedicated support, marketing, privacy-policy, or privacy-choices page",
+		))
+	}
+	return checks
+}
+
+func newValidateURLCheck(id string, target validateURLTarget, message, remediation string) validation.CheckResult {
+	return validation.CheckResult{
+		ID:           id,
+		Severity:     validation.SeverityWarning,
+		Locale:       target.Locale,
+		Field:        target.Field,
+		ResourceType: target.ResourceType,
+		ResourceID:   target.ResourceID,
+		Message:      message,
+		Remediation:  remediation,
+	}
+}
+
+func sortValidateURLTargets(targets []validateURLTarget) {
+	sort.SliceStable(targets, func(i, j int) bool {
+		left := targets[i]
+		right := targets[j]
+		if left.ResourceType != right.ResourceType {
+			return left.ResourceType < right.ResourceType
+		}
+		if left.ResourceID != right.ResourceID {
+			return left.ResourceID < right.ResourceID
+		}
+		if left.Locale != right.Locale {
+			return left.Locale < right.Locale
+		}
+		return left.Field < right.Field
+	})
+}
+
+func sortValidationURLChecks(checks []validation.CheckResult) {
+	sort.SliceStable(checks, func(i, j int) bool {
+		left := checks[i]
+		right := checks[j]
+		if left.ResourceType != right.ResourceType {
+			return left.ResourceType < right.ResourceType
+		}
+		if left.ResourceID != right.ResourceID {
+			return left.ResourceID < right.ResourceID
+		}
+		if left.Locale != right.Locale {
+			return left.Locale < right.Locale
+		}
+		if left.Field != right.Field {
+			return left.Field < right.Field
+		}
+		return left.ID < right.ID
+	})
+}

--- a/internal/cli/validate/metadata_urls_test.go
+++ b/internal/cli/validate/metadata_urls_test.go
@@ -1,0 +1,304 @@
+package validate
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/metadataurl"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/validation"
+)
+
+type fakeValidateURLChecker struct {
+	mu      sync.Mutex
+	results map[string]metadataurl.Result
+	errors  map[string]error
+	calls   map[string]int
+}
+
+func (f *fakeValidateURLChecker) Check(_ context.Context, rawURL string) (metadataurl.Result, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.calls == nil {
+		f.calls = make(map[string]int)
+	}
+	f.calls[rawURL]++
+	if err := f.errors[rawURL]; err != nil {
+		return metadataurl.Result{}, err
+	}
+	return f.results[rawURL], nil
+}
+
+func TestValidateURLChecksDeduplicateAndRedactFindings(t *testing.T) {
+	const duplicatedURL = "https://public.example/help"
+	const failedURL = "https://private.example/policy?token=secret"
+	checker := &fakeValidateURLChecker{
+		results: map[string]metadataurl.Result{
+			duplicatedURL: {
+				FinalURL:   mustParseValidateURL(t, "https://public.example/"),
+				StatusCode: 200,
+			},
+		},
+		errors: map[string]error{
+			failedURL: errors.New("request failed for https://private.example/policy?token=secret"),
+		},
+	}
+	targets := []validateURLTarget{
+		{RawURL: duplicatedURL, Locale: "en-US", Field: "supportUrl", ResourceType: "appStoreVersionLocalization", ResourceID: "version-loc-1"},
+		{RawURL: duplicatedURL, Locale: "fr-FR", Field: "supportUrl", ResourceType: "appStoreVersionLocalization", ResourceID: "version-loc-2"},
+		{RawURL: failedURL, Locale: "en-US", Field: "privacyPolicyUrl", ResourceType: "appInfoLocalization", ResourceID: "app-info-loc-1"},
+	}
+
+	checks, err := checkValidateURLs(context.Background(), checker, targets)
+	if err != nil {
+		t.Fatalf("checkValidateURLs() error: %v", err)
+	}
+	if checker.calls[duplicatedURL] != 1 {
+		t.Fatalf("duplicate URL calls = %d, want 1", checker.calls[duplicatedURL])
+	}
+	if len(checks) != 3 {
+		t.Fatalf("checks = %+v, want root findings for both fields and one request failure", checks)
+	}
+	for _, check := range checks {
+		if check.Severity != validation.SeverityWarning {
+			t.Fatalf("check = %+v, want warning", check)
+		}
+		if strings.Contains(check.Message, "public.example") || strings.Contains(check.Message, "private.example") || strings.Contains(check.Message, "secret") {
+			t.Fatalf("check leaked URL details: %+v", check)
+		}
+	}
+}
+
+func TestValidateURLChecksReportsRedirectAndStatusByStableIDs(t *testing.T) {
+	const rawURL = "https://support.example/help"
+	checker := &fakeValidateURLChecker{results: map[string]metadataurl.Result{
+		rawURL: {
+			FinalURL:   mustParseValidateURL(t, "https://landing.example/missing"),
+			StatusCode: 404,
+		},
+	}}
+	checks, err := checkValidateURLs(context.Background(), checker, []validateURLTarget{{
+		RawURL:       rawURL,
+		Locale:       "en-US",
+		Field:        "supportUrl",
+		ResourceType: "appStoreVersionLocalization",
+		ResourceID:   "version-loc-1",
+	}})
+	if err != nil {
+		t.Fatalf("checkValidateURLs() error: %v", err)
+	}
+	wantIDs := []string{"legal.url.http_status", "legal.url.redirected_host"}
+	gotIDs := make([]string, 0, len(checks))
+	for _, check := range checks {
+		gotIDs = append(gotIDs, check.ID)
+	}
+	if !equalValidateStrings(gotIDs, wantIDs) {
+		t.Fatalf("check IDs = %v, want %v", gotIDs, wantIDs)
+	}
+	for _, check := range checks {
+		if strings.Contains(check.Message, "example") || strings.Contains(check.Remediation, "example") {
+			t.Fatalf("check leaked destination details: %+v", check)
+		}
+	}
+}
+
+func TestValidateURLChecksMapsUnsafeAndTimeoutErrorsWithoutDetails(t *testing.T) {
+	checker := &fakeValidateURLChecker{
+		errors: map[string]error{
+			"https://private.example/policy": metadataurl.ErrUnsafeTarget,
+			"https://slow.example/policy":    errors.Join(context.DeadlineExceeded, errors.New("response body contained secret")),
+		},
+	}
+	targets := []validateURLTarget{
+		{RawURL: "https://private.example/policy", Locale: "en-US", Field: "privacyPolicyUrl", ResourceType: "appInfoLocalization", ResourceID: "app-info-loc-1"},
+		{RawURL: "https://slow.example/policy", Locale: "en-US", Field: "privacyChoicesUrl", ResourceType: "appInfoLocalization", ResourceID: "app-info-loc-1"},
+	}
+
+	checks, err := checkValidateURLs(context.Background(), checker, targets)
+	if err != nil {
+		t.Fatalf("checkValidateURLs() error: %v", err)
+	}
+	gotIDs := make(map[string]bool, len(checks))
+	for _, check := range checks {
+		gotIDs[check.ID] = true
+	}
+	if len(checks) != 2 || !gotIDs["legal.url.unsafe_target"] || !gotIDs["legal.url.request_failed"] {
+		t.Fatalf("checks = %+v, want unsafe and request_failed findings", checks)
+	}
+	for _, check := range checks {
+		if strings.Contains(check.Message, "private.example") || strings.Contains(check.Message, "slow.example") || strings.Contains(check.Message, "secret") || strings.Contains(check.Remediation, "example") {
+			t.Fatalf("check leaked URL or transport details: %+v", check)
+		}
+	}
+}
+
+func TestValidateURLTargetsIncludesAllSupportedFields(t *testing.T) {
+	targets := validateURLTargets(
+		[]validation.VersionLocalization{{
+			ID:           "version-loc-1",
+			Locale:       "en-US",
+			SupportURL:   "https://example.com/support",
+			MarketingURL: "https://example.com/marketing",
+		}},
+		[]validation.AppInfoLocalization{{
+			ID:                "app-info-loc-1",
+			Locale:            "en-US",
+			PrivacyPolicyURL:  "https://example.com/privacy",
+			PrivacyChoicesURL: "https://example.com/choices",
+		}},
+	)
+	if len(targets) != 4 {
+		t.Fatalf("targets = %+v, want all four URL fields", targets)
+	}
+	for _, target := range targets {
+		if target.RawURL == "" || target.ResourceID == "" || target.Locale == "" {
+			t.Fatalf("target = %+v, want complete target context", target)
+		}
+	}
+
+	targets = validateURLTargets(
+		[]validation.VersionLocalization{{
+			Locale:       "en-US",
+			SupportURL:   "not a URL",
+			MarketingURL: "ftp://example.com/marketing",
+		}},
+		nil,
+	)
+	if len(targets) != 0 {
+		t.Fatalf("targets = %+v, want syntax-invalid URLs skipped", targets)
+	}
+}
+
+func TestRunValidatePassesCheckURLsToReadinessAndPrintsReport(t *testing.T) {
+	previous := buildReadinessReportFn
+	var received ReadinessOptions
+	buildReadinessReportFn = func(_ context.Context, opts ReadinessOptions) (validation.Report, error) {
+		received = opts
+		return validation.Report{AppID: opts.AppID, VersionID: opts.VersionID, Checks: []validation.CheckResult{}}, nil
+	}
+	t.Cleanup(func() { buildReadinessReportFn = previous })
+
+	var runErr error
+	stdout := captureValidateStdout(t, func() {
+		runErr = runValidate(context.Background(), validateOptions{
+			AppID:     "app-1",
+			VersionID: "version-1",
+			CheckURLs: true,
+			Output:    "json",
+		})
+	})
+	if runErr != nil {
+		t.Fatalf("runValidate() error: %v", runErr)
+	}
+	if !received.CheckURLs {
+		t.Fatalf("readiness options = %+v, want CheckURLs=true", received)
+	}
+	var report validation.Report
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("json.Unmarshal() error: %v; stdout=%q", err, stdout)
+	}
+}
+
+func TestRunValidatePrintsReportBeforeValidationError(t *testing.T) {
+	previous := buildReadinessReportFn
+	buildReadinessReportFn = func(_ context.Context, _ ReadinessOptions) (validation.Report, error) {
+		return validation.Report{
+			AppID:     "app-1",
+			VersionID: "version-1",
+			Summary:   validation.Summary{Warnings: 1, Blocking: 1},
+			Checks: []validation.CheckResult{{
+				ID:          "metadata.minimum.name",
+				Severity:    validation.SeverityWarning,
+				Message:     "app name is shorter than 2 characters",
+				Remediation: "Use an app name with at least 2 characters",
+			}},
+		}, nil
+	}
+	t.Cleanup(func() { buildReadinessReportFn = previous })
+
+	stdout := captureValidateStdout(t, func() {
+		err := runValidate(context.Background(), validateOptions{
+			AppID:     "app-1",
+			VersionID: "version-1",
+			Output:    "json",
+		})
+		if err == nil || !shared.IsValidationError(err) {
+			t.Fatalf("runValidate() error = %v, want a reported validation error", err)
+		}
+	})
+	if !strings.Contains(stdout, "metadata.minimum.name") {
+		t.Fatalf("report was not printed before validation error: %q", stdout)
+	}
+}
+
+func TestRunValidateDefaultsToOfflineURLChecks(t *testing.T) {
+	previous := buildReadinessReportFn
+	var received ReadinessOptions
+	buildReadinessReportFn = func(_ context.Context, opts ReadinessOptions) (validation.Report, error) {
+		received = opts
+		return validation.Report{}, nil
+	}
+	t.Cleanup(func() { buildReadinessReportFn = previous })
+
+	stdout := captureValidateStdout(t, func() {
+		if err := runValidate(context.Background(), validateOptions{AppID: "app-1", VersionID: "version-1", Output: "json"}); err != nil {
+			t.Fatalf("runValidate() error: %v", err)
+		}
+	})
+	if received.CheckURLs {
+		t.Fatal("default validation unexpectedly enabled URL checks")
+	}
+	if strings.TrimSpace(stdout) == "" {
+		t.Fatal("expected JSON report output")
+	}
+}
+
+func mustParseValidateURL(t *testing.T, rawURL string) *url.URL {
+	t.Helper()
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("url.Parse(%q): %v", rawURL, err)
+	}
+	return parsed
+}
+
+func equalValidateStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func captureValidateStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	oldStdout := os.Stdout
+	readPipe, writePipe, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error: %v", err)
+	}
+	os.Stdout = writePipe
+
+	fn()
+
+	if err := writePipe.Close(); err != nil {
+		t.Fatalf("close write pipe: %v", err)
+	}
+	os.Stdout = oldStdout
+	data, err := io.ReadAll(readPipe)
+	if err != nil {
+		t.Fatalf("read stdout pipe: %v", err)
+	}
+	return string(data)
+}

--- a/internal/cli/validate/metadata_urls_test.go
+++ b/internal/cli/validate/metadata_urls_test.go
@@ -109,6 +109,53 @@ func TestValidateURLChecksReportsRedirectAndStatusByStableIDs(t *testing.T) {
 	}
 }
 
+func TestValidateURLChecksRetainsCrossHostRedirectWarningWhenFinalHostReturns(t *testing.T) {
+	const rawURL = "https://support.example/help"
+	checker := &fakeValidateURLChecker{results: map[string]metadataurl.Result{
+		rawURL: {
+			FinalURL:       mustParseValidateURL(t, "https://support.example/final"),
+			StatusCode:     200,
+			RedirectedHost: true,
+		},
+	}}
+	checks, err := checkValidateURLs(context.Background(), checker, []validateURLTarget{{
+		RawURL:       rawURL,
+		Locale:       "en-US",
+		Field:        "supportUrl",
+		ResourceType: "appStoreVersionLocalization",
+		ResourceID:   "version-loc-1",
+	}})
+	if err != nil {
+		t.Fatalf("checkValidateURLs() error: %v", err)
+	}
+	if len(checks) != 1 || checks[0].ID != "legal.url.redirected_host" {
+		t.Fatalf("checks = %+v, want one redirected_host warning", checks)
+	}
+}
+
+func TestValidateURLChecksDoesNotWarnForSameHostResult(t *testing.T) {
+	const rawURL = "https://support.example/help"
+	checker := &fakeValidateURLChecker{results: map[string]metadataurl.Result{
+		rawURL: {
+			FinalURL:   mustParseValidateURL(t, "https://support.example/final"),
+			StatusCode: 200,
+		},
+	}}
+	checks, err := checkValidateURLs(context.Background(), checker, []validateURLTarget{{
+		RawURL:       rawURL,
+		Locale:       "en-US",
+		Field:        "supportUrl",
+		ResourceType: "appStoreVersionLocalization",
+		ResourceID:   "version-loc-1",
+	}})
+	if err != nil {
+		t.Fatalf("checkValidateURLs() error: %v", err)
+	}
+	if len(checks) != 0 {
+		t.Fatalf("checks = %+v, want no warnings", checks)
+	}
+}
+
 func TestValidateURLChecksMapsUnsafeAndTimeoutErrorsWithoutDetails(t *testing.T) {
 	checker := &fakeValidateURLChecker{
 		errors: map[string]error{

--- a/internal/cli/validate/readiness.go
+++ b/internal/cli/validate/readiness.go
@@ -21,6 +21,7 @@ type ReadinessOptions struct {
 	Platform  string
 	Strict    bool
 	Deep      bool
+	CheckURLs bool
 	Build     *validation.Build
 }
 
@@ -266,6 +267,18 @@ func BuildReadinessReport(ctx context.Context, opts ReadinessOptions) (validatio
 		HasPaidAppPrice:             hasPaidAppPrice,
 		AppPricingKnown:             appPricingKnown,
 	}, opts.Strict)
+	if opts.CheckURLs {
+		targets := validateURLTargets(versionLocalizations, appInfoLocalizations)
+		if len(targets) > 0 {
+			urlChecks, checkErr := checkValidateURLs(ctx, newValidateURLChecker(), targets)
+			if checkErr != nil {
+				return validation.Report{}, checkErr
+			}
+			report.Checks = append(report.Checks, urlChecks...)
+			report.Summary = validation.SummarizeChecks(report.Checks, opts.Strict)
+			report.Remediation = validation.BuildRemediation(report.Checks, opts.Strict)
+		}
+	}
 
 	return report, nil
 }

--- a/internal/cli/validate/validate.go
+++ b/internal/cli/validate/validate.go
@@ -22,14 +22,16 @@ type validateOptions struct {
 	Platform  string
 	Strict    bool
 	Deep      bool
+	CheckURLs bool
 	AppleID   string
 	Output    string
 	Pretty    bool
 }
 
 var (
-	clientFactory         = shared.GetASCClient
-	fetchScreenshotSetsFn = fetchScreenshotSets
+	clientFactory          = shared.GetASCClient
+	fetchScreenshotSetsFn  = fetchScreenshotSets
+	buildReadinessReportFn = BuildReadinessReport
 )
 
 // ValidateCommand returns the asc validate command.
@@ -42,6 +44,7 @@ func ValidateCommand() *ffcli.Command {
 	platform := fs.String("platform", "", "Platform: IOS, MAC_OS, TV_OS, VISION_OS")
 	strict := fs.Bool("strict", false, "Treat warnings as errors (exit non-zero)")
 	deep := fs.Bool("deep", false, "[experimental] Verify blockers that require a cached Apple web session")
+	checkURLs := fs.Bool("check-urls", false, "[experimental] Check metadata URL destinations with bounded public HTTP requests")
 	appleID := fs.String("apple-id", "", "[experimental] Cached Apple web session to use with --deep")
 	output := shared.BindOutputFlags(fs)
 
@@ -67,6 +70,8 @@ reported.
 Checks:
   - Metadata length limits
   - Placeholder copy in localized listing fields (warning; --strict to block)
+  - Deterministic metadata content and keyword hygiene warnings
+  - Optional bounded checks for public metadata URL destinations (--check-urls)
   - Required fields and localizations
   - App Store review details completeness
   - Primary category configured
@@ -91,6 +96,7 @@ Examples:
   asc validate --app "APP_ID" --version-id "VERSION_ID" --platform IOS --output table
   asc validate --app "APP_ID" --version-id "VERSION_ID" --strict
   asc validate --app "APP_ID" --version-id "VERSION_ID" --deep
+  asc validate --app "APP_ID" --version-id "VERSION_ID" --check-urls
   asc validate --app "APP_ID" --version "1.0.0" --deep --apple-id "user@example.com"
 
 TestFlight:
@@ -147,6 +153,7 @@ Subscriptions:
 				Platform:  normalizedPlatform,
 				Strict:    *strict,
 				Deep:      *deep,
+				CheckURLs: *checkURLs,
 				AppleID:   trimmedAppleID,
 				Output:    *output.Output,
 				Pretty:    *output.Pretty,
@@ -176,12 +183,12 @@ func validateParentFlagUsageMessage(parentFlags *flag.FlagSet) string {
 	}
 
 	moveAfterSubcommand := make([]string, 0, 4)
-	topLevelOnly := make([]string, 0, 7)
+	topLevelOnly := make([]string, 0, 8)
 	parentFlags.Visit(func(f *flag.Flag) {
 		switch f.Name {
 		case "app", "output", "pretty", "strict":
 			moveAfterSubcommand = append(moveAfterSubcommand, "--"+f.Name)
-		case "version", "version-id", "platform", "deep", "apple-id":
+		case "version", "version-id", "platform", "deep", "check-urls", "apple-id":
 			topLevelOnly = append(topLevelOnly, "--"+f.Name)
 		}
 	})
@@ -222,13 +229,14 @@ func validateFlagVerb(flags []string) string {
 }
 
 func runValidate(ctx context.Context, opts validateOptions) error {
-	report, err := BuildReadinessReport(ctx, ReadinessOptions{
+	report, err := buildReadinessReportFn(ctx, ReadinessOptions{
 		AppID:     opts.AppID,
 		Version:   opts.Version,
 		VersionID: opts.VersionID,
 		Platform:  opts.Platform,
 		Strict:    opts.Strict,
 		Deep:      opts.Deep,
+		CheckURLs: opts.CheckURLs,
 	})
 	if err != nil {
 		if !opts.Deep || !asc.IsRequiredAgreementError(err) {

--- a/internal/cli/validate/validate_content_help_test.go
+++ b/internal/cli/validate/validate_content_help_test.go
@@ -18,3 +18,25 @@ func TestValidateHelpDocumentsPlaceholderWarningScope(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateCommandAcceptsOptInURLChecks(t *testing.T) {
+	cmd := ValidateCommand()
+	if err := cmd.Parse([]string{"--app", "app-1", "--version-id", "version-1", "--check-urls"}); err != nil {
+		t.Fatalf("Parse() error: %v", err)
+	}
+	flagDef := cmd.FlagSet.Lookup("check-urls")
+	if flagDef == nil {
+		t.Fatal("--check-urls flag is not registered")
+	}
+	if !strings.HasPrefix(flagDef.Usage, "[experimental] ") {
+		t.Fatalf("--check-urls usage = %q, want [experimental] prefix", flagDef.Usage)
+	}
+}
+
+func TestValidateURLChecksAreTopLevelOnly(t *testing.T) {
+	cmd := ValidateCommand()
+	err := cmd.ParseAndRun(t.Context(), []string{"--check-urls", "testflight", "--app", "app-1", "--build", "build-1"})
+	if err == nil || !strings.Contains(err.Error(), "--check-urls is only valid for asc validate") {
+		t.Fatalf("error = %v, want top-level-only URL-check diagnostic", err)
+	}
+}

--- a/internal/metadataurl/check.go
+++ b/internal/metadataurl/check.go
@@ -37,8 +37,9 @@ var ErrUnsafeTarget = errors.New("metadata URL target is not a public internet a
 // Result contains the response metadata needed by callers. Response bodies
 // are never retained.
 type Result struct {
-	FinalURL   *url.URL
-	StatusCode int
+	FinalURL       *url.URL
+	StatusCode     int
+	RedirectedHost bool
 }
 
 // Outcome is the result of checking one destination.
@@ -153,22 +154,67 @@ func CheckWithClient(ctx context.Context, client *http.Client, rawURL string) (R
 	requestCtx, cancel := shared.ContextWithTimeout(ctx)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, rawURL, nil)
+	currentURL, err := url.Parse(rawURL)
 	if err != nil {
 		return Result{}, err
 	}
-	req.Header.Set("User-Agent", "asc metadata validate")
+	if err := validateTargetURL(currentURL); err != nil {
+		return Result{}, err
+	}
+	initialHost := strings.ToLower(currentURL.Hostname())
 
-	resp, err := client.Do(req)
-	if err != nil {
-		return Result{}, err
+	// Do not let net/http follow redirects: its automatic path reads a portion
+	// of each redirect body before closing it. Build a fresh request for every
+	// hop so credentials, cookies, and referrer headers cannot cross origins.
+	safeClient := *client
+	safeClient.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
 	}
-	defer resp.Body.Close()
-	finalURL := req.URL
-	if resp.Request != nil && resp.Request.URL != nil {
-		finalURL = resp.Request.URL
+	safeClient.Jar = nil
+
+	redirectedHost := false
+	for redirects := 0; ; {
+		req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, currentURL.String(), nil)
+		if err != nil {
+			return Result{}, err
+		}
+		req.Header.Set("User-Agent", "asc metadata validate")
+
+		resp, err := safeClient.Do(req)
+		if err != nil {
+			return Result{}, err
+		}
+		statusCode := resp.StatusCode
+		location := resp.Header.Get("Location")
+		if resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+
+		if !isRedirectStatus(statusCode) || location == "" {
+			finalURL := *currentURL
+			return Result{
+				FinalURL:       &finalURL,
+				StatusCode:     statusCode,
+				RedirectedHost: redirectedHost,
+			}, nil
+		}
+		if redirects >= MaxRedirects {
+			return Result{}, fmt.Errorf("metadata URL exceeded %d redirects", MaxRedirects)
+		}
+
+		nextURL, err := currentURL.Parse(location)
+		if err != nil {
+			return Result{}, err
+		}
+		if err := validateTargetURL(nextURL); err != nil {
+			return Result{}, err
+		}
+		if strings.ToLower(nextURL.Hostname()) != initialHost {
+			redirectedHost = true
+		}
+		currentURL = nextURL
+		redirects++
 	}
-	return Result{FinalURL: finalURL, StatusCode: resp.StatusCode}, nil
 }
 
 type httpChecker struct {
@@ -179,19 +225,37 @@ func (c *httpChecker) Check(ctx context.Context, rawURL string) (Result, error) 
 	return CheckWithClient(ctx, c.client, rawURL)
 }
 
-// RedirectPolicy rejects non-HTTP(S), unsafe literal IP, and excessive
-// redirects. DNS-resolved destinations are checked again by PublicDialControl.
+// RedirectPolicy rejects non-HTTP(S), userinfo, unsafe literal IP, and
+// excessive redirects. DNS-resolved destinations are checked again by
+// PublicDialControl.
 func RedirectPolicy(req *http.Request, via []*http.Request) error {
 	if len(via) >= MaxRedirects {
 		return fmt.Errorf("metadata URL exceeded %d redirects", MaxRedirects)
 	}
-	if !IsHTTPURL(req.URL) {
+	if req == nil {
 		return ErrUnsafeTarget
 	}
-	if ip, err := netip.ParseAddr(req.URL.Hostname()); err == nil && !IsPublicIP(ip) {
+	return validateTargetURL(req.URL)
+}
+
+func validateTargetURL(parsed *url.URL) error {
+	if !IsHTTPURL(parsed) || parsed.User != nil {
+		return ErrUnsafeTarget
+	}
+	if ip, err := netip.ParseAddr(parsed.Hostname()); err == nil && !IsPublicIP(ip) {
 		return ErrUnsafeTarget
 	}
 	return nil
+}
+
+func isRedirectStatus(statusCode int) bool {
+	switch statusCode {
+	case http.StatusMovedPermanently, http.StatusFound, http.StatusSeeOther,
+		http.StatusTemporaryRedirect, http.StatusPermanentRedirect:
+		return true
+	default:
+		return false
+	}
 }
 
 // IsHTTPURL reports whether parsed is an absolute HTTP(S) URL with a host.

--- a/internal/metadataurl/check.go
+++ b/internal/metadataurl/check.go
@@ -1,0 +1,280 @@
+// Package metadataurl provides bounded, read-only checks for public metadata
+// URL destinations.
+package metadataurl
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"sort"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+const (
+	// CheckConcurrency bounds simultaneous destination requests.
+	CheckConcurrency = 4
+	// CheckTimeout bounds each destination request when no ASC timeout override
+	// is configured.
+	CheckTimeout = 10 * time.Second
+	// MaxRedirects bounds the number of HTTP(S) redirects followed.
+	MaxRedirects = 10
+)
+
+// ErrUnsafeTarget reports a destination that is not safe to contact as a
+// public metadata URL.
+var ErrUnsafeTarget = errors.New("metadata URL target is not a public internet address")
+
+// Result contains the response metadata needed by callers. Response bodies
+// are never retained.
+type Result struct {
+	FinalURL   *url.URL
+	StatusCode int
+}
+
+// Outcome is the result of checking one destination.
+type Outcome struct {
+	Result Result
+	Err    error
+}
+
+// Checker checks one HTTP(S) destination.
+type Checker interface {
+	Check(context.Context, string) (Result, error)
+}
+
+// CheckAll checks each unique, trimmed URL once, with bounded concurrency.
+// The returned map is keyed by the trimmed URL supplied to the checker. An
+// individual request failure is retained in Outcome and does not abort the
+// remaining checks. Context cancellation is returned to the caller.
+func CheckAll(ctx context.Context, checker Checker, rawURLs []string) (map[string]Outcome, error) {
+	outcomes := make(map[string]Outcome, len(rawURLs))
+	if len(rawURLs) == 0 {
+		return outcomes, nil
+	}
+	if checker == nil {
+		return nil, errors.New("metadata URL checker is nil")
+	}
+
+	unique := make(map[string]struct{}, len(rawURLs))
+	for _, rawURL := range rawURLs {
+		if trimmed := strings.TrimSpace(rawURL); trimmed != "" {
+			unique[trimmed] = struct{}{}
+		}
+	}
+	urls := make([]string, 0, len(unique))
+	for rawURL := range unique {
+		urls = append(urls, rawURL)
+	}
+	sort.Strings(urls)
+	if len(urls) == 0 {
+		return outcomes, nil
+	}
+
+	jobs := make(chan string)
+	var workers sync.WaitGroup
+	var outcomesMu sync.Mutex
+	workerCount := min(CheckConcurrency, len(urls))
+	workers.Add(workerCount)
+	for range workerCount {
+		go func() {
+			defer workers.Done()
+			for rawURL := range jobs {
+				result, err := checker.Check(ctx, rawURL)
+				outcomesMu.Lock()
+				outcomes[rawURL] = Outcome{Result: result, Err: err}
+				outcomesMu.Unlock()
+			}
+		}()
+	}
+	for _, rawURL := range urls {
+		select {
+		case jobs <- rawURL:
+		case <-ctx.Done():
+			close(jobs)
+			workers.Wait()
+			return nil, ctx.Err()
+		}
+	}
+	close(jobs)
+	workers.Wait()
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return outcomes, nil
+}
+
+// NewChecker returns the production bounded HTTP checker.
+func NewChecker() Checker {
+	return &httpChecker{client: NewHTTPClient()}
+}
+
+// NewHTTPClient returns the configured bounded HTTP client. It is exported for
+// compatibility adapters and tests that need to inject a custom transport.
+func NewHTTPClient() *http.Client {
+	timeout := asc.ResolveTimeoutWithDefault(CheckTimeout)
+	dialer := &net.Dialer{
+		Timeout:        timeout,
+		KeepAlive:      30 * time.Second,
+		ControlContext: PublicDialControl,
+	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = nil
+	transport.DialContext = dialer.DialContext
+	transport.DisableKeepAlives = true
+	transport.MaxConnsPerHost = CheckConcurrency
+	transport.ResponseHeaderTimeout = timeout
+	transport.TLSHandshakeTimeout = timeout
+	transport.MaxResponseHeaderBytes = 1 << 20
+
+	return &http.Client{
+		Transport:     transport,
+		Timeout:       timeout,
+		CheckRedirect: RedirectPolicy,
+	}
+}
+
+// CheckWithClient performs one bounded request using client. It is useful for
+// package adapters that need a custom RoundTripper while retaining the shared
+// request contract.
+func CheckWithClient(ctx context.Context, client *http.Client, rawURL string) (Result, error) {
+	if client == nil {
+		return Result{}, errors.New("metadata URL HTTP client is nil")
+	}
+	requestCtx, cancel := shared.ContextWithTimeout(ctx)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return Result{}, err
+	}
+	req.Header.Set("User-Agent", "asc metadata validate")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return Result{}, err
+	}
+	defer resp.Body.Close()
+	finalURL := req.URL
+	if resp.Request != nil && resp.Request.URL != nil {
+		finalURL = resp.Request.URL
+	}
+	return Result{FinalURL: finalURL, StatusCode: resp.StatusCode}, nil
+}
+
+type httpChecker struct {
+	client *http.Client
+}
+
+func (c *httpChecker) Check(ctx context.Context, rawURL string) (Result, error) {
+	return CheckWithClient(ctx, c.client, rawURL)
+}
+
+// RedirectPolicy rejects non-HTTP(S), unsafe literal IP, and excessive
+// redirects. DNS-resolved destinations are checked again by PublicDialControl.
+func RedirectPolicy(req *http.Request, via []*http.Request) error {
+	if len(via) >= MaxRedirects {
+		return fmt.Errorf("metadata URL exceeded %d redirects", MaxRedirects)
+	}
+	if !IsHTTPURL(req.URL) {
+		return ErrUnsafeTarget
+	}
+	if ip, err := netip.ParseAddr(req.URL.Hostname()); err == nil && !IsPublicIP(ip) {
+		return ErrUnsafeTarget
+	}
+	return nil
+}
+
+// IsHTTPURL reports whether parsed is an absolute HTTP(S) URL with a host.
+func IsHTTPURL(parsed *url.URL) bool {
+	if parsed == nil || parsed.Hostname() == "" {
+		return false
+	}
+	return parsed.Scheme == "http" || parsed.Scheme == "https"
+}
+
+// PublicDialControl rejects every resolved non-public address, including
+// addresses that otherwise look global-unicast but belong to special-purpose
+// IANA ranges.
+func PublicDialControl(_ context.Context, _, address string, _ syscall.RawConn) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return ErrUnsafeTarget
+	}
+	parsed, err := netip.ParseAddr(host)
+	if err != nil || !IsPublicIP(parsed) {
+		return ErrUnsafeTarget
+	}
+	return nil
+}
+
+// These IANA special-purpose ranges can still satisfy netip.Addr.IsGlobalUnicast.
+// Translation prefixes stay blocked because they can encode non-public IPv4 targets.
+var reservedIPPrefixes = []netip.Prefix{
+	netip.MustParsePrefix("0.0.0.0/8"),
+	netip.MustParsePrefix("100.64.0.0/10"),
+	netip.MustParsePrefix("192.0.0.0/24"),
+	netip.MustParsePrefix("192.0.2.0/24"),
+	netip.MustParsePrefix("192.88.99.0/24"),
+	netip.MustParsePrefix("198.18.0.0/15"),
+	netip.MustParsePrefix("198.51.100.0/24"),
+	netip.MustParsePrefix("203.0.113.0/24"),
+	netip.MustParsePrefix("240.0.0.0/4"),
+	netip.MustParsePrefix("::ffff:0:0:0/96"),
+	netip.MustParsePrefix("64:ff9b::/96"),
+	netip.MustParsePrefix("64:ff9b:1::/48"),
+	netip.MustParsePrefix("100::/64"),
+	netip.MustParsePrefix("100:0:0:1::/64"),
+	netip.MustParsePrefix("2001::/23"),
+	netip.MustParsePrefix("2001::/32"),
+	netip.MustParsePrefix("2001:2::/48"),
+	netip.MustParsePrefix("2001:10::/28"),
+	netip.MustParsePrefix("2001:db8::/32"),
+	netip.MustParsePrefix("2002::/16"),
+	netip.MustParsePrefix("3ffe::/16"),
+	netip.MustParsePrefix("3fff::/20"),
+	netip.MustParsePrefix("5f00::/8"),
+	netip.MustParsePrefix("fec0::/10"),
+}
+
+// Check these IANA globally reachable allocations before their broader parent ranges.
+var globallyReachableIPExceptions = []netip.Prefix{
+	netip.MustParsePrefix("192.0.0.9/32"),
+	netip.MustParsePrefix("192.0.0.10/32"),
+	netip.MustParsePrefix("2001:1::1/128"),
+	netip.MustParsePrefix("2001:1::2/128"),
+	netip.MustParsePrefix("2001:1::3/128"),
+	netip.MustParsePrefix("2001:3::/32"),
+	netip.MustParsePrefix("2001:4:112::/48"),
+	netip.MustParsePrefix("2001:20::/28"),
+	netip.MustParsePrefix("2001:30::/28"),
+}
+
+// IsPublicIP reports whether address is suitable for an outbound metadata
+// destination.
+func IsPublicIP(address netip.Addr) bool {
+	address = address.Unmap()
+	if !address.IsValid() || !address.IsGlobalUnicast() || address.IsPrivate() || address.IsLoopback() || address.IsLinkLocalUnicast() {
+		return false
+	}
+	for _, prefix := range globallyReachableIPExceptions {
+		if prefix.Contains(address) {
+			return true
+		}
+	}
+	for _, prefix := range reservedIPPrefixes {
+		if prefix.Contains(address) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/metadataurl/check_test.go
+++ b/internal/metadataurl/check_test.go
@@ -1,0 +1,110 @@
+package metadataurl
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"sync"
+	"testing"
+)
+
+type fakeChecker struct {
+	mu    sync.Mutex
+	calls map[string]int
+}
+
+func (f *fakeChecker) Check(_ context.Context, rawURL string) (Result, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.calls == nil {
+		f.calls = make(map[string]int)
+	}
+	f.calls[rawURL]++
+	return Result{FinalURL: mustParseURL(rawURL), StatusCode: http.StatusOK}, nil
+}
+
+func TestCheckAllTrimsSortsAndDeduplicatesURLs(t *testing.T) {
+	checker := &fakeChecker{}
+	outcomes, err := CheckAll(context.Background(), checker, []string{
+		" https://example.com/b ",
+		"https://example.com/a",
+		"https://example.com/a",
+		" ",
+	})
+	if err != nil {
+		t.Fatalf("CheckAll() error: %v", err)
+	}
+	if len(outcomes) != 2 || checker.calls["https://example.com/a"] != 1 || checker.calls["https://example.com/b"] != 1 {
+		t.Fatalf("outcomes = %+v, calls = %+v, want two unique trimmed checks", outcomes, checker.calls)
+	}
+}
+
+func TestCheckAllPreservesIndividualErrorsAndContextCancellation(t *testing.T) {
+	checker := checkerFunc(func(ctx context.Context, rawURL string) (Result, error) {
+		if rawURL == "https://example.com/fail" {
+			return Result{}, errors.New("request failed")
+		}
+		return Result{FinalURL: mustParseURL(rawURL), StatusCode: http.StatusOK}, nil
+	})
+	outcomes, err := CheckAll(context.Background(), checker, []string{"https://example.com/fail"})
+	if err != nil {
+		t.Fatalf("CheckAll() error: %v", err)
+	}
+	if outcomes["https://example.com/fail"].Err == nil {
+		t.Fatal("expected individual request error to be retained")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = CheckAll(ctx, checker, []string{"https://example.com/cancel"})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("CheckAll() error = %v, want context cancellation", err)
+	}
+}
+
+type checkerFunc func(context.Context, string) (Result, error)
+
+func (f checkerFunc) Check(ctx context.Context, rawURL string) (Result, error) {
+	return f(ctx, rawURL)
+}
+
+func TestRedirectPolicyRejectsUnsafeAndExcessiveRedirects(t *testing.T) {
+	publicRequest, err := http.NewRequest(http.MethodGet, "https://8.8.8.8/support", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest() error: %v", err)
+	}
+	if err := RedirectPolicy(publicRequest, nil); err != nil {
+		t.Fatalf("RedirectPolicy() public error: %v", err)
+	}
+
+	privateRequest, err := http.NewRequest(http.MethodGet, "http://127.0.0.1/support", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest() error: %v", err)
+	}
+	if err := RedirectPolicy(privateRequest, nil); !errors.Is(err, ErrUnsafeTarget) {
+		t.Fatalf("RedirectPolicy() private error = %v, want ErrUnsafeTarget", err)
+	}
+
+	via := make([]*http.Request, MaxRedirects)
+	if err := RedirectPolicy(publicRequest, via); err == nil || err.Error() != "metadata URL exceeded 10 redirects" {
+		t.Fatalf("RedirectPolicy() limit error = %v, want redirect limit", err)
+	}
+}
+
+func TestPublicDialControlRejectsPrivateAddresses(t *testing.T) {
+	if err := PublicDialControl(context.Background(), "tcp4", "127.0.0.1:443", nil); !errors.Is(err, ErrUnsafeTarget) {
+		t.Fatalf("PublicDialControl() private error = %v, want ErrUnsafeTarget", err)
+	}
+	if err := PublicDialControl(context.Background(), "tcp4", "8.8.8.8:443", nil); err != nil {
+		t.Fatalf("PublicDialControl() public error = %v", err)
+	}
+}
+
+func mustParseURL(rawURL string) *url.URL {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		panic(err)
+	}
+	return parsed
+}

--- a/internal/metadataurl/check_test.go
+++ b/internal/metadataurl/check_test.go
@@ -3,9 +3,13 @@ package metadataurl
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 )
 
@@ -85,6 +89,13 @@ func TestRedirectPolicyRejectsUnsafeAndExcessiveRedirects(t *testing.T) {
 	if err := RedirectPolicy(privateRequest, nil); !errors.Is(err, ErrUnsafeTarget) {
 		t.Fatalf("RedirectPolicy() private error = %v, want ErrUnsafeTarget", err)
 	}
+	userinfoRequest, err := http.NewRequest(http.MethodGet, "https://user:password@example.com/support", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest() error: %v", err)
+	}
+	if err := RedirectPolicy(userinfoRequest, nil); !errors.Is(err, ErrUnsafeTarget) {
+		t.Fatalf("RedirectPolicy() userinfo error = %v, want ErrUnsafeTarget", err)
+	}
 
 	via := make([]*http.Request, MaxRedirects)
 	if err := RedirectPolicy(publicRequest, via); err == nil || err.Error() != "metadata URL exceeded 10 redirects" {
@@ -99,6 +110,320 @@ func TestPublicDialControlRejectsPrivateAddresses(t *testing.T) {
 	if err := PublicDialControl(context.Background(), "tcp4", "8.8.8.8:443", nil); err != nil {
 		t.Fatalf("PublicDialControl() public error = %v", err)
 	}
+}
+
+func TestCheckWithClientRejectsInitialUserinfoBeforeRoundTrip(t *testing.T) {
+	var requests atomic.Int64
+	var authorization atomic.Value
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		authorization.Store(r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	transport := newMetadataURLTestTransport(t, map[string]string{
+		"origin.example.test": server.URL,
+	}, nil)
+	client := &http.Client{Transport: transport}
+
+	_, err := CheckWithClient(context.Background(), client, "http://user:password@origin.example.test/start")
+	if !errors.Is(err, ErrUnsafeTarget) {
+		t.Fatalf("CheckWithClient() error = %v, want ErrUnsafeTarget", err)
+	}
+	if got := requests.Load(); got != 0 {
+		t.Fatalf("server requests = %d, want zero", got)
+	}
+	if got := authorization.Load(); got != nil {
+		t.Fatalf("server Authorization = %v, want no request", got)
+	}
+}
+
+func TestCheckWithClientRejectsRedirectUserinfoBeforeNextRequest(t *testing.T) {
+	var destinationRequests atomic.Int64
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", "http://user:password@destination.example.test/final")
+		w.Header().Set("Content-Length", "0")
+		w.WriteHeader(http.StatusFound)
+	}))
+	destination := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		destinationRequests.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(origin.Close)
+	t.Cleanup(destination.Close)
+
+	transport := newMetadataURLTestTransport(t, map[string]string{
+		"origin.example.test":      origin.URL,
+		"destination.example.test": destination.URL,
+	}, nil)
+	client := &http.Client{Transport: transport}
+
+	_, err := CheckWithClient(context.Background(), client, "http://origin.example.test/start")
+	if !errors.Is(err, ErrUnsafeTarget) {
+		t.Fatalf("CheckWithClient() error = %v, want ErrUnsafeTarget", err)
+	}
+	if got := destinationRequests.Load(); got != 0 {
+		t.Fatalf("destination requests = %d, want zero", got)
+	}
+}
+
+func TestCheckWithClientDoesNotReadRedirectBodiesOrForwardHeaders(t *testing.T) {
+	var destinationAuthorization atomic.Value
+	var destinationCookie atomic.Value
+	var destinationProxyAuthorization atomic.Value
+	var destinationReferer atomic.Value
+	destination := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		destinationAuthorization.Store(r.Header.Get("Authorization"))
+		destinationCookie.Store(r.Header.Get("Cookie"))
+		destinationProxyAuthorization.Store(r.Header.Get("Proxy-Authorization"))
+		destinationReferer.Store(r.Header.Get("Referer"))
+		w.Header().Set("Content-Length", "5")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "final")
+	}))
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", "http://destination.example.test/final")
+		body := "redirect body that must not be read"
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		w.WriteHeader(http.StatusFound)
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(destination.Close)
+	t.Cleanup(origin.Close)
+
+	stats := &metadataURLBodyStats{}
+	transport := newMetadataURLTestTransport(t, map[string]string{
+		"origin.example.test":      origin.URL,
+		"destination.example.test": destination.URL,
+	}, stats)
+	client := &http.Client{Transport: transport}
+
+	result, err := CheckWithClient(context.Background(), client, "http://origin.example.test/start")
+	if err != nil {
+		t.Fatalf("CheckWithClient() error = %v", err)
+	}
+	if result.StatusCode != http.StatusOK {
+		t.Fatalf("result.StatusCode = %d, want %d", result.StatusCode, http.StatusOK)
+	}
+	if got := stats.reads.Load(); got != 0 {
+		t.Fatalf("redirect response body reads = %d, want zero", got)
+	}
+	if got := stats.closes.Load(); got != 2 {
+		t.Fatalf("response body closes = %d, want 2", got)
+	}
+	for name, value := range map[string]*atomic.Value{
+		"Authorization":       &destinationAuthorization,
+		"Cookie":              &destinationCookie,
+		"Proxy-Authorization": &destinationProxyAuthorization,
+		"Referer":             &destinationReferer,
+	} {
+		if got := value.Load(); got != "" {
+			t.Errorf("destination %s = %q, want empty", name, got)
+		}
+	}
+}
+
+func TestCheckWithClientRejectsMalformedAndUnsupportedRedirectTargets(t *testing.T) {
+	for name, location := range map[string]string{
+		"unsupported scheme": "ftp://destination.example.test/final",
+		"malformed URL":      "http://%zz",
+	} {
+		t.Run(name, func(t *testing.T) {
+			var destinationRequests atomic.Int64
+			origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Location", location)
+				w.Header().Set("Content-Length", "0")
+				w.WriteHeader(http.StatusFound)
+			}))
+			destination := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				destinationRequests.Add(1)
+				w.WriteHeader(http.StatusOK)
+			}))
+			t.Cleanup(origin.Close)
+			t.Cleanup(destination.Close)
+
+			transport := newMetadataURLTestTransport(t, map[string]string{
+				"origin.example.test":      origin.URL,
+				"destination.example.test": destination.URL,
+			}, nil)
+			_, err := CheckWithClient(context.Background(), &http.Client{Transport: transport}, "http://origin.example.test/start")
+			if err == nil {
+				t.Fatal("CheckWithClient() error = nil, want rejected redirect target")
+			}
+			if name == "unsupported scheme" && !errors.Is(err, ErrUnsafeTarget) {
+				t.Fatalf("CheckWithClient() error = %v, want ErrUnsafeTarget", err)
+			}
+			if got := destinationRequests.Load(); got != 0 {
+				t.Fatalf("destination requests = %d, want zero", got)
+			}
+		})
+	}
+}
+
+func TestCheckWithClientBoundsRedirectLoopWithoutReadingBodies(t *testing.T) {
+	var requests atomic.Int64
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		body := "redirect body"
+		w.Header().Set("Location", "http://origin.example.test/next")
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		w.WriteHeader(http.StatusFound)
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(origin.Close)
+
+	stats := &metadataURLBodyStats{}
+	transport := newMetadataURLTestTransport(t, map[string]string{
+		"origin.example.test": origin.URL,
+	}, stats)
+	_, err := CheckWithClient(context.Background(), &http.Client{Transport: transport}, "http://origin.example.test/start")
+	if err == nil || err.Error() != "metadata URL exceeded 10 redirects" {
+		t.Fatalf("CheckWithClient() error = %v, want redirect limit", err)
+	}
+	if got := requests.Load(); got > int64(MaxRedirects+1) {
+		t.Fatalf("redirect requests = %d, want at most %d", got, MaxRedirects+1)
+	}
+	if got := stats.reads.Load(); got != 0 {
+		t.Fatalf("redirect response body reads = %d, want zero", got)
+	}
+}
+
+func TestCheckWithClientTracksCrossHostRedirectEvenWhenItReturns(t *testing.T) {
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/start" {
+			w.Header().Set("Location", "http://destination.example.test/middle")
+			w.Header().Set("Content-Length", "0")
+			w.WriteHeader(http.StatusFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	destination := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", "http://origin.example.test/final")
+		w.Header().Set("Content-Length", "0")
+		w.WriteHeader(http.StatusFound)
+	}))
+	t.Cleanup(origin.Close)
+	t.Cleanup(destination.Close)
+
+	transport := newMetadataURLTestTransport(t, map[string]string{
+		"origin.example.test":      origin.URL,
+		"destination.example.test": destination.URL,
+	}, nil)
+	result, err := CheckWithClient(context.Background(), &http.Client{Transport: transport}, "http://origin.example.test/start")
+	if err != nil {
+		t.Fatalf("CheckWithClient() error = %v", err)
+	}
+	if !result.RedirectedHost {
+		t.Fatal("result.RedirectedHost = false, want true")
+	}
+	if got := result.FinalURL.String(); got != "http://origin.example.test/final" {
+		t.Fatalf("result.FinalURL = %q, want original host final URL", got)
+	}
+}
+
+func TestCheckWithClientDoesNotMarkSameHostRedirect(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/start" {
+			w.Header().Set("Location", "/final")
+			w.Header().Set("Content-Length", "0")
+			w.WriteHeader(http.StatusFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	transport := newMetadataURLTestTransport(t, map[string]string{
+		"origin.example.test": server.URL,
+	}, nil)
+	result, err := CheckWithClient(context.Background(), &http.Client{Transport: transport}, "http://origin.example.test/start")
+	if err != nil {
+		t.Fatalf("CheckWithClient() error = %v", err)
+	}
+	if result.RedirectedHost {
+		t.Fatal("result.RedirectedHost = true, want false")
+	}
+}
+
+type metadataURLBodyStats struct {
+	reads  atomic.Int64
+	closes atomic.Int64
+}
+
+type metadataURLTrackingBody struct {
+	io.ReadCloser
+	stats *metadataURLBodyStats
+}
+
+func (b *metadataURLTrackingBody) Read(p []byte) (int, error) {
+	b.stats.reads.Add(1)
+	return b.ReadCloser.Read(p)
+}
+
+func (b *metadataURLTrackingBody) Close() error {
+	b.stats.closes.Add(1)
+	return b.ReadCloser.Close()
+}
+
+type metadataURLTestTransport struct {
+	t                *testing.T
+	base             http.RoundTripper
+	routes           map[string]*url.URL
+	stats            *metadataURLBodyStats
+	injectedFirstHop atomic.Bool
+}
+
+func newMetadataURLTestTransport(t *testing.T, routes map[string]string, stats *metadataURLBodyStats) http.RoundTripper {
+	t.Helper()
+	parsedRoutes := make(map[string]*url.URL, len(routes))
+	for host, rawURL := range routes {
+		parsed, err := url.Parse(rawURL)
+		if err != nil {
+			t.Fatalf("url.Parse(%q): %v", rawURL, err)
+		}
+		parsedRoutes[host] = parsed
+	}
+	if stats == nil {
+		stats = &metadataURLBodyStats{}
+	}
+	base := http.DefaultTransport.(*http.Transport).Clone()
+	base.Proxy = nil
+	return &metadataURLTestTransport{
+		t:      t,
+		base:   base,
+		routes: parsedRoutes,
+		stats:  stats,
+	}
+}
+
+func (t *metadataURLTestTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.t.Helper()
+	route, ok := t.routes[req.URL.Hostname()]
+	if !ok {
+		return nil, errors.New("metadata URL test route not found")
+	}
+	request := req.Clone(req.Context())
+	requestURL := *req.URL
+	requestURL.Scheme = route.Scheme
+	requestURL.Host = route.Host
+	requestURL.User = nil
+	request.URL = &requestURL
+	request.Host = ""
+	if t.injectedFirstHop.CompareAndSwap(false, true) {
+		request.Header.Set("Authorization", "Bearer first-hop")
+		request.Header.Set("Cookie", "session=first-hop")
+		request.Header.Set("Proxy-Authorization", "Basic first-hop")
+		request.Header.Set("Referer", "https://referrer.example.test/source")
+	}
+	response, err := t.base.RoundTrip(request)
+	if err != nil {
+		return nil, err
+	}
+	response.Request = req
+	response.Body = &metadataURLTrackingBody{ReadCloser: response.Body, stats: t.stats}
+	return response, nil
 }
 
 func mustParseURL(rawURL string) *url.URL {

--- a/internal/metadataurl/check_test.go
+++ b/internal/metadataurl/check_test.go
@@ -289,6 +289,37 @@ func TestCheckWithClientBoundsRedirectLoopWithoutReadingBodies(t *testing.T) {
 	}
 }
 
+func TestCheckWithClientTreatsRedirectWithoutLocationAsFinalResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := "redirect body"
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		w.WriteHeader(http.StatusFound)
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(server.Close)
+	stats := &metadataURLBodyStats{}
+	transport := newMetadataURLTestTransport(t, map[string]string{
+		"origin.example.test": server.URL,
+	}, stats)
+
+	result, err := CheckWithClient(context.Background(), &http.Client{Transport: transport}, "http://origin.example.test/start")
+	if err != nil {
+		t.Fatalf("CheckWithClient() error = %v", err)
+	}
+	if result.StatusCode != http.StatusFound {
+		t.Fatalf("result.StatusCode = %d, want %d", result.StatusCode, http.StatusFound)
+	}
+	if got := result.FinalURL.String(); got != "http://origin.example.test/start" {
+		t.Fatalf("result.FinalURL = %q, want original URL", got)
+	}
+	if got := stats.reads.Load(); got != 0 {
+		t.Fatalf("redirect response body reads = %d, want zero", got)
+	}
+	if got := stats.closes.Load(); got != 1 {
+		t.Fatalf("redirect response body closes = %d, want one", got)
+	}
+}
+
 func TestCheckWithClientTracksCrossHostRedirectEvenWhenItReturns(t *testing.T) {
 	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/start" {

--- a/internal/validation/metadata_quality.go
+++ b/internal/validation/metadata_quality.go
@@ -1,0 +1,120 @@
+package validation
+
+import "sort"
+
+// MetadataQualityChecks returns deterministic, warning-only checks that can be
+// evaluated from the localized metadata already loaded by asc validate.
+//
+// It intentionally projects only the narrow, actionable subset of the keyword
+// audit. Informational budget/cross-locale findings, user-supplied blocked
+// terms, and the audit's missing-localization error remain owned by the
+// dedicated keyword audit command.
+func MetadataQualityChecks(versionLocs []VersionLocalization, appInfoLocs []AppInfoLocalization) []CheckResult {
+	checks := make([]CheckResult, 0)
+
+	for _, loc := range appInfoLocs {
+		for _, issue := range AppInfoLocalizationMinimumLengthIssues(loc) {
+			if issue.Field != "name" {
+				continue
+			}
+			checks = append(checks, CheckResult{
+				ID:           "metadata.minimum.name",
+				Severity:     SeverityWarning,
+				Locale:       loc.Locale,
+				Field:        issue.Field,
+				ResourceType: "appInfoLocalization",
+				ResourceID:   loc.ID,
+				Message:      "app name is shorter than 2 characters",
+				Remediation:  "Use an app name with at least 2 characters",
+			})
+		}
+	}
+
+	keywordChecks := AuditKeywords(KeywordAuditInput{
+		VersionLocalizations: versionLocs,
+		AppInfoLocalizations: appInfoLocs,
+	}, false).Checks
+	versionByLocale := make(map[string]VersionLocalization, len(versionLocs))
+	for _, loc := range versionLocs {
+		locale := loc.Locale
+		if current, exists := versionByLocale[locale]; !exists || loc.ID < current.ID {
+			versionByLocale[locale] = loc
+		}
+	}
+
+	allowed := map[string]struct{}{
+		"metadata.keywords.empty_segments":          {},
+		"metadata.keywords.noncanonical_separators": {},
+		"metadata.keywords.locale_duplicates":       {},
+		"metadata.keywords.overlap_name":            {},
+		"metadata.keywords.overlap_subtitle":        {},
+	}
+	messages := map[string][2]string{
+		"metadata.keywords.empty_segments": {
+			"keyword field contains empty phrase segments",
+			"Remove repeated, leading, or trailing separators from the keyword field",
+		},
+		"metadata.keywords.noncanonical_separators": {
+			"keyword field uses non-canonical separators",
+			"Use a comma-separated keyword field",
+		},
+		"metadata.keywords.locale_duplicates": {
+			"keyword field repeats one or more phrases within this locale",
+			"Remove duplicated phrases from the keyword field",
+		},
+		"metadata.keywords.overlap_name": {
+			"keyword field repeats one or more localized app-name terms",
+			"Avoid repeating app-name terms inside the keyword field",
+		},
+		"metadata.keywords.overlap_subtitle": {
+			"keyword field repeats one or more localized subtitle terms",
+			"Avoid repeating subtitle terms inside the keyword field",
+		},
+	}
+	seen := make(map[string]struct{}, len(keywordChecks))
+	for _, keywordCheck := range keywordChecks {
+		if _, ok := allowed[keywordCheck.ID]; !ok {
+			continue
+		}
+		loc, ok := versionByLocale[keywordCheck.Locale]
+		if !ok {
+			continue
+		}
+		key := keywordCheck.Locale + "\x00" + keywordCheck.ID
+		if _, duplicate := seen[key]; duplicate {
+			continue
+		}
+		seen[key] = struct{}{}
+		message := messages[keywordCheck.ID]
+		checks = append(checks, CheckResult{
+			ID:           keywordCheck.ID,
+			Severity:     SeverityWarning,
+			Locale:       keywordCheck.Locale,
+			Field:        "keywords",
+			ResourceType: "appStoreVersionLocalization",
+			ResourceID:   loc.ID,
+			Message:      message[0],
+			Remediation:  message[1],
+		})
+	}
+
+	sort.SliceStable(checks, func(i, j int) bool {
+		left := checks[i]
+		right := checks[j]
+		if left.ResourceType != right.ResourceType {
+			return left.ResourceType < right.ResourceType
+		}
+		if left.ResourceID != right.ResourceID {
+			return left.ResourceID < right.ResourceID
+		}
+		if left.Locale != right.Locale {
+			return left.Locale < right.Locale
+		}
+		if left.Field != right.Field {
+			return left.Field < right.Field
+		}
+		return left.ID < right.ID
+	})
+
+	return checks
+}

--- a/internal/validation/metadata_quality_test.go
+++ b/internal/validation/metadata_quality_test.go
@@ -1,0 +1,148 @@
+package validation
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMetadataQualityChecksMapsDeterministicWarningsWithoutKeywordValues(t *testing.T) {
+	checks := MetadataQualityChecks(
+		[]VersionLocalization{{
+			ID:       "version-loc-1",
+			Locale:   "en-US",
+			Keywords: "alpha,alpha,,beta",
+		}},
+		[]AppInfoLocalization{{
+			ID:       "app-info-loc-1",
+			Locale:   "en-US",
+			Name:     "X",
+			Subtitle: "Beta",
+		}, {
+			ID:       "app-info-loc-2",
+			Locale:   "en-US",
+			Name:     "Alpha",
+			Subtitle: "Beta",
+		}},
+	)
+
+	wantIDs := []string{
+		"metadata.minimum.name",
+		"metadata.keywords.empty_segments",
+		"metadata.keywords.locale_duplicates",
+		"metadata.keywords.overlap_name",
+		"metadata.keywords.overlap_subtitle",
+	}
+	if got := checkIDs(checks); !equalStrings(got, wantIDs) {
+		t.Fatalf("check IDs = %v, want %v", got, wantIDs)
+	}
+	for _, check := range checks {
+		if check.Severity != SeverityWarning {
+			t.Fatalf("check = %+v, want warning", check)
+		}
+		if check.ResourceType == "" || check.ResourceID == "" || check.Locale != "en-US" {
+			t.Fatalf("check = %+v, want localization context", check)
+		}
+		if strings.Contains(strings.ToLower(check.Message), "alpha") || strings.Contains(strings.ToLower(check.Message), "beta") {
+			t.Fatalf("check leaked keyword value: %+v", check)
+		}
+	}
+}
+
+func TestMetadataQualityChecksSkipsInformationalAndUserSuppliedKeywordRules(t *testing.T) {
+	checks := MetadataQualityChecks(
+		[]VersionLocalization{{
+			ID:       "version-loc-1",
+			Locale:   "en-US",
+			Keywords: "alpha,beta",
+		}},
+		[]AppInfoLocalization{{
+			ID:       "app-info-loc-1",
+			Locale:   "en-US",
+			Name:     "A useful app",
+			Subtitle: "Track routines",
+		}},
+	)
+	if len(checks) != 0 {
+		t.Fatalf("checks = %+v, want no warning-only quality findings", checks)
+	}
+}
+
+func TestMetadataQualityChecksCountsAppNameRunes(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		appName   string
+		wantIssue bool
+	}{
+		{name: "one multibyte rune", appName: "界", wantIssue: true},
+		{name: "two multibyte runes", appName: "界面", wantIssue: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			checks := MetadataQualityChecks(nil, []AppInfoLocalization{{
+				ID:     "app-info-loc-1",
+				Locale: "zh-Hans",
+				Name:   test.appName,
+			}})
+			gotIssue := hasCheckID(checks, "metadata.minimum.name")
+			if gotIssue != test.wantIssue {
+				t.Fatalf("checks = %+v, want metadata.minimum.name=%t", checks, test.wantIssue)
+			}
+		})
+	}
+}
+
+func TestValidateIncludesMetadataQualityWarningsAndStrictModeControlsBlocking(t *testing.T) {
+	report := Validate(Input{
+		VersionLocalizations: []VersionLocalization{{
+			ID:       "version-loc-1",
+			Locale:   "en-US",
+			Keywords: "alpha,alpha",
+		}},
+		AppInfoLocalizations: []AppInfoLocalization{{
+			ID:     "app-info-loc-1",
+			Locale: "en-US",
+			Name:   "X",
+		}},
+	}, false)
+	if !hasCheckID(report.Checks, "metadata.minimum.name") || !hasCheckID(report.Checks, "metadata.keywords.locale_duplicates") {
+		t.Fatalf("checks = %+v, want metadata quality warnings", report.Checks)
+	}
+	if report.Summary.Blocking != report.Summary.Errors {
+		t.Fatalf("summary = %+v, want warnings non-blocking without strict mode", report.Summary)
+	}
+
+	strictReport := Validate(Input{
+		VersionLocalizations: []VersionLocalization{{
+			ID:       "version-loc-1",
+			Locale:   "en-US",
+			Keywords: "alpha,alpha",
+		}},
+		AppInfoLocalizations: []AppInfoLocalization{{
+			ID:     "app-info-loc-1",
+			Locale: "en-US",
+			Name:   "X",
+		}},
+	}, true)
+	if strictReport.Summary.Blocking != strictReport.Summary.Errors+strictReport.Summary.Warnings {
+		t.Fatalf("strict summary = %+v, want warnings to block", strictReport.Summary)
+	}
+}
+
+func checkIDs(checks []CheckResult) []string {
+	ids := make([]string, 0, len(checks))
+	for _, check := range checks {
+		ids = append(ids, check.ID)
+	}
+	return ids
+}
+
+func equalStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/validation/report.go
+++ b/internal/validation/report.go
@@ -44,6 +44,7 @@ func Validate(input Input, strict bool) Report {
 	checks = append(checks, releaseChecks(input.ReleaseType, input.EarliestReleaseDate)...)
 	checks = append(checks, legalChecks(input.Copyright, activeMonetization, reviewRelevantSubscriptions, input.VersionLocalizations, input.AppInfoLocalizations)...)
 	checks = append(checks, contentChecks(input.VersionLocalizations, input.AppInfoLocalizations)...)
+	checks = append(checks, MetadataQualityChecks(input.VersionLocalizations, input.AppInfoLocalizations)...)
 	checks = append(checks, privacyPublishStateChecks(input.AppID)...)
 
 	summary := summarize(checks, strict)

--- a/scripts/generate-command-docs.py
+++ b/scripts/generate-command-docs.py
@@ -189,6 +189,7 @@ def render(usage: str, flags: list[tuple[str, str]], groups: list[tuple[str, lis
             "",
             "# Canonical readiness and lower-level submission lifecycle flow",
             "asc validate --app \"123456789\" --version \"1.2.3\"",
+            "asc validate --app \"123456789\" --version \"1.2.3\" --check-urls",
             "asc submit status --version-id \"VERSION_ID\"",
             "asc submit cancel --version-id \"VERSION_ID\" --confirm",
             "",

--- a/scripts/test_generate_command_docs.py
+++ b/scripts/test_generate_command_docs.py
@@ -72,5 +72,17 @@ class ParseHelpTests(unittest.TestCase):
         )
 
 
+class RenderTests(unittest.TestCase):
+    def test_validate_url_check_is_present_in_high_signal_examples(self) -> None:
+        rendered = generate_command_docs.render(
+            "asc <subcommand> [flags]", [], []
+        )
+
+        self.assertIn(
+            'asc validate --app "123456789" --version "1.2.3" --check-urls',
+            rendered,
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #2232

Adds deterministic metadata-quality warnings and opt-in bounded URL destination checks to `asc validate`. The existing metadata validator now reuses the extracted checker. URL findings are warning-only, generic/redacted, and appended to the existing report. Network requests are explicit, read-only, bounded, and restricted to public destinations.

Validation:
- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- focused unit, CLI, renderer, and race tests

No App Store Connect resources are mutated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added metadata quality warnings for short app names and problematic keywords.
  * Added experimental `--check-urls` validation for localized app-version and app-info links.
  * URL checks identify unsafe destinations, redirects, unavailable pages, and unexpected responses.

* **Behavior**
  * Metadata warnings appear in validation reports and can block validation in strict mode.
  * URL checking is opt-in, privacy-safe, and disabled by default.

* **Documentation**
  * Updated validation help and documentation with metadata checks and URL-checking guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->