### PR TITLE
feat(signing): add sync password rotation

### DIFF
--- a/commands/signing.mdx
+++ b/commands/signing.mdx
@@ -20,6 +20,7 @@ Apple code signing has four separate pieces:
 | Encrypt one app's signing assets and local private identity in Git | `asc signing sync push --bundle-id ...` |
 | Sync one shared identity across an app and its embedded targets | `asc signing sync push --targets-file ...` |
 | Decrypt signing assets on another machine or CI worker | `asc signing sync pull` |
+| Re-encrypt the repository with a replacement password | `asc signing sync rotate-password --confirm` |
 | Plan profiles for every target in an iOS archive and an exact device set | `asc signing reconcile plan` |
 | Apply an approved reconciliation plan | `asc signing reconcile apply --confirm` |
 | Run one release-testing command with a temporary keychain | `asc signing run` |
@@ -333,9 +334,43 @@ The normalized PKCS#12 is protected by the same sync password. A pull that repor
 
 Use `--password-file` for local work. In a secret-managed CI environment, `ASC_SIGNING_SYNC_PASSWORD` is also supported. The inline `--password` flag and `ASC_MATCH_PASSWORD` are deprecated during 4.x and will be rejected in 5.0.0.
 
+### Rotate the repository password
+
+Prepare the replacement secret in a separate protected file, distribute it to
+dependent machines and CI secret stores, and then rotate the selected branch:
+
+```bash  theme={null}
+umask 077
+printf '%s' "$SIGNING_SYNC_PASSWORD_NEXT" \
+  > ~/.config/asc/signing-sync-password-next
+
+asc signing sync rotate-password \
+  --repo git@github.com:team/signing.git \
+  --password-file ~/.config/asc/signing-sync-password \
+  --new-password-file ~/.config/asc/signing-sync-password-next \
+  --confirm \
+  --output json \
+  --pretty
+```
+
+The two password files must be distinct regular files with mode `0600` or more
+restrictive. Rotation does not accept inline passwords or environment
+fallbacks. The command authenticates and validates the complete repository
+with the current password, re-encrypts all artifacts with fresh salts and
+nonces, rewraps normalized PKCS#12 identities with the new password, validates
+the complete result again, and publishes one Git commit. A corrupt or
+inconsistent artifact aborts the operation before publication.
+
+Existing pulls that still use the previous password fail against the new branch
+head. Update every dependent worker promptly and keep the replacement password
+file out of source control and build artifacts. The rotation commit does not
+rewrite Git history: the previous password can still decrypt matching artifacts
+from older commits. If the password was exposed, also rotate repository access
+and follow your team's history-retention procedure.
+
 ### Current sync scope
 
-The encrypted store currently uses Git. Push applies one profile configuration and one identity across its selected targets; it does not accept per-target profile types or device sets. Pull decrypts the whole repository rather than selecting individual apps. Password rotation, certificate renewal, persistent keychain import, and stale-asset deletion remain explicit operator work.
+The encrypted store currently uses Git. Push applies one profile configuration and one identity across its selected targets; it does not accept per-target profile types or device sets. Pull decrypts the whole repository rather than selecting individual apps. Certificate renewal, persistent keychain import, and stale-asset deletion remain explicit operator work.
 
 ## CI example
 

--- a/docs/design/signing-sync-password-rotation.md
+++ b/docs/design/signing-sync-password-rotation.md
@@ -1,0 +1,85 @@
+# Signing sync password rotation
+
+## Problem
+
+The encrypted signing repository accepts a repository password when assets are
+pushed or pulled, but changing that password currently requires a manual
+decrypt-and-republish workflow. That workflow is easy to interrupt, can omit
+artifacts, and does not account for private identities whose normalized
+PKCS#12 payload is itself protected by the repository password.
+
+## Command
+
+Add a focused command:
+
+```bash
+asc signing sync rotate-password \
+  --repo git@github.com:team/certs.git \
+  --password-file ~/.config/asc/signing-sync-password \
+  --new-password-file ~/.config/asc/signing-sync-password-next \
+  --confirm
+```
+
+The command also accepts the existing `--branch` and output flags. Both secret
+files are required. They must be distinct protected regular files, and their
+resolved values must differ. The command does not accept inline passwords or
+environment fallbacks so that two long-lived secrets cannot be confused or
+exposed in process arguments.
+
+`--confirm` is required because a successful rotation makes the previous
+password unusable for the branch head. The operator must distribute the new
+secret before dependent jobs pull again.
+
+## Transaction boundary
+
+Rotation happens in one temporary clone and one Git commit:
+
+1. Validate flags and both protected password files before cloning.
+2. Clone the selected branch without creating it.
+3. Enumerate every encrypted artifact and apply the existing path, file-count,
+   cumulative-size, envelope, metadata, identity-context, profile-binding, and
+   certificate-validity checks using the current password.
+4. Re-encrypt every artifact with a fresh salt and nonce. Versioned artifacts
+   retain their authenticated metadata. Legacy artifacts retain their legacy
+   envelope so rotation does not silently change their format.
+5. Decode each normalized PKCS#12 identity with the current password and
+   re-encode it with the new password before encrypting its outer envelope.
+6. Re-read and validate the complete rewritten repository with the new
+   password.
+7. Commit and push all rewritten artifacts together.
+
+Any failure before the Git push discards the temporary clone. No partially
+rotated repository is published. Git branch protection or a concurrent remote
+update may reject the final push; the remote then remains unchanged.
+
+The commit changes the selected branch head; it does not rewrite Git history.
+Anyone who has the old password and access to an earlier commit may still
+decrypt those historical artifacts. A credential-compromise response must also
+rotate repository access and apply the team's history-retention policy.
+
+## Compatibility and output
+
+Existing `push` and `pull` behavior is unchanged. The rotation receipt uses the
+existing signing sync result shape with `operation: "rotate-password"`, the
+sanitized repository URL, the deterministic artifact list, and identity
+presence and sensitivity summaries. Passwords and decrypted bytes never appear
+in stdout, stderr, commit messages, or Git configuration.
+
+## Failure behavior
+
+- Invalid output options, missing required flags, unsafe password files, equal
+  passwords, and missing `--confirm` fail before clone or repository writes.
+- A wrong current password, corrupt artifact, invalid authenticated metadata,
+  stale active identity certificate, or inconsistent identity graph aborts the
+  entire rotation.
+- An empty encrypted repository succeeds without a commit and reports an empty
+  file list.
+- A failed final Git push is reported as an error and does not claim success.
+
+## Verification
+
+Focused coverage must prove flag validation order, protected-file handling,
+legacy and versioned artifact rotation, private-identity rewrapping, whole-store
+validation before mutation, new-password validation before publication, one
+commit containing every artifact, sanitized output, and current-password
+rejection after success.

--- a/internal/cli/signing/signing_sync.go
+++ b/internal/cli/signing/signing_sync.go
@@ -76,6 +76,7 @@ Examples:
 		Subcommands: []*ffcli.Command{
 			syncPushCommand(),
 			syncPullCommand(),
+			syncRotatePasswordCommand(),
 		},
 		Exec: func(ctx context.Context, args []string) error {
 			return flag.ErrHelp
@@ -613,42 +614,7 @@ func prepareDecryptedSigningFiles(store *signingpkg.GitStore, encryptedFiles []s
 }
 
 func prepareDecryptedSigningFilesInRoot(store *signingpkg.GitStore, encryptedFiles []string, password string, root rootfs.Root) ([]decryptedSigningFile, error) {
-	if len(encryptedFiles) > maxEncryptedSigningFiles {
-		return nil, fmt.Errorf("encrypted signing repository contains %d files; limit is %d", len(encryptedFiles), maxEncryptedSigningFiles)
-	}
-	if err := signingpkg.ValidateEncryptedRepositoryPaths(encryptedFiles); err != nil {
-		return nil, err
-	}
-	var cumulativeSize int64
-	for _, relPath := range encryptedFiles {
-		size, err := store.EncryptedFileSize(relPath)
-		if err != nil {
-			return nil, fmt.Errorf("inspect encrypted artifact %s: %w", relPath, err)
-		}
-		if size < 0 || size > maxEncryptedSigningBytes-cumulativeSize {
-			return nil, fmt.Errorf("encrypted signing repository exceeds the %d-byte cumulative size limit", maxEncryptedSigningBytes)
-		}
-		cumulativeSize += size
-	}
-	decrypted := make([]decryptedSigningFile, 0, len(encryptedFiles))
-	for _, relPath := range encryptedFiles {
-		plaintext, metadata, err := store.ReadEncryptedFileWithMetadata(relPath, password)
-		if err != nil {
-			return nil, fmt.Errorf("decrypt %s: %w", relPath, err)
-		}
-		sensitive, identity, err := classifySigningFile(relPath, plaintext, metadata, password)
-		if err != nil {
-			return nil, fmt.Errorf("validate %s: %w", relPath, err)
-		}
-		decrypted = append(decrypted, decryptedSigningFile{
-			RelativePath: relPath,
-			Plaintext:    plaintext,
-			Metadata:     metadata,
-			Sensitive:    sensitive,
-			Identity:     identity,
-		})
-	}
-	activeIdentityPaths, err := validateIdentityArtifactGraph(decrypted)
+	decrypted, activeIdentityPaths, err := loadAndValidateSigningFiles(store, encryptedFiles, password)
 	if err != nil {
 		return nil, err
 	}
@@ -658,13 +624,6 @@ func prepareDecryptedSigningFilesInRoot(store *signingpkg.GitStore, encryptedFil
 			canonicalPath := strings.ReplaceAll(filepath.ToSlash(file.RelativePath), `\`, "/")
 			if _, active := activeIdentityPaths[canonicalPath]; !active {
 				continue
-			}
-			_, certificate, err := modernpkcs12.Decode(file.Plaintext, password)
-			if err != nil || certificate == nil {
-				return nil, fmt.Errorf("active identity core is not a decodable PKCS#12 identity")
-			}
-			if now := time.Now(); now.Before(certificate.NotBefore) || !now.Before(certificate.NotAfter) {
-				return nil, fmt.Errorf("active identity certificate is not currently valid")
 			}
 		}
 		filtered = append(filtered, file)
@@ -682,6 +641,65 @@ func prepareDecryptedSigningFilesInRoot(store *signingpkg.GitStore, encryptedFil
 		}
 	}
 	return decrypted, nil
+}
+
+func loadAndValidateSigningFiles(store *signingpkg.GitStore, encryptedFiles []string, password string) ([]decryptedSigningFile, map[string]struct{}, error) {
+	if len(encryptedFiles) > maxEncryptedSigningFiles {
+		return nil, nil, fmt.Errorf("encrypted signing repository contains %d files; limit is %d", len(encryptedFiles), maxEncryptedSigningFiles)
+	}
+	if err := signingpkg.ValidateEncryptedRepositoryPaths(encryptedFiles); err != nil {
+		return nil, nil, err
+	}
+	var cumulativeSize int64
+	for _, relPath := range encryptedFiles {
+		size, err := store.EncryptedFileSize(relPath)
+		if err != nil {
+			return nil, nil, fmt.Errorf("inspect encrypted artifact %s: %w", relPath, err)
+		}
+		if size < 0 || size > maxEncryptedSigningBytes-cumulativeSize {
+			return nil, nil, fmt.Errorf("encrypted signing repository exceeds the %d-byte cumulative size limit", maxEncryptedSigningBytes)
+		}
+		cumulativeSize += size
+	}
+	decrypted := make([]decryptedSigningFile, 0, len(encryptedFiles))
+	for _, relPath := range encryptedFiles {
+		plaintext, metadata, err := store.ReadEncryptedFileWithMetadata(relPath, password)
+		if err != nil {
+			return nil, nil, fmt.Errorf("decrypt %s: %w", relPath, err)
+		}
+		sensitive, identity, err := classifySigningFile(relPath, plaintext, metadata, password)
+		if err != nil {
+			return nil, nil, fmt.Errorf("validate %s: %w", relPath, err)
+		}
+		decrypted = append(decrypted, decryptedSigningFile{
+			RelativePath: relPath,
+			Plaintext:    plaintext,
+			Metadata:     metadata,
+			Sensitive:    sensitive,
+			Identity:     identity,
+		})
+	}
+	activeIdentityPaths, err := validateIdentityArtifactGraph(decrypted)
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, file := range decrypted {
+		if file.Metadata.Kind != "pkcs12-identity" {
+			continue
+		}
+		canonicalPath := strings.ReplaceAll(filepath.ToSlash(file.RelativePath), `\`, "/")
+		if _, active := activeIdentityPaths[canonicalPath]; !active {
+			continue
+		}
+		_, certificate, err := modernpkcs12.Decode(file.Plaintext, password)
+		if err != nil || certificate == nil {
+			return nil, nil, fmt.Errorf("active identity core is not a decodable PKCS#12 identity")
+		}
+		if now := time.Now(); now.Before(certificate.NotBefore) || !now.Before(certificate.NotAfter) {
+			return nil, nil, fmt.Errorf("active identity certificate is not currently valid")
+		}
+	}
+	return decrypted, activeIdentityPaths, nil
 }
 
 func validateIdentityArtifactGraph(files []decryptedSigningFile) (map[string]struct{}, error) {

--- a/internal/cli/signing/signing_sync_password_rotation.go
+++ b/internal/cli/signing/signing_sync_password_rotation.go
@@ -1,0 +1,202 @@
+package signing
+
+import (
+	"context"
+	"crypto/subtle"
+	"flag"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	signingpkg "github.com/rudrankriyam/App-Store-Connect-CLI/internal/signing"
+	modernpkcs12 "software.sslmate.com/src/go-pkcs12"
+)
+
+func syncRotatePasswordCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("rotate-password", flag.ExitOnError)
+
+	repoURL := fs.String("repo", "", "Git repo URL (required)")
+	passwordFile := fs.String("password-file", "", "Protected file containing the current repository encryption password (required)")
+	newPasswordFile := fs.String("new-password-file", "", "Protected file containing the new repository encryption password (required)")
+	branch := fs.String("branch", "main", "Git branch")
+	confirm := fs.Bool("confirm", false, "Confirm that the previous password will no longer decrypt the branch head")
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "rotate-password",
+		ShortUsage: "asc signing sync rotate-password --repo URL --password-file PATH --new-password-file PATH --confirm",
+		ShortHelp:  "Re-encrypt every signing asset with a new repository password.",
+		LongHelp: `Re-encrypt every artifact in an encrypted signing Git repository.
+
+The complete repository is authenticated and validated with the current
+password before any local rewrite. Private PKCS#12 identities are rewrapped
+with the new password, the rewritten repository is validated again, and all
+artifacts are published in one Git commit.
+
+Both password files must be protected regular files with mode 0600 or more
+restrictive. Distribute the new secret before dependent jobs pull again.
+
+Example:
+  asc signing sync rotate-password --repo git@github.com:team/certs.git \
+    --password-file ~/.config/asc/signing-sync-password \
+    --new-password-file ~/.config/asc/signing-sync-password-next --confirm`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageErrorf("unexpected argument(s): %s", strings.Join(args, " "))
+			}
+			if _, err := shared.ValidateOutputFormat(*output.Output, *output.Pretty); err != nil {
+				return shared.UsageError(err.Error())
+			}
+
+			repo := strings.TrimSpace(*repoURL)
+			if repo == "" {
+				return shared.UsageError("--repo is required")
+			}
+			currentPath := strings.TrimSpace(*passwordFile)
+			if currentPath == "" {
+				return shared.UsageError("--password-file is required")
+			}
+			newPath := strings.TrimSpace(*newPasswordFile)
+			if newPath == "" {
+				return shared.UsageError("--new-password-file is required")
+			}
+			selectedBranch := strings.TrimSpace(*branch)
+			if selectedBranch == "" {
+				return shared.UsageError("--branch must not be empty")
+			}
+			if !*confirm {
+				return shared.UsageError("--confirm is required to rotate the signing sync password")
+			}
+
+			currentPassword, nextPassword, err := readSigningSyncRotationPasswords(currentPath, newPath)
+			if err != nil {
+				return err
+			}
+
+			tmpDir, err := os.MkdirTemp("", "asc-signing-sync-rotate-*")
+			if err != nil {
+				return fmt.Errorf("signing sync rotate-password: create temp dir: %w", err)
+			}
+			store := &signingpkg.GitStore{RepoURL: repo, LocalDir: tmpDir, Branch: selectedBranch}
+			defer func() { _ = store.Cleanup() }()
+
+			fmt.Fprintln(os.Stderr, "Cloning signing repo...")
+			if err := store.Clone(ctx, false); err != nil {
+				return fmt.Errorf("signing sync rotate-password: %w", err)
+			}
+			encryptedFiles, err := store.ListEncryptedFiles()
+			if err != nil {
+				return fmt.Errorf("signing sync rotate-password: list files: %w", err)
+			}
+			slices.Sort(encryptedFiles)
+			if len(encryptedFiles) == 0 {
+				fmt.Fprintln(os.Stderr, "No encrypted signing files found in repo")
+				return shared.PrintOutput(&SyncResult{
+					Operation: "rotate-password",
+					RepoURL:   sanitizeRepoURLForOutput(repo),
+					Files:     []string{},
+				}, *output.Output, *output.Pretty)
+			}
+
+			decrypted, _, err := loadAndValidateSigningFiles(store, encryptedFiles, currentPassword)
+			if err != nil {
+				return fmt.Errorf("signing sync rotate-password: %w", err)
+			}
+			if err := rewriteSigningFilesWithPassword(store, decrypted, currentPassword, nextPassword); err != nil {
+				return fmt.Errorf("signing sync rotate-password: %w", err)
+			}
+			rewritten, _, err := loadAndValidateSigningFiles(store, encryptedFiles, nextPassword)
+			if err != nil {
+				return fmt.Errorf("signing sync rotate-password: validate rewritten repository: %w", err)
+			}
+
+			fmt.Fprintln(os.Stderr, "Publishing rotated signing assets...")
+			if err := store.CommitAndPush(ctx, "Rotate signing sync password"); err != nil {
+				return fmt.Errorf("signing sync rotate-password: %w", err)
+			}
+
+			sensitiveFiles := make([]string, 0)
+			identityPresent := false
+			for _, file := range rewritten {
+				if file.Sensitive {
+					sensitiveFiles = append(sensitiveFiles, file.RelativePath)
+				}
+				identityPresent = identityPresent || file.Identity
+			}
+			fmt.Fprintf(os.Stderr, "Done — %d encrypted signing files rotated\n", len(encryptedFiles))
+			return shared.PrintOutput(&SyncResult{
+				Operation:       "rotate-password",
+				RepoURL:         sanitizeRepoURLForOutput(repo),
+				Files:           encryptedFiles,
+				IdentityPresent: identityPresent,
+				SensitiveFiles:  sensitiveFiles,
+			}, *output.Output, *output.Pretty)
+		},
+	}
+}
+
+func readSigningSyncRotationPasswords(currentPath, newPath string) (string, string, error) {
+	currentInfo, err := os.Stat(currentPath)
+	if err == nil {
+		if nextInfo, nextErr := os.Stat(newPath); nextErr == nil && os.SameFile(currentInfo, nextInfo) {
+			return "", "", shared.UsageError("--password-file and --new-password-file must identify different files")
+		}
+	}
+	currentData, err := readProtectedSecretFile(currentPath, "current signing sync password")
+	if err != nil {
+		return "", "", err
+	}
+	nextData, err := readProtectedSecretFile(newPath, "new signing sync password")
+	if err != nil {
+		return "", "", err
+	}
+	currentPassword := trimPasswordFileNewline(string(currentData))
+	if currentPassword == "" {
+		return "", "", shared.UsageError("current signing sync password file is empty")
+	}
+	nextPassword := trimPasswordFileNewline(string(nextData))
+	if nextPassword == "" {
+		return "", "", shared.UsageError("new signing sync password file is empty")
+	}
+	if subtle.ConstantTimeCompare([]byte(currentPassword), []byte(nextPassword)) == 1 {
+		return "", "", shared.UsageError("current and new signing sync passwords must differ")
+	}
+	return currentPassword, nextPassword, nil
+}
+
+func rewriteSigningFilesWithPassword(store *signingpkg.GitStore, files []decryptedSigningFile, currentPassword, newPassword string) error {
+	for _, file := range files {
+		plaintext := file.Plaintext
+		if file.Identity {
+			privateKey, certificate, err := modernpkcs12.Decode(plaintext, currentPassword)
+			if err != nil || certificate == nil {
+				return fmt.Errorf("rewrap %s: identity is not decodable with the current password", file.RelativePath)
+			}
+			plaintext, err = normalizeSigningIdentity(&signingIdentity{
+				PrivateKey:        privateKey,
+				Certificate:       certificate,
+				CertificateSHA256: signingCertificateSHA256(certificate),
+			}, newPassword)
+			if err != nil {
+				return fmt.Errorf("rewrap %s: %w", file.RelativePath, err)
+			}
+		}
+
+		var err error
+		if file.Metadata.Version == 0 {
+			err = store.ReplaceEncryptedFile(file.RelativePath, plaintext, newPassword)
+		} else {
+			err = store.ReplaceEncryptedFileWithMetadata(file.RelativePath, plaintext, newPassword, file.Metadata)
+		}
+		if err != nil {
+			return fmt.Errorf("reencrypt %s: %w", file.RelativePath, err)
+		}
+	}
+	return nil
+}

--- a/internal/cli/signing/signing_sync_password_rotation.go
+++ b/internal/cli/signing/signing_sync_password_rotation.go
@@ -19,11 +19,11 @@ import (
 func syncRotatePasswordCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("rotate-password", flag.ExitOnError)
 
-	repoURL := fs.String("repo", "", "Git repo URL (required)")
-	passwordFile := fs.String("password-file", "", "Protected file containing the current repository encryption password (required)")
-	newPasswordFile := fs.String("new-password-file", "", "Protected file containing the new repository encryption password (required)")
-	branch := fs.String("branch", "main", "Git branch")
-	confirm := fs.Bool("confirm", false, "Confirm that the previous password will no longer decrypt the branch head")
+	repoURL := fs.String("repo", "", "[experimental] Git repo URL (required)")
+	passwordFile := fs.String("password-file", "", "[experimental] Protected file containing the current repository encryption password (required)")
+	newPasswordFile := fs.String("new-password-file", "", "[experimental] Protected file containing the new repository encryption password (required)")
+	branch := fs.String("branch", "main", "[experimental] Git branch")
+	confirm := fs.Bool("confirm", false, "[experimental] Confirm that the previous password will no longer decrypt the branch head")
 	output := shared.BindOutputFlags(fs)
 
 	return &ffcli.Command{

--- a/internal/cli/signing/signing_sync_password_rotation_test.go
+++ b/internal/cli/signing/signing_sync_password_rotation_test.go
@@ -1,0 +1,247 @@
+package signing
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	signingpkg "github.com/rudrankriyam/App-Store-Connect-CLI/internal/signing"
+	modernpkcs12 "software.sslmate.com/src/go-pkcs12"
+)
+
+func TestSigningSyncCommandRegistersRotatePassword(t *testing.T) {
+	command := SigningSyncCommand()
+	for _, subcommand := range command.Subcommands {
+		if subcommand.Name == "rotate-password" {
+			return
+		}
+	}
+	t.Fatal("signing sync command does not register rotate-password")
+}
+
+func TestSigningSyncRotatePasswordRequiresConfirmBeforeSecretReads(t *testing.T) {
+	command := syncRotatePasswordCommand()
+	if err := command.Parse([]string{
+		"--repo", "file:///repository-that-must-not-be-cloned",
+		"--password-file", filepath.Join(t.TempDir(), "missing-current"),
+		"--new-password-file", filepath.Join(t.TempDir(), "missing-new"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	err := command.Run(context.Background())
+	if err == nil || err.Error() != "--confirm is required to rotate the signing sync password" {
+		t.Fatalf("error = %v, want confirmation usage error", err)
+	}
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("error = %v, want usage error", err)
+	}
+}
+
+func TestSigningSyncRotatePasswordRejectsEqualPasswordsBeforeClone(t *testing.T) {
+	currentPasswordFile := filepath.Join(t.TempDir(), "current")
+	newPasswordFile := filepath.Join(t.TempDir(), "next")
+	writePrivateTestFile(t, currentPasswordFile, []byte("same-password\n"))
+	writePrivateTestFile(t, newPasswordFile, []byte("same-password\n"))
+
+	command := syncRotatePasswordCommand()
+	if err := command.Parse([]string{
+		"--repo", "file:///repository-that-must-not-be-cloned",
+		"--password-file", currentPasswordFile,
+		"--new-password-file", newPasswordFile,
+		"--confirm",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		runErr = command.Run(context.Background())
+	})
+	if runErr == nil || runErr.Error() != "current and new signing sync passwords must differ" {
+		t.Fatalf("error = %v, want equal-password usage error", runErr)
+	}
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("error = %v, want usage error", runErr)
+	}
+	if stdout != "" || strings.Contains(stderr, "Cloning signing repo") {
+		t.Fatalf("unexpected output before validation: stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
+func TestSigningSyncRotatePasswordReencryptsCompleteRepositoryAndIdentity(t *testing.T) {
+	const oldPassword = "old-repository-password"
+	const newPassword = "new-repository-password"
+
+	remoteURL, remotePath := newSigningSyncBareRemote(t)
+	seedStore := &signingpkg.GitStore{
+		RepoURL:  remoteURL,
+		LocalDir: filepath.Join(t.TempDir(), "seed-clone"),
+		Branch:   "main",
+	}
+	if err := seedStore.Clone(context.Background(), false); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = seedStore.Cleanup() })
+
+	key := mustECKey(t)
+	certificate := mustSigningCertificate(t, key, 91)
+	identity := &signingIdentity{
+		PrivateKey:        key,
+		Certificate:       certificate,
+		CertificateSHA256: certificateSHA256(certificate),
+	}
+	artifacts, err := prepareSigningIdentityArtifacts(identity, oldPassword, "com.example.app", "IOS_APP_ADHOC")
+	if err != nil {
+		t.Fatal(err)
+	}
+	profilePath, profileContent := bindTestSigningIdentityArtifacts(t, artifacts, certificate, key, "com.example.app", "IOS_APP_ADHOC", "profile-rotation")
+	certificatePath := filepath.Join("certs", "distribution", "certificate.cer")
+	if err := seedStore.WriteEncryptedFile(certificatePath, certificate.Raw, oldPassword); err != nil {
+		t.Fatal(err)
+	}
+	if err := seedStore.WriteEncryptedFile(profilePath, profileContent, oldPassword); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeOrReuseSigningIdentityArtifacts(seedStore, artifacts, oldPassword); err != nil {
+		t.Fatal(err)
+	}
+	if err := seedStore.CommitAndPush(context.Background(), "seed encrypted signing assets"); err != nil {
+		t.Fatal(err)
+	}
+
+	currentPasswordFile := filepath.Join(t.TempDir(), "current")
+	newPasswordFile := filepath.Join(t.TempDir(), "next")
+	writePrivateTestFile(t, currentPasswordFile, []byte(oldPassword+"\n"))
+	writePrivateTestFile(t, newPasswordFile, []byte(newPassword+"\n"))
+
+	command := syncRotatePasswordCommand()
+	if err := command.Parse([]string{
+		"--repo", remoteURL,
+		"--password-file", currentPasswordFile,
+		"--new-password-file", newPasswordFile,
+		"--confirm",
+		"--output", "json",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		runErr = command.Run(context.Background())
+	})
+	if runErr != nil {
+		t.Fatalf("rotate-password error = %v\nstderr=%s", runErr, stderr)
+	}
+	var result SyncResult
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("decode output %q: %v", stdout, err)
+	}
+	if result.Operation != "rotate-password" || result.RepoURL != remoteURL || !result.IdentityPresent {
+		t.Fatalf("rotation result = %#v", result)
+	}
+	if len(result.Files) != 4 || len(result.SensitiveFiles) != 1 || result.SensitiveFiles[0] != artifacts.IdentityPath {
+		t.Fatalf("rotation files = %#v sensitive = %#v", result.Files, result.SensitiveFiles)
+	}
+
+	verifyStore := &signingpkg.GitStore{
+		RepoURL:  remoteURL,
+		LocalDir: filepath.Join(t.TempDir(), "verify-clone"),
+		Branch:   "main",
+	}
+	if err := verifyStore.Clone(context.Background(), false); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = verifyStore.Cleanup() })
+	encryptedFiles, err := verifyStore.ListEncryptedFiles()
+	if err != nil {
+		t.Fatal(err)
+	}
+	decrypted, err := prepareDecryptedSigningFiles(verifyStore, encryptedFiles, newPassword, t.TempDir())
+	if err != nil {
+		t.Fatalf("new password rejected: %v", err)
+	}
+	if _, _, err := verifyStore.ReadEncryptedFileWithMetadata(certificatePath, oldPassword); err == nil {
+		t.Fatal("old password still decrypts a rotated artifact")
+	}
+	legacyCertificate, certificateMetadata, err := verifyStore.ReadEncryptedFileWithMetadata(certificatePath, newPassword)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(legacyCertificate) != string(certificate.Raw) || certificateMetadata.Version != 0 {
+		t.Fatalf("legacy artifact changed format or content: metadata=%#v", certificateMetadata)
+	}
+
+	var identityPlaintext []byte
+	for _, file := range decrypted {
+		if file.RelativePath == artifacts.IdentityPath {
+			identityPlaintext = file.Plaintext
+			break
+		}
+	}
+	if len(identityPlaintext) == 0 {
+		t.Fatal("rotated identity is missing")
+	}
+	if _, _, err := modernpkcs12.Decode(identityPlaintext, newPassword); err != nil {
+		t.Fatalf("rotated identity does not use new password: %v", err)
+	}
+	if _, _, err := modernpkcs12.Decode(identityPlaintext, oldPassword); err == nil {
+		t.Fatal("rotated identity still uses old password")
+	}
+
+	if got := strings.TrimSpace(runGitCommand(t, remotePath, "rev-list", "--count", "main")); got != "3" {
+		t.Fatalf("commit count = %s, want seed README, encrypted assets, and one rotation commit", got)
+	}
+}
+
+func TestSigningSyncRotatePasswordDoesNotPublishWhenOneArtifactIsCorrupt(t *testing.T) {
+	const oldPassword = "old-repository-password"
+	const newPassword = "new-repository-password"
+
+	remoteURL, _ := newSigningSyncBareRemote(t)
+	seedStore := &signingpkg.GitStore{RepoURL: remoteURL, LocalDir: filepath.Join(t.TempDir(), "seed-clone"), Branch: "main"}
+	if err := seedStore.Clone(context.Background(), false); err != nil {
+		t.Fatal(err)
+	}
+	if err := seedStore.WriteEncryptedFile(filepath.Join("certs", "distribution", "valid.cer"), []byte("valid"), oldPassword); err != nil {
+		t.Fatal(err)
+	}
+	corruptPath := filepath.Join(seedStore.LocalDir, "profiles", "appstore", "corrupt.mobileprovision.enc")
+	if err := os.MkdirAll(filepath.Dir(corruptPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(corruptPath, []byte("corrupt"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := seedStore.CommitAndPush(context.Background(), "seed corrupt signing assets"); err != nil {
+		t.Fatal(err)
+	}
+	if err := seedStore.Cleanup(); err != nil {
+		t.Fatal(err)
+	}
+
+	currentPasswordFile := filepath.Join(t.TempDir(), "current")
+	newPasswordFile := filepath.Join(t.TempDir(), "next")
+	writePrivateTestFile(t, currentPasswordFile, []byte(oldPassword))
+	writePrivateTestFile(t, newPasswordFile, []byte(newPassword))
+	command := syncRotatePasswordCommand()
+	if err := command.Parse([]string{
+		"--repo", remoteURL,
+		"--password-file", currentPasswordFile,
+		"--new-password-file", newPasswordFile,
+		"--confirm",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := command.Run(context.Background()); err == nil || !strings.Contains(err.Error(), "decrypt profiles/appstore/corrupt.mobileprovision") {
+		t.Fatalf("error = %v, want corrupt-artifact failure", err)
+	}
+
+	verifyDir := t.TempDir()
+	runGitCommand(t, verifyDir, "clone", remoteURL, "clone")
+	if got := strings.TrimSpace(runGitCommand(t, filepath.Join(verifyDir, "clone"), "rev-list", "--count", "HEAD")); got != "2" {
+		t.Fatalf("commit count = %s, rotation published despite corrupt input", got)
+	}
+}

--- a/internal/cli/signing/signing_sync_password_rotation_test.go
+++ b/internal/cli/signing/signing_sync_password_rotation_test.go
@@ -24,6 +24,19 @@ func TestSigningSyncCommandRegistersRotatePassword(t *testing.T) {
 	t.Fatal("signing sync command does not register rotate-password")
 }
 
+func TestSigningSyncRotatePasswordFlagsAreExperimental(t *testing.T) {
+	command := syncRotatePasswordCommand()
+	for _, name := range []string{"repo", "password-file", "new-password-file", "branch", "confirm"} {
+		flagDefinition := command.FlagSet.Lookup(name)
+		if flagDefinition == nil {
+			t.Fatalf("missing --%s flag", name)
+		}
+		if !strings.Contains(flagDefinition.Usage, "[experimental]") {
+			t.Errorf("--%s usage = %q, want experimental lifecycle marker", name, flagDefinition.Usage)
+		}
+	}
+}
+
 func TestSigningSyncRotatePasswordRequiresConfirmBeforeSecretReads(t *testing.T) {
 	command := syncRotatePasswordCommand()
 	if err := command.Parse([]string{

--- a/internal/signing/gitstore.go
+++ b/internal/signing/gitstore.go
@@ -179,6 +179,23 @@ func (g *GitStore) WriteEncryptedFile(relPath string, plaintext []byte, password
 	return root.WriteFile(relPath+".enc", encrypted, 0o600)
 }
 
+// ReplaceEncryptedFile atomically creates or replaces a legacy encrypted
+// artifact while preserving its existing file mode when present.
+func (g *GitStore) ReplaceEncryptedFile(relPath string, plaintext []byte, password string) error {
+	if err := validateEncryptedRepositoryPath(filepath.ToSlash(relPath)); err != nil {
+		return err
+	}
+	encrypted, err := Encrypt(plaintext, password)
+	if err != nil {
+		return err
+	}
+	root, err := g.filesystemRoot()
+	if err != nil {
+		return err
+	}
+	return root.WriteFilePreservingMode(relPath+".enc", encrypted, 0o600)
+}
+
 // WriteEncryptedFileWithMetadata writes a versioned encrypted file whose
 // non-secret metadata is authenticated with the ciphertext.
 func (g *GitStore) WriteEncryptedFileWithMetadata(relPath string, plaintext []byte, password string, metadata EncryptedFileMetadata) error {
@@ -198,7 +215,7 @@ func (g *GitStore) WriteEncryptedFileWithMetadata(relPath string, plaintext []by
 }
 
 // ReplaceEncryptedFileWithMetadata atomically creates or replaces a versioned
-// encrypted non-secret index artifact after the caller has validated its scope.
+// encrypted artifact after the caller has validated its scope.
 func (g *GitStore) ReplaceEncryptedFileWithMetadata(relPath string, plaintext []byte, password string, metadata EncryptedFileMetadata) error {
 	if err := validateEncryptedRepositoryPath(filepath.ToSlash(relPath)); err != nil {
 		return err

--- a/internal/signing/gitstore.go
+++ b/internal/signing/gitstore.go
@@ -179,8 +179,10 @@ func (g *GitStore) WriteEncryptedFile(relPath string, plaintext []byte, password
 	return root.WriteFile(relPath+".enc", encrypted, 0o600)
 }
 
-// ReplaceEncryptedFile atomically creates or replaces a legacy encrypted
-// artifact while preserving its existing file mode when present.
+// ReplaceEncryptedFile creates or replaces a legacy encrypted artifact while
+// preserving its existing file mode when present. Replacement is atomic on
+// platforms where rename replaces an existing destination; on Windows, the
+// original is restored if publishing the replacement fails.
 func (g *GitStore) ReplaceEncryptedFile(relPath string, plaintext []byte, password string) error {
 	if err := validateEncryptedRepositoryPath(filepath.ToSlash(relPath)); err != nil {
 		return err


### PR DESCRIPTION
## What changed

- add `asc signing sync rotate-password` for complete encrypted-repository password rotation
- require separate protected current and replacement password files plus `--confirm`
- authenticate and validate every encrypted artifact before rewriting anything
- preserve legacy envelope format and authenticated metadata for versioned artifacts
- rewrap normalized PKCS#12 identities so both the identity and outer envelope use the replacement password
- validate the complete rewritten repository with the replacement password before publication
- publish all rewritten artifacts in one Git commit and report a sanitized structured receipt
- document distribution order, failure boundaries, and the fact that Git history is not rewritten

## Safety and compatibility

Existing push and pull behavior is unchanged. Validation, rewriting, and second-pass verification happen in a temporary clone. A corrupt artifact or wrong current password aborts before publication. The previous password cannot decrypt the new branch head after success, but older Git commits remain subject to repository history and access-retention policy.

## Validation

- focused RED-GREEN coverage for confirmation and secret validation
- local bare-Git integration covering legacy assets, versioned metadata, private-identity rewrapping, one-commit publication, and old-password rejection
- corrupt-artifact integration proving no rotation commit is published
- `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/signing ./internal/signing ./internal/asc -count=1`
- `ASC_BYPASS_KEYCHAIN=1 make format`
- `ASC_BYPASS_KEYCHAIN=1 make check-docs`
- `ASC_BYPASS_KEYCHAIN=1 make build`
- `ASC_BYPASS_KEYCHAIN=1 make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- built-binary help and missing-confirm exit/output behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the experimental `signing sync rotate-password` command for securely rotating encrypted repository passwords.
  * Re-encrypts signing artifacts and PKCS#12 identities, validates all content, and publishes changes in a single commit.
  * Requires confirmation and separate protected password files for the current and new passwords.
  * Prevents publication when validation or artifact decryption fails.

* **Documentation**
  * Added command usage details and design documentation for password rotation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->