### PR TITLE
Add persistent signing keychain installation

### DIFF
--- a/commands/signing.mdx
+++ b/commands/signing.mdx
@@ -465,12 +465,14 @@ workflow artifact.
   run: |
     set +x
     umask 077
-    password_file="$RUNNER_TEMP/asc-signing-password"
-    keychain_path="$RUNNER_TEMP/asc-release.keychain-db"
-    keychain_password_file="$RUNNER_TEMP/asc-release-keychain-password"
+    keychain_dir="$(mktemp -d "$RUNNER_TEMP/asc-signing.XXXXXX")"
+    password_file="$keychain_dir/repository-password"
+    keychain_path="$keychain_dir/release.keychain-db"
+    keychain_password_file="$keychain_dir/keychain-password"
     cleanup_signing() {
       /usr/bin/security delete-keychain "$keychain_path" >/dev/null 2>&1 || true
       rm -f "$password_file" "$keychain_password_file"
+      rmdir "$keychain_dir" >/dev/null 2>&1 || true
     }
     trap cleanup_signing EXIT
     printf '%s' "$SIGNING_SYNC_PASSWORD" > "$password_file"
@@ -526,8 +528,9 @@ For an App Store export, the profile loop reads exact paths from the pull
 receipt instead of guessing the repository layout. The identity lookup likewise
 uses the complete relative path from `sensitiveFiles` and requires exactly one
 pulled PKCS#12 identity. The generated keychain password is independent of the
-repository password, and the keychain intentionally persists through archive
-and export, then the shell cleanup trap removes it.
+repository password. The run-owned temporary directory ensures the cleanup trap
+cannot delete a pre-existing keychain when installation fails. The keychain
+intentionally persists through archive and export, then the trap removes it.
 
 Manual export inspects the archive and matches locally installed profiles for the main app and embedded targets. An explicit `--export-options` file is authoritative and cannot be combined with `--signing-style`, `--team-id`, or `--method`.
 

--- a/commands/signing.mdx
+++ b/commands/signing.mdx
@@ -23,6 +23,7 @@ Apple code signing has four separate pieces:
 | Plan profiles for every target in an iOS archive and an exact device set | `asc signing reconcile plan` |
 | Apply an approved reconciliation plan | `asc signing reconcile apply --confirm` |
 | Run one release-testing command with a temporary keychain | `asc signing run` |
+| Keep one identity in a new dedicated keychain | `asc signing keychain install --confirm` |
 
 Use `fetch` when the matching private key already exists on the machine. Use `sync` when a team or CI worker needs the private identity too. Use `reconcile` for multi-target, registered-device release testing where one stale or incomplete profile can break the whole export.
 
@@ -51,7 +52,8 @@ Private input files must be regular files, must not be symlinks, and must not be
 chmod 600 \
   ~/.config/asc/signing-sync-password \
   ./distribution.p12 \
-  ./distribution-p12-password
+  ./distribution-p12-password \
+  ./release-keychain-password
 ```
 
 Keep decrypted outputs and secrets out of source control:
@@ -333,6 +335,49 @@ The normalized PKCS#12 is protected by the same sync password. A pull that repor
 
 Use `--password-file` for local work. In a secret-managed CI environment, `ASC_SIGNING_SYNC_PASSWORD` is also supported. The inline `--password` flag and `ASC_MATCH_PASSWORD` are deprecated during 4.x and will be rejected in 5.0.0.
 
+### Install a persistent signing keychain
+
+Use `signing run` when an identity should exist only for one child command. Use
+`signing keychain install` when separate archive, export, or CI steps need one
+dedicated keychain to remain available:
+
+```bash  theme={null}
+mkdir -p .asc/keychains .asc/secrets
+chmod 700 .asc/keychains .asc/secrets
+
+asc signing keychain install \
+  --identity .asc/signing/pulled/identities/IDENTITY.p12 \
+  --identity-password-file ~/.config/asc/signing-sync-password \
+  --keychain .asc/keychains/release.keychain-db \
+  --keychain-password-file .asc/secrets/release-keychain-password \
+  --expected-certificate-sha256 CERTIFICATE_SHA256 \
+  --add-to-search-list \
+  --confirm \
+  --output json
+```
+
+The command is macOS-only and requires a cgo-enabled build. It decodes the
+PKCS#12, verifies the private key and currently valid code-signing certificate,
+and checks the optional SHA-256 fingerprint before creating anything. The
+destination must not exist. This keeps partition-list changes inside a new
+keychain rather than modifying unrelated identities in a login or shared
+keychain.
+
+Both passwords come from protected regular files and are never placed in
+subprocess arguments. The command deletes the new keychain if import,
+codesigning verification, or search-list activation fails. It does not change
+the default keychain. Without `--add-to-search-list`, it also removes any
+automatic search-list entry that the host creates.
+
+The JSON receipt contains the absolute keychain path, public certificate
+fingerprints, team ID, and whether the user search list changed. It never
+contains the identity source path or either password. The keychain persists on
+success; delete it explicitly when the job or machine no longer needs it.
+
+Provisioning profiles remain independent persistent assets. Install each
+profile with `asc profiles local install`, using the exact paths reported by
+`signing sync pull`.
+
 ### Current sync scope
 
 The encrypted store currently uses Git. Push applies one profile configuration and one identity across its selected targets; it does not accept per-target profile types or device sets. Pull decrypts the whole repository rather than selecting individual apps. Password rotation, certificate renewal, persistent keychain import, and stale-asset deletion remain explicit operator work.
@@ -362,7 +407,7 @@ The example below writes the repository password to a runner-private file withou
       --output json > .asc/signing/pull-result.json
 ```
 
-For an App Store export, install the pulled provisioning profiles and import the pulled identity into a job-scoped macOS keychain using your CI's keychain setup. Read the exact profile paths from the pull result instead of guessing the repository layout:
+For an App Store export, install the pulled provisioning profiles and put the pulled identity in a dedicated job-scoped macOS keychain. Read the exact paths from the pull result instead of guessing the repository layout:
 
 ```bash  theme={null}
 jq -r '.files[] | select(endswith(".mobileprovision"))' \
@@ -371,7 +416,28 @@ jq -r '.files[] | select(endswith(".mobileprovision"))' \
     asc profiles local install \
       --path ".asc/signing/pulled/$profile_path" \
       --output json
-  done
+done
+```
+
+Create the job keychain after writing a generated keychain password to a
+runner-private file. Add a cleanup trap before installation because the
+keychain intentionally persists after a successful command:
+
+```bash  theme={null}
+keychain_path="$RUNNER_TEMP/asc-release.keychain-db"
+keychain_password_file="$RUNNER_TEMP/asc-release-keychain-password"
+trap '/usr/bin/security delete-keychain "$keychain_path" >/dev/null 2>&1 || true; rm -f "$keychain_password_file"' EXIT
+umask 077
+openssl rand -base64 32 > "$keychain_password_file"
+
+asc signing keychain install \
+  --identity .asc/signing/pulled/identities/IDENTITY.p12 \
+  --identity-password-file "$password_file" \
+  --keychain "$keychain_path" \
+  --keychain-password-file "$keychain_password_file" \
+  --add-to-search-list \
+  --confirm \
+  --output json
 ```
 
 Then archive and export with manual signing when the project requires an exact local identity/profile match:

--- a/commands/signing.mdx
+++ b/commands/signing.mdx
@@ -53,8 +53,7 @@ Private input files must be regular files, must not be symlinks, and must not be
 chmod 600 \
   ~/.config/asc/signing-sync-password \
   ./distribution.p12 \
-  ./distribution-p12-password \
-  ./release-keychain-password
+  ./distribution-p12-password
 ```
 
 Keep decrypted outputs and secrets out of source control:
@@ -63,6 +62,7 @@ Keep decrypted outputs and secrets out of source control:
 .asc/secrets/
 .asc/signing/
 .asc/distribution/
+.asc/keychains/
 ```
 
 ## Set up the bundle ID and capabilities
@@ -348,6 +348,12 @@ dedicated keychain to remain available:
 mkdir -p .asc/keychains .asc/secrets
 chmod 700 .asc/keychains .asc/secrets
 
+keychain_password_file=.asc/secrets/release-keychain-password
+if [ ! -e "$keychain_password_file" ]; then
+  (umask 077 && openssl rand -base64 48 > "$keychain_password_file")
+fi
+chmod 600 "$keychain_password_file"
+
 identity_path="$(
   jq -er '
     [.sensitiveFiles[]? | select(endswith(".p12"))]
@@ -361,7 +367,7 @@ asc signing keychain install \
   --identity ".asc/signing/pulled/$identity_path" \
   --identity-password-file ~/.config/asc/signing-sync-password \
   --keychain .asc/keychains/release.keychain-db \
-  --keychain-password-file .asc/secrets/release-keychain-password \
+  --keychain-password-file "$keychain_password_file" \
   --expected-certificate-sha256 CERTIFICATE_SHA256 \
   --add-to-search-list \
   --confirm \

--- a/commands/signing.mdx
+++ b/commands/signing.mdx
@@ -346,8 +346,17 @@ dedicated keychain to remain available:
 mkdir -p .asc/keychains .asc/secrets
 chmod 700 .asc/keychains .asc/secrets
 
+identity_path="$(
+  jq -er '
+    [.sensitiveFiles[]? | select(endswith(".p12"))]
+    | if length == 1 then .[0]
+      else error("expected exactly one signing identity")
+      end
+  ' .asc/signing/pull-result.json
+)"
+
 asc signing keychain install \
-  --identity .asc/signing/pulled/identities/IDENTITY.p12 \
+  --identity ".asc/signing/pulled/$identity_path" \
   --identity-password-file ~/.config/asc/signing-sync-password \
   --keychain .asc/keychains/release.keychain-db \
   --keychain-password-file .asc/secrets/release-keychain-password \
@@ -472,6 +481,15 @@ workflow artifact.
       --output-dir .asc/signing/pulled \
       --output json > .asc/signing/pull-result.json
 
+    identity_path="$(
+      jq -er '
+        [.sensitiveFiles[]? | select(endswith(".p12"))]
+        | if length == 1 then .[0]
+          else error("expected exactly one signing identity")
+          end
+      ' .asc/signing/pull-result.json
+    )"
+
     jq -r '.files[] | select(endswith(".mobileprovision"))' \
       .asc/signing/pull-result.json \
     | while IFS= read -r profile_path; do
@@ -482,7 +500,7 @@ workflow artifact.
 
     openssl rand -base64 32 > "$keychain_password_file"
     asc signing keychain install \
-      --identity .asc/signing/pulled/identities/IDENTITY.p12 \
+      --identity ".asc/signing/pulled/$identity_path" \
       --identity-password-file "$password_file" \
       --keychain "$keychain_path" \
       --keychain-password-file "$keychain_password_file" \
@@ -503,10 +521,11 @@ workflow artifact.
 ```
 
 For an App Store export, the profile loop reads exact paths from the pull
-receipt instead of guessing the repository layout. Replace `IDENTITY.p12` with
-the identity path reported in `sensitiveFiles`. The generated keychain password
-is independent of the repository password, and the keychain intentionally
-persists through archive and export, then the shell cleanup trap removes it.
+receipt instead of guessing the repository layout. The identity lookup likewise
+uses the complete relative path from `sensitiveFiles` and requires exactly one
+pulled PKCS#12 identity. The generated keychain password is independent of the
+repository password, and the keychain intentionally persists through archive
+and export, then the shell cleanup trap removes it.
 
 Manual export inspects the archive and matches locally installed profiles for the main app and embedded targets. An explicit `--export-options` file is authoritative and cannot be combined with `--signing-style`, `--team-id`, or `--method`.
 

--- a/commands/signing.mdx
+++ b/commands/signing.mdx
@@ -378,8 +378,11 @@ keychain.
 Both passwords come from protected regular files and are never placed in
 subprocess arguments. The command deletes the new keychain if import,
 codesigning verification, or search-list activation fails. It does not change
-the default keychain. Without `--add-to-search-list`, it also removes any
-automatic search-list entry that the host creates.
+the default keychain. Before creation it snapshots the user search list and
+restores that exact snapshot after any later failure, including when the
+destination had a stale entry. Without `--add-to-search-list`, a successful
+install removes any automatic or stale destination entry so the new keychain
+remains isolated.
 
 The JSON receipt contains the absolute keychain path, public certificate
 fingerprints, team ID, and whether the user search list changed. It never

--- a/commands/signing.mdx
+++ b/commands/signing.mdx
@@ -433,28 +433,24 @@ workflow artifact.
       --add-to-search-list \
       --confirm \
       --output json
+
+    asc xcode archive \
+      --workspace Example.xcworkspace \
+      --scheme Example \
+      --archive-path .asc/artifacts/Example.xcarchive
+
+    asc xcode export \
+      --archive-path .asc/artifacts/Example.xcarchive \
+      --ipa-path .asc/artifacts/Example.ipa \
+      --signing-style manual \
+      --team-id TEAM_ID
 ```
 
 For an App Store export, the profile loop reads exact paths from the pull
 receipt instead of guessing the repository layout. Replace `IDENTITY.p12` with
 the identity path reported in `sensitiveFiles`. The generated keychain password
 is independent of the repository password, and the keychain intentionally
-persists until the job-level cleanup trap runs.
-
-Then archive and export with manual signing when the project requires an exact local identity/profile match:
-
-```bash  theme={null}
-asc xcode archive \
-  --workspace Example.xcworkspace \
-  --scheme Example \
-  --archive-path .asc/artifacts/Example.xcarchive
-
-asc xcode export \
-  --archive-path .asc/artifacts/Example.xcarchive \
-  --ipa-path .asc/artifacts/Example.ipa \
-  --signing-style manual \
-  --team-id TEAM_ID
-```
+persists through archive and export, then the shell cleanup trap removes it.
 
 Manual export inspects the archive and matches locally installed profiles for the main app and embedded targets. An explicit `--export-options` file is authoritative and cannot be combined with `--signing-style`, `--team-id`, or `--method`.
 

--- a/commands/signing.mdx
+++ b/commands/signing.mdx
@@ -24,7 +24,7 @@ Apple code signing has four separate pieces:
 | Plan profiles for every target in an iOS archive and an exact device set | `asc signing reconcile plan` |
 | Apply an approved reconciliation plan | `asc signing reconcile apply --confirm` |
 | Run one release-testing command with a temporary keychain | `asc signing run` |
-| Keep one identity in a new dedicated keychain | `asc signing keychain install --confirm` |
+| Keep one identity in a new dedicated keychain (experimental) | `asc signing keychain install --confirm` |
 
 Use `fetch` when the matching private key already exists on the machine. Use `sync` when a team or CI worker needs the private identity too. Use `reconcile` for multi-target, registered-device release testing where one stale or incomplete profile can break the whole export.
 
@@ -337,6 +337,8 @@ The normalized PKCS#12 is protected by the same sync password. A pull that repor
 Use `--password-file` for local work. In a secret-managed CI environment, `ASC_SIGNING_SYNC_PASSWORD` is also supported. The inline `--password` flag and `ASC_MATCH_PASSWORD` are deprecated during 4.x and will be rejected in 5.0.0.
 
 ### Install a persistent signing keychain
+
+> [experimental] This workflow can change before it reaches stable lifecycle status.
 
 Use `signing run` when an identity should exist only for one child command. Use
 `signing keychain install` when separate archive, export, or CI steps need one

--- a/commands/signing.mdx
+++ b/commands/signing.mdx
@@ -384,7 +384,11 @@ The encrypted store currently uses Git. Push applies one profile configuration a
 
 ## CI example
 
-The example below writes the repository password to a runner-private file without enabling shell tracing, pulls the encrypted assets, and removes the password file after use. Do not upload `.asc/signing/pulled` as a workflow artifact.
+The example below keeps all secret-file, profile-installation, and keychain
+steps in one shell process. The repository password therefore remains
+available through identity installation, and one trap removes both password
+files and the persistent job keychain. Do not upload `.asc/signing/pulled` as a
+workflow artifact.
 
 ```yaml  theme={null}
 - name: Pull signing assets
@@ -395,7 +399,13 @@ The example below writes the repository password to a runner-private file withou
     set +x
     umask 077
     password_file="$RUNNER_TEMP/asc-signing-password"
-    trap 'rm -f "$password_file"' EXIT
+    keychain_path="$RUNNER_TEMP/asc-release.keychain-db"
+    keychain_password_file="$RUNNER_TEMP/asc-release-keychain-password"
+    cleanup_signing() {
+      /usr/bin/security delete-keychain "$keychain_path" >/dev/null 2>&1 || true
+      rm -f "$password_file" "$keychain_password_file"
+    }
+    trap cleanup_signing EXIT
     printf '%s' "$SIGNING_SYNC_PASSWORD" > "$password_file"
     mkdir -p .asc/signing
     chmod 700 .asc/signing
@@ -405,40 +415,31 @@ The example below writes the repository password to a runner-private file withou
       --password-file "$password_file" \
       --output-dir .asc/signing/pulled \
       --output json > .asc/signing/pull-result.json
-```
 
-For an App Store export, install the pulled provisioning profiles and put the pulled identity in a dedicated job-scoped macOS keychain. Read the exact paths from the pull result instead of guessing the repository layout:
+    jq -r '.files[] | select(endswith(".mobileprovision"))' \
+      .asc/signing/pull-result.json \
+    | while IFS= read -r profile_path; do
+        asc profiles local install \
+          --path ".asc/signing/pulled/$profile_path" \
+          --output json
+      done
 
-```bash  theme={null}
-jq -r '.files[] | select(endswith(".mobileprovision"))' \
-  .asc/signing/pull-result.json \
-| while IFS= read -r profile_path; do
-    asc profiles local install \
-      --path ".asc/signing/pulled/$profile_path" \
+    openssl rand -base64 32 > "$keychain_password_file"
+    asc signing keychain install \
+      --identity .asc/signing/pulled/identities/IDENTITY.p12 \
+      --identity-password-file "$password_file" \
+      --keychain "$keychain_path" \
+      --keychain-password-file "$keychain_password_file" \
+      --add-to-search-list \
+      --confirm \
       --output json
-done
 ```
 
-Create the job keychain after writing a generated keychain password to a
-runner-private file. Add a cleanup trap before installation because the
-keychain intentionally persists after a successful command:
-
-```bash  theme={null}
-keychain_path="$RUNNER_TEMP/asc-release.keychain-db"
-keychain_password_file="$RUNNER_TEMP/asc-release-keychain-password"
-trap '/usr/bin/security delete-keychain "$keychain_path" >/dev/null 2>&1 || true; rm -f "$keychain_password_file"' EXIT
-umask 077
-openssl rand -base64 32 > "$keychain_password_file"
-
-asc signing keychain install \
-  --identity .asc/signing/pulled/identities/IDENTITY.p12 \
-  --identity-password-file "$password_file" \
-  --keychain "$keychain_path" \
-  --keychain-password-file "$keychain_password_file" \
-  --add-to-search-list \
-  --confirm \
-  --output json
-```
+For an App Store export, the profile loop reads exact paths from the pull
+receipt instead of guessing the repository layout. Replace `IDENTITY.p12` with
+the identity path reported in `sensitiveFiles`. The generated keychain password
+is independent of the repository password, and the keychain intentionally
+persists until the job-level cleanup trap runs.
 
 Then archive and export with manual signing when the project requires an exact local identity/profile match:
 

--- a/docs/design/signing-keychain-install.md
+++ b/docs/design/signing-keychain-install.md
@@ -65,7 +65,10 @@ rollback fail, both errors are returned. Rollback uses an independent bounded
 context, so cancellation of the initiating command does not prevent keychain
 deletion or search-list restoration. The same rule applies when cancellation
 interrupts initial keychain configuration before the outer installer can mark
-creation complete.
+creation complete. Keychain creation and unlocking are separate checked stages;
+an unlock failure deletes the newly created destination through the same
+Security framework keychain reference before returning. A cleanup failure is
+joined with the unlock failure.
 
 The command does not delete, replace, or merge an existing keychain. It does
 not install provisioning profiles; use `asc profiles local install` for that
@@ -140,9 +143,12 @@ private input handling, certificate checks, exact output fields, destination
 refusal, search-list isolation and activation, shared-lock ordering,
 independent-context rollback after cancellation, exact search-list restoration,
 rollback error propagation, configuration-failure cleanup after cancellation,
-and probe isolation from the destination directory. Darwin coverage accepts a
-leaf certificate plus its chain while rejecting a missing or duplicated leaf.
-cgo-disabled, Linux, and Windows compile paths verify the platform guard.
+and probe isolation from the destination directory. The Darwin Security
+framework wrapper deletes the just-created keychain through its retained
+reference when unlocking fails and reports any cleanup error alongside the
+unlock error. Darwin coverage accepts a leaf certificate plus its chain while
+rejecting a missing or duplicated leaf. cgo-disabled, Linux, and Windows
+compile paths verify the platform guard.
 
 A gated macOS integration test creates a disposable keychain, imports a real
 test PKCS#12 identity, runs the codesign probe, confirms search-list activation,

--- a/docs/design/signing-keychain-install.md
+++ b/docs/design/signing-keychain-install.md
@@ -38,6 +38,11 @@ in a subprocess argument. `--confirm` is required because the keychain remains
 on disk after the process exits. `--add-to-search-list` is explicit and
 preserves the existing user search-list order.
 
+The operation shares the signing-environment lock used by `asc signing run`.
+Keychain creation, import, verification, and the complete search-list
+transaction are serialized so one command cannot replace another command's
+new search-list entry with a stale snapshot.
+
 An optional `--expected-certificate-sha256` binds the operation to a known
 certificate. The PKCS#12 is decoded and checked for a matching private key,
 current certificate validity, code-signing usage, and the expected digest
@@ -51,7 +56,9 @@ list failure triggers deletion of the new keychain and restoration of the
 original search list. A host-created automatic search-list entry is removed
 immediately when `--add-to-search-list` is absent; explicit activation is the
 last operation when the flag is present. If both the primary operation and
-rollback fail, both errors are returned.
+rollback fail, both errors are returned. Rollback uses an independent bounded
+context, so cancellation of the initiating command does not prevent keychain
+deletion or search-list restoration.
 
 The command does not delete, replace, or merge an existing keychain. It does
 not install provisioning profiles; use `asc profiles local install` for that
@@ -75,9 +82,72 @@ JSON output is a computed result with only public information:
 Human-readable renderers expose the same fields. Source identity paths and all
 password material are omitted.
 
+## Alternatives and trade-offs
+
+Import into the login or another existing keychain was rejected because a
+partition-list update can affect unrelated private keys and because rollback
+cannot safely restore an arbitrary shared keychain. Reusing `asc signing run`
+was rejected for archive and export pipelines split across multiple commands:
+its keychain is intentionally deleted when its one child process exits.
+Passing passwords to `/usr/bin/security` as arguments was rejected because
+process listings can expose them. The Security framework handles creation and
+PKCS#12 import, while the one utility operation that needs the keychain
+password receives it on stdin.
+
+The dedicated-keychain approach consumes one explicit path and password file,
+and the operator owns successful-run cleanup. In exchange, it provides a
+bounded mutation surface, deterministic rollback, and a receipt that can be
+passed between CI steps without secret material.
+
+## Edge cases and failure modes
+
+The destination parent must resolve to an existing trusted directory, and the
+destination file must not exist. Symlinked or multiply linked secret inputs,
+weak input permissions, empty passwords, malformed PKCS#12 data, missing
+private-key binding, expired or not-yet-valid certificates, non-code-signing
+certificates, fingerprint mismatches, import failures, unusable identities,
+and search-list failures all stop the operation. A PKCS#12 certificate chain is
+allowed, but the inspected leaf certificate must appear exactly once after
+import.
+
+Concurrent signing commands wait on the shared lock. Cancellation while
+waiting returns without mutation. Cancellation after creation triggers the
+same independent-context rollback as any other post-creation failure.
+
 ## Compatibility
 
 The command is additive and macOS-only. It requires a cgo-enabled build so the
 Security framework can create the keychain and import PKCS#12 data without
 putting passwords in process arguments. Other platforms return a validation
 error without reading secrets or creating files.
+
+It does not call App Store Connect, change a project, create a Git commit, or
+push a repository. The only persistent successful-run changes are the new
+keychain file and, when requested, one user search-list entry. Provisioning
+profile installation remains a separate explicit command.
+
+## Validation and live verification
+
+Unit coverage verifies command validation, experimental lifecycle markers,
+private input handling, certificate checks, exact output fields, destination
+refusal, search-list isolation and activation, shared-lock ordering,
+independent-context rollback after cancellation, exact search-list restoration,
+and rollback error propagation. Darwin coverage accepts a leaf certificate
+plus its chain while rejecting a missing or duplicated leaf. cgo-disabled,
+Linux, and Windows compile paths verify the platform guard.
+
+A gated macOS integration test creates a disposable keychain, imports a real
+test PKCS#12 identity, runs the codesign probe, confirms search-list activation,
+removes the entry, deletes the keychain, and proves the original search list is
+restored. Repository formatting, documentation, build, lint, and full tests run
+before each push. The built CLI is also checked for exit 2 and empty stdout
+when `--confirm` is missing.
+
+## Unresolved risks
+
+Successful installation is intentionally persistent. A terminated runner that
+does not execute its outer cleanup can leave the dedicated keychain on disk;
+CI must install a trap before invoking the command. The command verifies local
+import and codesign usability but cannot prove a later archive, export, or
+remote signing service will accept the identity. It also does not rotate or
+delete previously installed persistent keychains.

--- a/docs/design/signing-keychain-install.md
+++ b/docs/design/signing-keychain-install.md
@@ -56,16 +56,19 @@ write and cleanup scope.
 ## Failure and rollback contract
 
 All input, destination, and output-format validation happens before the first
-side effect. Once creation succeeds, any later import, verification, or search
-list failure triggers deletion of the new keychain and restoration of the
-original search list. A host-created automatic search-list entry is removed
-immediately when `--add-to-search-list` is absent; explicit activation is the
-last operation when the flag is present. If both the primary operation and
-rollback fail, both errors are returned. Rollback uses an independent bounded
-context, so cancellation of the initiating command does not prevent keychain
-deletion or search-list restoration. The same rule applies when cancellation
-interrupts initial keychain configuration before the outer installer can mark
-creation complete. On macOS, SIGINT, SIGTERM, and SIGHUP cancel the initiating
+side effect. The user search list is snapshotted before keychain creation in
+both activation modes. Once creation succeeds, any later import, verification,
+isolation, or search-list failure triggers deletion of the new keychain and
+restoration of that exact snapshot, including a stale destination entry that
+existed before the destination file did. A host-created automatic or stale
+destination entry is removed immediately when `--add-to-search-list` is absent;
+explicit activation is the last operation when the flag is present. If both
+the primary operation and rollback fail, both errors are returned. Rollback
+uses an independent bounded context, so cancellation of the initiating command
+does not prevent keychain deletion or search-list restoration. The same rule
+applies when cancellation interrupts initial keychain configuration before the
+outer installer can mark creation complete. On macOS, SIGINT, SIGTERM, and
+SIGHUP cancel the initiating
 context so termination follows this rollback path. Keychain creation and
 unlocking are separate checked stages;
 an unlock failure deletes the newly created destination through the same

--- a/docs/design/signing-keychain-install.md
+++ b/docs/design/signing-keychain-install.md
@@ -48,6 +48,11 @@ certificate. The PKCS#12 is decoded and checked for a matching private key,
 current certificate validity, code-signing usage, and the expected digest
 before the keychain is created.
 
+The final codesign usability probe is copied into an ASC-owned private
+temporary directory, never the operator-selected keychain directory. An
+existing file beside the destination keychain is therefore outside the probe's
+write and cleanup scope.
+
 ## Failure and rollback contract
 
 All input, destination, and output-format validation happens before the first
@@ -58,7 +63,9 @@ immediately when `--add-to-search-list` is absent; explicit activation is the
 last operation when the flag is present. If both the primary operation and
 rollback fail, both errors are returned. Rollback uses an independent bounded
 context, so cancellation of the initiating command does not prevent keychain
-deletion or search-list restoration.
+deletion or search-list restoration. The same rule applies when cancellation
+interrupts initial keychain configuration before the outer installer can mark
+creation complete.
 
 The command does not delete, replace, or merge an existing keychain. It does
 not install provisioning profiles; use `asc profiles local install` for that
@@ -132,9 +139,10 @@ Unit coverage verifies command validation, experimental lifecycle markers,
 private input handling, certificate checks, exact output fields, destination
 refusal, search-list isolation and activation, shared-lock ordering,
 independent-context rollback after cancellation, exact search-list restoration,
-and rollback error propagation. Darwin coverage accepts a leaf certificate
-plus its chain while rejecting a missing or duplicated leaf. cgo-disabled,
-Linux, and Windows compile paths verify the platform guard.
+rollback error propagation, configuration-failure cleanup after cancellation,
+and probe isolation from the destination directory. Darwin coverage accepts a
+leaf certificate plus its chain while rejecting a missing or duplicated leaf.
+cgo-disabled, Linux, and Windows compile paths verify the platform guard.
 
 A gated macOS integration test creates a disposable keychain, imports a real
 test PKCS#12 identity, runs the codesign probe, confirms search-list activation,

--- a/docs/design/signing-keychain-install.md
+++ b/docs/design/signing-keychain-install.md
@@ -1,0 +1,83 @@
+# Persistent signing keychain installation
+
+## Status
+
+Proposed for 4.12.0 as an experimental command.
+
+## Problem
+
+`asc signing run` already creates an isolated temporary keychain, installs one
+identity for a child process, and removes the keychain afterward. Provisioning
+profiles already have a separate persistent installer under
+`asc profiles local install`. There is no equivalent non-interactive path for
+keeping a private signing identity in a dedicated keychain across commands or
+CI steps.
+
+## Decision
+
+Add:
+
+```bash
+asc signing keychain install \
+  --identity .asc/signing/App.p12 \
+  --identity-password-file .asc/secrets/p12-password \
+  --keychain .asc/keychains/release.keychain-db \
+  --keychain-password-file .asc/secrets/keychain-password \
+  --add-to-search-list \
+  --confirm
+```
+
+The command creates one new, dedicated keychain and imports exactly one
+currently valid code-signing identity. It never imports into an existing
+keychain. Refusing an existing destination avoids changing unrelated keys and
+keeps the partition-list update scoped to the newly created identity.
+
+The keychain and PKCS#12 passwords come only from protected regular files.
+Neither secret is accepted directly as a flag, included in output, or placed
+in a subprocess argument. `--confirm` is required because the keychain remains
+on disk after the process exits. `--add-to-search-list` is explicit and
+preserves the existing user search-list order.
+
+An optional `--expected-certificate-sha256` binds the operation to a known
+certificate. The PKCS#12 is decoded and checked for a matching private key,
+current certificate validity, code-signing usage, and the expected digest
+before the keychain is created.
+
+## Failure and rollback contract
+
+All input, destination, and output-format validation happens before the first
+side effect. Once creation succeeds, any later import, verification, or search
+list failure triggers deletion of the new keychain and restoration of the
+original search list. A host-created automatic search-list entry is removed
+immediately when `--add-to-search-list` is absent; explicit activation is the
+last operation when the flag is present. If both the primary operation and
+rollback fail, both errors are returned.
+
+The command does not delete, replace, or merge an existing keychain. It does
+not install provisioning profiles; use `asc profiles local install` for that
+independent persistent operation. It does not change the default keychain.
+
+## Output
+
+JSON output is a computed result with only public information:
+
+```json
+{
+  "action": "installed",
+  "keychainPath": "/absolute/path/release.keychain-db",
+  "certificateSha256": "...",
+  "certificateSha1": "...",
+  "teamId": "TEAM12345",
+  "searchListUpdated": true
+}
+```
+
+Human-readable renderers expose the same fields. Source identity paths and all
+password material are omitted.
+
+## Compatibility
+
+The command is additive and macOS-only. It requires a cgo-enabled build so the
+Security framework can create the keychain and import PKCS#12 data without
+putting passwords in process arguments. Other platforms return a validation
+error without reading secrets or creating files.

--- a/docs/design/signing-keychain-install.md
+++ b/docs/design/signing-keychain-install.md
@@ -65,7 +65,9 @@ rollback fail, both errors are returned. Rollback uses an independent bounded
 context, so cancellation of the initiating command does not prevent keychain
 deletion or search-list restoration. The same rule applies when cancellation
 interrupts initial keychain configuration before the outer installer can mark
-creation complete. Keychain creation and unlocking are separate checked stages;
+creation complete. On macOS, SIGINT, SIGTERM, and SIGHUP cancel the initiating
+context so termination follows this rollback path. Keychain creation and
+unlocking are separate checked stages;
 an unlock failure deletes the newly created destination through the same
 Security framework keychain reference before returning. A cleanup failure is
 joined with the unlock failure.

--- a/guides/code-signing.mdx
+++ b/guides/code-signing.mdx
@@ -172,6 +172,14 @@ PKCS#12 into a new dedicated keychain when separate archive and export commands
 need the identity to persist:
 
 ```bash  theme={null}
+identity_path="$(
+  jq -er '
+    [.sensitiveFiles[]? | select(endswith(".p12"))]
+    | if length == 1 then .[0]
+      else error("expected exactly one signing identity")
+      end
+  ' .asc/signing/pull-result.json
+)"
 keychain_path="$RUNNER_TEMP/asc-release.keychain-db"
 keychain_password_file="$RUNNER_TEMP/asc-release-keychain-password"
 cleanup_signing() {
@@ -182,7 +190,7 @@ trap cleanup_signing EXIT
 openssl rand -base64 32 > "$keychain_password_file"
 
 asc signing keychain install \
-  --identity .asc/signing/pulled/identities/distribution/IDENTITY.p12 \
+  --identity ".asc/signing/pulled/$identity_path" \
   --identity-password-file "$password_file" \
   --keychain "$keychain_path" \
   --keychain-password-file "$keychain_password_file" \
@@ -199,8 +207,9 @@ jq -r '.files[] | select(endswith(".mobileprovision"))' \
   done
 ```
 
-Replace `IDENTITY.p12` with the identity path reported in `sensitiveFiles`.
-The identity password is the encrypted-repository password because sync
+The receipt supplies the identity's complete relative path. This example
+requires exactly one pulled PKCS#12 identity and stops if that invariant is not
+met. The identity password is the encrypted-repository password because sync
 normalizes the pulled PKCS#12 under that secret. The keychain password is a
 separate generated secret. The install command is macOS-only, requires a
 cgo-enabled build, refuses an existing destination, and rolls back the new

--- a/guides/code-signing.mdx
+++ b/guides/code-signing.mdx
@@ -167,9 +167,50 @@ asc signing sync pull \
   --output json > .asc/signing/pull-result.json
 ```
 
-The result lists private identities under `sensitiveFiles`. Import the pulled PKCS#12 into a job-scoped macOS keychain using the CI runner's keychain setup, install each profile with `asc profiles local install`, then archive and export. Do not upload the decrypted directory.
+The result lists private identities under `sensitiveFiles`. Install the pulled
+PKCS#12 into a new dedicated keychain when separate archive and export commands
+need the identity to persist:
 
-`asc` does not currently perform a persistent App Store identity import. Its temporary-keychain command is intentionally limited to registered-device release testing.
+```bash  theme={null}
+keychain_path="$RUNNER_TEMP/asc-release.keychain-db"
+keychain_password_file="$RUNNER_TEMP/asc-release-keychain-password"
+cleanup_signing() {
+  /usr/bin/security delete-keychain "$keychain_path" >/dev/null 2>&1 || true
+  rm -f "$password_file" "$keychain_password_file"
+}
+trap cleanup_signing EXIT
+openssl rand -base64 32 > "$keychain_password_file"
+
+asc signing keychain install \
+  --identity .asc/signing/pulled/identities/distribution/IDENTITY.p12 \
+  --identity-password-file "$password_file" \
+  --keychain "$keychain_path" \
+  --keychain-password-file "$keychain_password_file" \
+  --add-to-search-list \
+  --confirm \
+  --output json
+
+jq -r '.files[] | select(endswith(".mobileprovision"))' \
+  .asc/signing/pull-result.json \
+| while IFS= read -r profile_path; do
+    asc profiles local install \
+      --path ".asc/signing/pulled/$profile_path" \
+      --output json
+  done
+```
+
+Replace `IDENTITY.p12` with the identity path reported in `sensitiveFiles`.
+The identity password is the encrypted-repository password because sync
+normalizes the pulled PKCS#12 under that secret. The keychain password is a
+separate generated secret. The install command is macOS-only, requires a
+cgo-enabled build, refuses an existing destination, and rolls back the new
+keychain if import, codesigning verification, or search-list activation fails.
+It does not change the default keychain.
+
+The keychain remains available after the command succeeds. Keep archive and
+export inside the lifetime of the cleanup trap on disposable CI workers; for a
+long-lived machine, omit the trap only when the dedicated keychain is intended
+to remain. Do not upload the decrypted directory, password files, or keychain.
 
 ## Registered-device release testing
 
@@ -225,10 +266,10 @@ asc signing run \
 
 `signing run` accepts iOS ad hoc profiles with registered devices. It rejects App Store, development, enterprise, macOS, and tvOS profiles.
 
-For an archive with extensions, App Clips, Watch apps, or other embedded targets, don't use this single-profile wrapper for export. On a disposable macOS worker, import the identity into a job-scoped keychain, install each completed profile action's `outputPath` from `.asc/distribution/signing/apply-result.json`, export, and discard the worker state when the job ends.
+For an archive with extensions, App Clips, Watch apps, or other embedded targets, don't use this single-profile wrapper for export. On a disposable macOS worker, use `asc signing keychain install` for the job-scoped identity, install each completed profile action's `outputPath` from `.asc/distribution/signing/apply-result.json`, export, and discard the worker state when the job ends.
 
 ## What the encrypted store does not do
 
-The current store uses Git and pulls the whole repository. It does not rotate the repository password, renew certificates, delete stale assets, assign different settings per target, or import an App Store identity into a persistent keychain. Treat those as separate reviewed operations.
+The current store uses Git. It does not renew certificates, delete stale encrypted assets, assign different settings per target, or manage the later lifecycle of installed persistent keychains. Treat those as separate reviewed operations.
 
 Read the [signing command reference](/commands/signing) before the first live push; it includes file-permission rules, exact output fields, failure boundaries, profile maintenance, and recovery behavior.

--- a/guides/code-signing.mdx
+++ b/guides/code-signing.mdx
@@ -154,8 +154,13 @@ Write the repository password from the CI secret manager to a runner-private fil
 ```bash  theme={null}
 set +x
 umask 077
-password_file="$RUNNER_TEMP/asc-signing-password"
-trap 'rm -f "$password_file"' EXIT
+signing_tmp="$(mktemp -d "$RUNNER_TEMP/asc-signing.XXXXXX")"
+password_file="$signing_tmp/repository-password"
+cleanup_signing_pull() {
+  rm -f "$password_file"
+  rmdir "$signing_tmp" >/dev/null 2>&1 || true
+}
+trap cleanup_signing_pull EXIT
 printf '%s' "$SIGNING_SYNC_PASSWORD" > "$password_file"
 mkdir -p .asc/signing
 chmod 700 .asc/signing
@@ -182,11 +187,12 @@ identity_path="$(
       end
   ' .asc/signing/pull-result.json
 )"
-keychain_path="$RUNNER_TEMP/asc-release.keychain-db"
-keychain_password_file="$RUNNER_TEMP/asc-release-keychain-password"
+keychain_path="$signing_tmp/release.keychain-db"
+keychain_password_file="$signing_tmp/keychain-password"
 cleanup_signing() {
   /usr/bin/security delete-keychain "$keychain_path" >/dev/null 2>&1 || true
   rm -f "$password_file" "$keychain_password_file"
+  rmdir "$signing_tmp" >/dev/null 2>&1 || true
 }
 trap cleanup_signing EXIT
 openssl rand -base64 32 > "$keychain_password_file"
@@ -216,7 +222,9 @@ normalizes the pulled PKCS#12 under that secret. The keychain password is a
 separate generated secret. The install command is macOS-only, requires a
 cgo-enabled build, refuses an existing destination, and rolls back the new
 keychain if import, codesigning verification, or search-list activation fails.
-It does not change the default keychain.
+It does not change the default keychain. The run-owned temporary directory
+ensures the cleanup trap cannot delete a pre-existing keychain if installation
+fails.
 
 The keychain remains available after the command succeeds. Keep archive and
 export inside the lifetime of the cleanup trap on disposable CI workers; for a

--- a/guides/code-signing.mdx
+++ b/guides/code-signing.mdx
@@ -171,6 +171,8 @@ The result lists private identities under `sensitiveFiles`. Install the pulled
 PKCS#12 into a new dedicated keychain when separate archive and export commands
 need the identity to persist:
 
+> [experimental] Persistent keychain installation can change before it reaches stable lifecycle status.
+
 ```bash  theme={null}
 identity_path="$(
   jq -er '

--- a/internal/asc/output_registry_init.go
+++ b/internal/asc/output_registry_init.go
@@ -523,6 +523,7 @@ func registerAllOutputRenderers() {
 	registerRows(profileDownloadResultRows)
 	registerRows(signingFetchResultRows)
 	registerRows(signingSyncRows)
+	registerRows(signingKeychainInstallRows)
 	registerRows(xcodeTestResultRows)
 	registerRows(xcodeCloudRunResultRows)
 	registerRows(xcodeCloudStatusResultRows)

--- a/internal/asc/output_signing_keychain.go
+++ b/internal/asc/output_signing_keychain.go
@@ -1,0 +1,27 @@
+package asc
+
+// SigningKeychainInstallResult is the public, non-secret receipt for a
+// persistent signing keychain installation.
+type SigningKeychainInstallResult struct {
+	Action            string `json:"action"`
+	KeychainPath      string `json:"keychainPath"`
+	CertificateSHA256 string `json:"certificateSha256"`
+	CertificateSHA1   string `json:"certificateSha1"`
+	TeamID            string `json:"teamId"`
+	SearchListUpdated bool   `json:"searchListUpdated"`
+}
+
+func signingKeychainInstallRows(result *SigningKeychainInstallResult) ([]string, [][]string) {
+	headers := []string{"Action", "Keychain Path", "Certificate SHA-256", "Certificate SHA-1", "Team ID", "Search List Updated"}
+	if result == nil {
+		return headers, nil
+	}
+	return headers, [][]string{{
+		result.Action,
+		result.KeychainPath,
+		result.CertificateSHA256,
+		result.CertificateSHA1,
+		result.TeamID,
+		formatBool(result.SearchListUpdated),
+	}}
+}

--- a/internal/asc/output_signing_keychain_test.go
+++ b/internal/asc/output_signing_keychain_test.go
@@ -1,0 +1,57 @@
+package asc
+
+import (
+	"encoding/json"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestSigningKeychainInstallResultJSONContainsOnlyPublicReceiptFields(t *testing.T) {
+	result := &SigningKeychainInstallResult{
+		Action:            "installed",
+		KeychainPath:      "/tmp/release.keychain-db",
+		CertificateSHA256: strings.Repeat("A", 64),
+		CertificateSHA1:   strings.Repeat("B", 40),
+		TeamID:            "TEAM12345",
+		SearchListUpdated: true,
+	}
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	wantKeys := []string{"action", "certificateSha1", "certificateSha256", "keychainPath", "searchListUpdated", "teamId"}
+	got := make([]string, 0, len(decoded))
+	for key := range decoded {
+		got = append(got, key)
+	}
+	sort.Strings(got)
+	if !slices.Equal(got, wantKeys) {
+		t.Fatalf("keys = %v, want %v", got, wantKeys)
+	}
+}
+
+func TestSigningKeychainInstallResultRendererRegistered(t *testing.T) {
+	ensureOutputRegistryPopulated()
+	handler := requireOutputHandlerFor[SigningKeychainInstallResult](t, "SigningKeychainInstallResult")
+	result := &SigningKeychainInstallResult{
+		Action:            "installed",
+		KeychainPath:      "/tmp/release.keychain-db",
+		CertificateSHA256: strings.Repeat("A", 64),
+		CertificateSHA1:   strings.Repeat("B", 40),
+		TeamID:            "TEAM12345",
+		SearchListUpdated: true,
+	}
+	headers, rows, err := handler(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSingleRowEquals(t, headers, rows,
+		[]string{"Action", "Keychain Path", "Certificate SHA-256", "Certificate SHA-1", "Team ID", "Search List Updated"},
+		[]string{"installed", "/tmp/release.keychain-db", strings.Repeat("A", 64), strings.Repeat("B", 40), "TEAM12345", "true"})
+}

--- a/internal/cli/signing/signing.go
+++ b/internal/cli/signing/signing.go
@@ -20,6 +20,7 @@ func SigningCommand() *ffcli.Command {
 
 Examples:
   asc signing fetch --bundle-id com.example.app --profile-type IOS_APP_STORE --output ./signing
+  asc signing keychain install --identity ./signing/App.p12 --identity-password-file ./secrets/p12-password --keychain ./keychains/release.keychain-db --keychain-password-file ./secrets/keychain-password --confirm
   asc signing reconcile plan --archive-path .asc/artifacts/App.xcarchive --devices-file .asc/distribution/devices.json
   asc signing run --identity ./signing/App.p12 --profile ./signing/App.mobileprovision -- xcodebuild -exportArchive
   asc signing sync push --bundle-id com.example.app --profile-type IOS_APP_STORE --repo git@github.com:team/certs.git
@@ -28,6 +29,7 @@ Examples:
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
 			SigningFetchCommand(),
+			SigningKeychainCommand(),
 			SigningReconcileCommand(),
 			SigningRunCommand(),
 			SigningSyncCommand(),

--- a/internal/cli/signing/signing_keychain.go
+++ b/internal/cli/signing/signing_keychain.go
@@ -32,6 +32,7 @@ type signingKeychainInstallDeps struct {
 	GOOS                      string
 	SecurityAvailable         bool
 	Now                       func() time.Time
+	AcquireLock               func(context.Context) (func() error, error)
 	CreateKeychain            func(context.Context, string, []byte) error
 	ImportIdentity            func(context.Context, string, []byte, []byte, []byte, string) error
 	KeychainSearchList        func(context.Context) ([]string, error)
@@ -145,7 +146,7 @@ func executeSigningKeychainInstall(ctx context.Context, options signingKeychainI
 	return executeSigningKeychainInstallWith(ctx, options, platformSigningKeychainInstallDeps())
 }
 
-func executeSigningKeychainInstallWith(ctx context.Context, options signingKeychainInstallOptions, deps signingKeychainInstallDeps) (*asc.SigningKeychainInstallResult, error) {
+func executeSigningKeychainInstallWith(ctx context.Context, options signingKeychainInstallOptions, deps signingKeychainInstallDeps) (result *asc.SigningKeychainInstallResult, resultErr error) {
 	if deps.GOOS != "darwin" {
 		return nil, shared.NewValidationError(fmt.Errorf("signing keychain install is supported only on macOS"))
 	}
@@ -208,6 +209,18 @@ func executeSigningKeychainInstallWith(ctx context.Context, options signingKeych
 	if err != nil {
 		return nil, fmt.Errorf("signing keychain install: inspect identity: %w", err)
 	}
+	unlock, err := deps.AcquireLock(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("signing keychain install: acquire signing environment lock: %w", err)
+	}
+	defer func() {
+		if unlock == nil {
+			return
+		}
+		if err := unlock(); err != nil {
+			resultErr = errors.Join(resultErr, fmt.Errorf("signing keychain install: release signing environment lock: %w", err))
+		}
+	}()
 	var originalSearchList []string
 	searchListHadPath := false
 	if options.AddToSearchList {
@@ -224,16 +237,18 @@ func executeSigningKeychainInstallWith(ctx context.Context, options signingKeych
 		if !created {
 			return primary
 		}
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
 		var cleanupErr error
-		if err := deps.DeleteKeychain(ctx, resolvedKeychainPath); err != nil {
+		if err := deps.DeleteKeychain(cleanupCtx, resolvedKeychainPath); err != nil {
 			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("delete keychain: %w", err))
 		}
 		if options.AddToSearchList {
-			if err := deps.SetKeychainSearchList(ctx, originalSearchList); err != nil {
+			if err := deps.SetKeychainSearchList(cleanupCtx, originalSearchList); err != nil {
 				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("restore keychain search list: %w", err))
 			}
 		} else if deps.RemoveKeychainSearchEntry != nil {
-			if err := deps.RemoveKeychainSearchEntry(ctx, resolvedKeychainPath); err != nil {
+			if err := deps.RemoveKeychainSearchEntry(cleanupCtx, resolvedKeychainPath); err != nil {
 				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("remove keychain search-list entry: %w", err))
 			}
 		}
@@ -275,7 +290,7 @@ func executeSigningKeychainInstallWith(ctx context.Context, options signingKeych
 }
 
 func requireSigningKeychainInstallDeps(deps signingKeychainInstallDeps, addToSearchList bool) error {
-	if deps.CreateKeychain == nil || deps.ImportIdentity == nil || deps.DeleteKeychain == nil {
+	if deps.AcquireLock == nil || deps.CreateKeychain == nil || deps.ImportIdentity == nil || deps.DeleteKeychain == nil {
 		return fmt.Errorf("signing keychain install: platform keychain operations are unavailable")
 	}
 	if addToSearchList && (deps.KeychainSearchList == nil || deps.SetKeychainSearchList == nil) {

--- a/internal/cli/signing/signing_keychain.go
+++ b/internal/cli/signing/signing_keychain.go
@@ -273,6 +273,9 @@ func executeSigningKeychainInstallWith(ctx context.Context, options signingKeych
 		}
 		searchListUpdated = true
 	}
+	if err := ctx.Err(); err != nil {
+		return nil, rollback(fmt.Errorf("signing keychain install: %w", err))
+	}
 
 	return &asc.SigningKeychainInstallResult{
 		Action:            "installed",

--- a/internal/cli/signing/signing_keychain.go
+++ b/internal/cli/signing/signing_keychain.go
@@ -41,7 +41,10 @@ type signingKeychainInstallDeps struct {
 	DeleteKeychain            func(context.Context, string) error
 }
 
-var installSigningKeychainFn = executeSigningKeychainInstall
+var (
+	installSigningKeychainFn      = executeSigningKeychainInstall
+	signingKeychainInstallContext = platformSigningRunContext
+)
 
 // SigningKeychainCommand returns the signing keychain command group.
 func SigningKeychainCommand() *ffcli.Command {
@@ -118,7 +121,9 @@ Examples:
 			if !*confirm {
 				return shared.UsageError("--confirm is required to create a persistent signing keychain")
 			}
-			result, err := installSigningKeychainFn(ctx, signingKeychainInstallOptions{
+			installCtx, stopSignals := signingKeychainInstallContext(ctx)
+			defer stopSignals()
+			result, err := installSigningKeychainFn(installCtx, signingKeychainInstallOptions{
 				IdentityPath:              identity,
 				IdentityPasswordPath:      identityPassword,
 				KeychainPath:              keychain,

--- a/internal/cli/signing/signing_keychain.go
+++ b/internal/cli/signing/signing_keychain.go
@@ -1,0 +1,334 @@
+package signing
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"errors"
+	"flag"
+	"fmt"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
+)
+
+type signingKeychainInstallOptions struct {
+	IdentityPath              string
+	IdentityPasswordPath      string
+	KeychainPath              string
+	KeychainPasswordPath      string
+	ExpectedCertificateSHA256 string
+	AddToSearchList           bool
+}
+
+type signingKeychainInstallDeps struct {
+	GOOS                      string
+	SecurityAvailable         bool
+	Now                       func() time.Time
+	CreateKeychain            func(context.Context, string, []byte) error
+	ImportIdentity            func(context.Context, string, []byte, []byte, []byte, string) error
+	KeychainSearchList        func(context.Context) ([]string, error)
+	SetKeychainSearchList     func(context.Context, []string) error
+	RemoveKeychainSearchEntry func(context.Context, string) error
+	DeleteKeychain            func(context.Context, string) error
+}
+
+var installSigningKeychainFn = executeSigningKeychainInstall
+
+// SigningKeychainCommand returns the signing keychain command group.
+func SigningKeychainCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("keychain", flag.ExitOnError)
+	return &ffcli.Command{
+		Name:        "keychain",
+		ShortUsage:  "asc signing keychain <subcommand> [flags]",
+		ShortHelp:   "[experimental] Manage dedicated local signing keychains.",
+		LongHelp:    "[experimental] Manage dedicated local signing keychains without changing the default keychain.",
+		FlagSet:     fs,
+		UsageFunc:   shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{SigningKeychainInstallCommand()},
+		Exec: func(context.Context, []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+// SigningKeychainInstallCommand returns the persistent keychain installer.
+func SigningKeychainInstallCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("install", flag.ExitOnError)
+	identityPath := fs.String("identity", "", "[experimental] Path to one PKCS#12 code-signing identity (required)")
+	identityPasswordPath := fs.String("identity-password-file", "", "[experimental] Protected file containing the PKCS#12 password (required)")
+	keychainPath := fs.String("keychain", "", "[experimental] New dedicated keychain path (required)")
+	keychainPasswordPath := fs.String("keychain-password-file", "", "[experimental] Protected file containing the new keychain password (required)")
+	expectedCertificateSHA256 := fs.String("expected-certificate-sha256", "", "[experimental] Expected identity certificate SHA-256")
+	addToSearchList := fs.Bool("add-to-search-list", false, "[experimental] Append the new keychain to the user search list")
+	confirm := fs.Bool("confirm", false, "[experimental] Confirm persistent keychain creation")
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "install",
+		ShortUsage: "asc signing keychain install --identity PATH --identity-password-file PATH --keychain PATH --keychain-password-file PATH --confirm [flags]",
+		ShortHelp:  "[experimental] Install one identity in a new persistent keychain.",
+		LongHelp: `[experimental] Create a dedicated persistent keychain and import one code-signing identity.
+
+The destination must not exist. Identity and keychain passwords are read from
+protected files and are never placed in command arguments. The command rolls
+back the new keychain if import, verification, or search-list activation fails.
+Provisioning profiles remain a separate operation under profiles local install.
+
+Examples:
+  asc signing keychain install --identity .asc/signing/App.p12 --identity-password-file .asc/secrets/p12-password --keychain .asc/keychains/release.keychain-db --keychain-password-file .asc/secrets/keychain-password --confirm
+  asc signing keychain install --identity .asc/signing/App.p12 --identity-password-file .asc/secrets/p12-password --keychain .asc/keychains/release.keychain-db --keychain-password-file .asc/secrets/keychain-password --expected-certificate-sha256 CERTIFICATE_SHA256 --add-to-search-list --confirm --output json`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageErrorf("unexpected argument(s): %s", strings.Join(args, " "))
+			}
+			if _, err := shared.ValidateOutputFormat(*output.Output, *output.Pretty); err != nil {
+				return shared.UsageError(err.Error())
+			}
+			identity := strings.TrimSpace(*identityPath)
+			if identity == "" {
+				return shared.UsageError("--identity is required")
+			}
+			identityPassword := strings.TrimSpace(*identityPasswordPath)
+			if identityPassword == "" {
+				return shared.UsageError("--identity-password-file is required")
+			}
+			keychain := strings.TrimSpace(*keychainPath)
+			if keychain == "" {
+				return shared.UsageError("--keychain is required")
+			}
+			keychainPassword := strings.TrimSpace(*keychainPasswordPath)
+			if keychainPassword == "" {
+				return shared.UsageError("--keychain-password-file is required")
+			}
+			expectedDigest, err := normalizeOptionalSigningKeychainSHA256(*expectedCertificateSHA256)
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
+			if !*confirm {
+				return shared.UsageError("--confirm is required to create a persistent signing keychain")
+			}
+			result, err := installSigningKeychainFn(ctx, signingKeychainInstallOptions{
+				IdentityPath:              identity,
+				IdentityPasswordPath:      identityPassword,
+				KeychainPath:              keychain,
+				KeychainPasswordPath:      keychainPassword,
+				ExpectedCertificateSHA256: expectedDigest,
+				AddToSearchList:           *addToSearchList,
+			})
+			if err != nil {
+				return err
+			}
+			return shared.PrintOutput(result, *output.Output, *output.Pretty)
+		},
+	}
+}
+
+func normalizeOptionalSigningKeychainSHA256(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", nil
+	}
+	return normalizeSigningRunExpectedSHA256(value, "expected certificate SHA-256")
+}
+
+func executeSigningKeychainInstall(ctx context.Context, options signingKeychainInstallOptions) (*asc.SigningKeychainInstallResult, error) {
+	return executeSigningKeychainInstallWith(ctx, options, platformSigningKeychainInstallDeps())
+}
+
+func executeSigningKeychainInstallWith(ctx context.Context, options signingKeychainInstallOptions, deps signingKeychainInstallDeps) (*asc.SigningKeychainInstallResult, error) {
+	if deps.GOOS != "darwin" {
+		return nil, shared.NewValidationError(fmt.Errorf("signing keychain install is supported only on macOS"))
+	}
+	if !deps.SecurityAvailable {
+		return nil, shared.NewValidationError(fmt.Errorf("signing keychain install requires a cgo-enabled macOS build"))
+	}
+	if ctx == nil {
+		return nil, shared.NewValidationError(fmt.Errorf("signing keychain install: context is required"))
+	}
+	resolvedKeychainPath, err := preflightSigningKeychainPath(options.KeychainPath)
+	if err != nil {
+		return nil, fmt.Errorf("signing keychain install: preflight destination: %w", err)
+	}
+	if err := requireSigningKeychainInstallDeps(deps, options.AddToSearchList); err != nil {
+		return nil, err
+	}
+	identityData, err := readBoundedSigningRunFile(options.IdentityPath, signingRunInputLimit, true)
+	if err != nil {
+		return nil, fmt.Errorf("signing keychain install: read identity: %w", err)
+	}
+	defer clear(identityData)
+	identityPasswordData, err := readBoundedSigningRunFile(options.IdentityPasswordPath, signingRunPasswordLimit, true)
+	if err != nil {
+		return nil, fmt.Errorf("signing keychain install: read identity password: %w", err)
+	}
+	defer clear(identityPasswordData)
+	keychainPasswordData, err := readBoundedSigningRunFile(options.KeychainPasswordPath, signingRunPasswordLimit, true)
+	if err != nil {
+		return nil, fmt.Errorf("signing keychain install: read keychain password: %w", err)
+	}
+	defer clear(keychainPasswordData)
+
+	identityPassword := trimSigningKeychainSecret(identityPasswordData)
+	keychainPassword := trimSigningKeychainSecret(keychainPasswordData)
+	if len(identityPassword) == 0 {
+		return nil, shared.NewValidationError(fmt.Errorf("signing keychain install: identity password is empty"))
+	}
+	if len(keychainPassword) == 0 {
+		return nil, shared.NewValidationError(fmt.Errorf("signing keychain install: keychain password is empty"))
+	}
+	if bytes.ContainsAny(keychainPassword, "\r\n\x00") {
+		return nil, shared.NewValidationError(fmt.Errorf("signing keychain install: keychain password must not contain line breaks or NUL bytes"))
+	}
+
+	now := time.Now
+	if deps.Now != nil {
+		now = deps.Now
+	}
+	identity, err := inspectSigningRunIdentity(identityData, identityPassword, now())
+	if err != nil {
+		return nil, fmt.Errorf("signing keychain install: inspect identity: %w", err)
+	}
+	if err := validateSigningKeychainCertificate(identity.Certificate); err != nil {
+		return nil, fmt.Errorf("signing keychain install: inspect identity: %w", err)
+	}
+	if options.ExpectedCertificateSHA256 != "" && !strings.EqualFold(options.ExpectedCertificateSHA256, identity.CertificateSHA256) {
+		return nil, shared.NewValidationError(fmt.Errorf("signing keychain install: identity certificate does not match --expected-certificate-sha256"))
+	}
+	teamID, err := signingRunCertificateTeamID(identity.Certificate)
+	if err != nil {
+		return nil, fmt.Errorf("signing keychain install: inspect identity: %w", err)
+	}
+	var originalSearchList []string
+	searchListHadPath := false
+	if options.AddToSearchList {
+		originalSearchList, err = deps.KeychainSearchList(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("signing keychain install: read keychain search list: %w", err)
+		}
+		originalSearchList = append([]string(nil), originalSearchList...)
+		searchListHadPath = slices.Contains(originalSearchList, resolvedKeychainPath)
+	}
+
+	created := false
+	rollback := func(primary error) error {
+		if !created {
+			return primary
+		}
+		var cleanupErr error
+		if err := deps.DeleteKeychain(ctx, resolvedKeychainPath); err != nil {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("delete keychain: %w", err))
+		}
+		if options.AddToSearchList {
+			if err := deps.SetKeychainSearchList(ctx, originalSearchList); err != nil {
+				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("restore keychain search list: %w", err))
+			}
+		} else if deps.RemoveKeychainSearchEntry != nil {
+			if err := deps.RemoveKeychainSearchEntry(ctx, resolvedKeychainPath); err != nil {
+				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("remove keychain search-list entry: %w", err))
+			}
+		}
+		if cleanupErr != nil {
+			return errors.Join(primary, fmt.Errorf("signing keychain install: rollback new keychain: %w", cleanupErr))
+		}
+		return primary
+	}
+	if err := deps.CreateKeychain(ctx, resolvedKeychainPath, keychainPassword); err != nil {
+		return nil, fmt.Errorf("signing keychain install: create keychain: %w", err)
+	}
+	created = true
+	if !options.AddToSearchList {
+		if err := deps.RemoveKeychainSearchEntry(ctx, resolvedKeychainPath); err != nil {
+			return nil, rollback(fmt.Errorf("signing keychain install: isolate keychain: %w", err))
+		}
+	}
+	if err := deps.ImportIdentity(ctx, resolvedKeychainPath, keychainPassword, identityData, identityPassword, identity.CertificateSHA1); err != nil {
+		return nil, rollback(fmt.Errorf("signing keychain install: import identity: %w", err))
+	}
+
+	searchListUpdated := false
+	if options.AddToSearchList && !searchListHadPath {
+		paths := append(originalSearchList, resolvedKeychainPath)
+		if err := deps.SetKeychainSearchList(ctx, paths); err != nil {
+			return nil, rollback(fmt.Errorf("signing keychain install: update keychain search list: %w", err))
+		}
+		searchListUpdated = true
+	}
+
+	return &asc.SigningKeychainInstallResult{
+		Action:            "installed",
+		KeychainPath:      resolvedKeychainPath,
+		CertificateSHA256: identity.CertificateSHA256,
+		CertificateSHA1:   identity.CertificateSHA1,
+		TeamID:            teamID,
+		SearchListUpdated: searchListUpdated,
+	}, nil
+}
+
+func requireSigningKeychainInstallDeps(deps signingKeychainInstallDeps, addToSearchList bool) error {
+	if deps.CreateKeychain == nil || deps.ImportIdentity == nil || deps.DeleteKeychain == nil {
+		return fmt.Errorf("signing keychain install: platform keychain operations are unavailable")
+	}
+	if addToSearchList && (deps.KeychainSearchList == nil || deps.SetKeychainSearchList == nil) {
+		return fmt.Errorf("signing keychain install: platform search-list operations are unavailable")
+	}
+	if !addToSearchList && deps.RemoveKeychainSearchEntry == nil {
+		return fmt.Errorf("signing keychain install: platform search-list isolation is unavailable")
+	}
+	return nil
+}
+
+func preflightSigningKeychainPath(path string) (string, error) {
+	absolute, err := filepath.Abs(strings.TrimSpace(path))
+	if err != nil {
+		return "", err
+	}
+	absolute = filepath.Clean(absolute)
+	parent := filepath.Dir(absolute)
+	physicalParent, err := filepath.EvalSymlinks(parent)
+	if err != nil {
+		return "", fmt.Errorf("resolve keychain parent: %w", err)
+	}
+	absolute = filepath.Join(physicalParent, filepath.Base(absolute))
+	root, err := rootfs.New(physicalParent)
+	if err != nil {
+		return "", err
+	}
+	defer root.Close()
+	if err := root.CheckCreateNewFile(filepath.Base(absolute)); err != nil {
+		return "", err
+	}
+	return absolute, nil
+}
+
+func trimSigningKeychainSecret(data []byte) []byte {
+	trimmed := bytes.TrimSuffix(data, []byte("\n"))
+	return bytes.TrimSuffix(trimmed, []byte("\r"))
+}
+
+func validateSigningKeychainCertificate(certificate *x509.Certificate) error {
+	if certificate == nil {
+		return fmt.Errorf("identity certificate is missing")
+	}
+	if certificate.KeyUsage != 0 && certificate.KeyUsage&x509.KeyUsageDigitalSignature == 0 {
+		return fmt.Errorf("identity certificate does not permit digital signatures")
+	}
+	if len(certificate.ExtKeyUsage) == 0 {
+		return nil
+	}
+	for _, usage := range certificate.ExtKeyUsage {
+		if usage == x509.ExtKeyUsageCodeSigning || usage == x509.ExtKeyUsageAny {
+			return nil
+		}
+	}
+	return fmt.Errorf("identity certificate is not valid for code signing")
+}

--- a/internal/cli/signing/signing_keychain.go
+++ b/internal/cli/signing/signing_keychain.go
@@ -226,16 +226,12 @@ func executeSigningKeychainInstallWith(ctx context.Context, options signingKeych
 			resultErr = errors.Join(resultErr, fmt.Errorf("signing keychain install: release signing environment lock: %w", err))
 		}
 	}()
-	var originalSearchList []string
-	searchListHadPath := false
-	if options.AddToSearchList {
-		originalSearchList, err = deps.KeychainSearchList(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("signing keychain install: read keychain search list: %w", err)
-		}
-		originalSearchList = append([]string(nil), originalSearchList...)
-		searchListHadPath = slices.Contains(originalSearchList, resolvedKeychainPath)
+	originalSearchList, err := deps.KeychainSearchList(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("signing keychain install: read keychain search list: %w", err)
 	}
+	originalSearchList = append([]string(nil), originalSearchList...)
+	searchListHadPath := slices.Contains(originalSearchList, resolvedKeychainPath)
 
 	created := false
 	rollback := func(primary error) error {
@@ -248,14 +244,8 @@ func executeSigningKeychainInstallWith(ctx context.Context, options signingKeych
 		if err := deps.DeleteKeychain(cleanupCtx, resolvedKeychainPath); err != nil {
 			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("delete keychain: %w", err))
 		}
-		if options.AddToSearchList {
-			if err := deps.SetKeychainSearchList(cleanupCtx, originalSearchList); err != nil {
-				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("restore keychain search list: %w", err))
-			}
-		} else if deps.RemoveKeychainSearchEntry != nil {
-			if err := deps.RemoveKeychainSearchEntry(cleanupCtx, resolvedKeychainPath); err != nil {
-				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("remove keychain search-list entry: %w", err))
-			}
+		if err := deps.SetKeychainSearchList(cleanupCtx, originalSearchList); err != nil {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("restore keychain search list: %w", err))
 		}
 		if cleanupErr != nil {
 			return errors.Join(primary, fmt.Errorf("signing keychain install: rollback new keychain: %w", cleanupErr))
@@ -298,7 +288,7 @@ func requireSigningKeychainInstallDeps(deps signingKeychainInstallDeps, addToSea
 	if deps.AcquireLock == nil || deps.CreateKeychain == nil || deps.ImportIdentity == nil || deps.DeleteKeychain == nil {
 		return fmt.Errorf("signing keychain install: platform keychain operations are unavailable")
 	}
-	if addToSearchList && (deps.KeychainSearchList == nil || deps.SetKeychainSearchList == nil) {
+	if deps.KeychainSearchList == nil || deps.SetKeychainSearchList == nil {
 		return fmt.Errorf("signing keychain install: platform search-list operations are unavailable")
 	}
 	if !addToSearchList && deps.RemoveKeychainSearchEntry == nil {

--- a/internal/cli/signing/signing_keychain_platform_darwin.go
+++ b/internal/cli/signing/signing_keychain_platform_darwin.go
@@ -15,6 +15,7 @@ func platformSigningKeychainInstallDeps() signingKeychainInstallDeps {
 	return signingKeychainInstallDeps{
 		GOOS:                      "darwin",
 		SecurityAvailable:         signingRunSecurityAvailable(),
+		AcquireLock:               runDeps.AcquireLock,
 		CreateKeychain:            createPersistentSigningKeychain,
 		ImportIdentity:            importPersistentSigningIdentity,
 		KeychainSearchList:        runDeps.KeychainSearchList,
@@ -60,14 +61,27 @@ func importPersistentSigningIdentity(ctx context.Context, keychainPath string, k
 		return utilityFailure("verify imported certificate", stderr, err)
 	}
 	certificates := parseSigningRunCertificateFingerprints(stdout)
-	if len(certificates) != 1 || !strings.EqualFold(certificates[0], expectedSHA1) {
-		return fmt.Errorf("verify imported certificate: expected only certificate %s, found %v", expectedSHA1, certificates)
+	if err := validatePersistentSigningCertificateFingerprints(certificates, expectedSHA1); err != nil {
+		return err
 	}
 	_, stderr, err = runSigningUtility(ctx, nil, "find-key", "-s", "-t", "private", keychainPath)
 	if err != nil {
 		return utilityFailure("verify imported private key", stderr, err)
 	}
 	return verifySigningRunIdentityUsable(ctx, filepath.Dir(keychainPath), keychainPath, expectedSHA1)
+}
+
+func validatePersistentSigningCertificateFingerprints(certificates []string, expectedSHA1 string) error {
+	matches := 0
+	for _, fingerprint := range certificates {
+		if strings.EqualFold(fingerprint, expectedSHA1) {
+			matches++
+		}
+	}
+	if matches != 1 {
+		return fmt.Errorf("verify imported certificate: expected certificate %s exactly once, found %v", expectedSHA1, certificates)
+	}
+	return nil
 }
 
 func withPersistentSigningKeychainPasswordInput(password []byte, operation func([]byte) error) error {

--- a/internal/cli/signing/signing_keychain_platform_darwin.go
+++ b/internal/cli/signing/signing_keychain_platform_darwin.go
@@ -6,9 +6,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"path/filepath"
 	"strings"
+	"time"
 )
+
+type persistentSigningUtilityRunner func(context.Context, []byte, ...string) ([]byte, []byte, error)
 
 func platformSigningKeychainInstallDeps() signingKeychainInstallDeps {
 	runDeps := platformSigningRunDeps()
@@ -32,10 +34,21 @@ func createPersistentSigningKeychain(ctx context.Context, keychainPath string, p
 	if err := createKeychainWithSecurityFramework(keychainPath, password); err != nil {
 		return err
 	}
-	_, stderr, err := runSigningUtility(ctx, nil, "set-keychain-settings", "-l", keychainPath)
+	return configurePersistentSigningKeychain(ctx, keychainPath, runSigningUtility, deleteSigningRunKeychain)
+}
+
+func configurePersistentSigningKeychain(
+	ctx context.Context,
+	keychainPath string,
+	runUtility persistentSigningUtilityRunner,
+	deleteKeychain func(context.Context, string) error,
+) error {
+	_, stderr, err := runUtility(ctx, nil, "set-keychain-settings", "-l", keychainPath)
 	if err != nil {
 		configureErr := utilityFailure("configure persistent keychain", stderr, err)
-		if cleanupErr := deleteSigningRunKeychain(ctx, keychainPath); cleanupErr != nil {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		if cleanupErr := deleteKeychain(cleanupCtx, keychainPath); cleanupErr != nil {
 			return errors.Join(configureErr, fmt.Errorf("remove unconfigured keychain: %w", cleanupErr))
 		}
 		return configureErr
@@ -68,7 +81,37 @@ func importPersistentSigningIdentity(ctx context.Context, keychainPath string, k
 	if err != nil {
 		return utilityFailure("verify imported private key", stderr, err)
 	}
-	return verifySigningRunIdentityUsable(ctx, filepath.Dir(keychainPath), keychainPath, expectedSHA1)
+	return verifyPersistentSigningIdentityUsable(ctx, keychainPath, expectedSHA1)
+}
+
+func verifyPersistentSigningIdentityUsable(ctx context.Context, keychainPath, expectedSHA1 string) (resultErr error) {
+	return withPersistentSigningProbe(
+		ctx,
+		keychainPath,
+		expectedSHA1,
+		createSigningRunTempDir,
+		removeSigningRunTempDir,
+		verifySigningRunIdentityUsable,
+	)
+}
+
+func withPersistentSigningProbe(
+	ctx context.Context,
+	keychainPath, expectedSHA1 string,
+	createTempDir func() (string, error),
+	removeTempDir func(string) error,
+	verify func(context.Context, string, string, string) error,
+) (resultErr error) {
+	probeDir, err := createTempDir()
+	if err != nil {
+		return fmt.Errorf("create private codesign probe directory: %w", err)
+	}
+	defer func() {
+		if err := removeTempDir(probeDir); err != nil {
+			resultErr = errors.Join(resultErr, fmt.Errorf("remove private codesign probe directory: %w", err))
+		}
+	}()
+	return verify(ctx, probeDir, keychainPath, expectedSHA1)
 }
 
 func validatePersistentSigningCertificateFingerprints(certificates []string, expectedSHA1 string) error {

--- a/internal/cli/signing/signing_keychain_platform_darwin.go
+++ b/internal/cli/signing/signing_keychain_platform_darwin.go
@@ -31,7 +31,7 @@ func createPersistentSigningKeychain(ctx context.Context, keychainPath string, p
 	if len(password) == 0 {
 		return fmt.Errorf("keychain password is empty")
 	}
-	if err := createKeychainWithSecurityFramework(keychainPath, password); err != nil {
+	if err := createPersistentKeychainWithSecurityFramework(keychainPath, password); err != nil {
 		return err
 	}
 	return configurePersistentSigningKeychain(ctx, keychainPath, runSigningUtility, deleteSigningRunKeychain)
@@ -46,12 +46,19 @@ func configurePersistentSigningKeychain(
 	_, stderr, err := runUtility(ctx, nil, "set-keychain-settings", "-l", keychainPath)
 	if err != nil {
 		configureErr := utilityFailure("configure persistent keychain", stderr, err)
-		cleanupCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-		defer cancel()
-		if cleanupErr := deleteKeychain(cleanupCtx, keychainPath); cleanupErr != nil {
-			return errors.Join(configureErr, fmt.Errorf("remove unconfigured keychain: %w", cleanupErr))
+		if cleanupErr := deleteCreatedPersistentSigningKeychain(keychainPath, deleteKeychain); cleanupErr != nil {
+			return errors.Join(configureErr, cleanupErr)
 		}
 		return configureErr
+	}
+	return nil
+}
+
+func deleteCreatedPersistentSigningKeychain(keychainPath string, deleteKeychain func(context.Context, string) error) error {
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if err := deleteKeychain(cleanupCtx, keychainPath); err != nil {
+		return fmt.Errorf("remove unconfigured keychain: %w", err)
 	}
 	return nil
 }

--- a/internal/cli/signing/signing_keychain_platform_darwin.go
+++ b/internal/cli/signing/signing_keychain_platform_darwin.go
@@ -1,0 +1,79 @@
+//go:build darwin
+
+package signing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+func platformSigningKeychainInstallDeps() signingKeychainInstallDeps {
+	runDeps := platformSigningRunDeps()
+	return signingKeychainInstallDeps{
+		GOOS:                      "darwin",
+		SecurityAvailable:         signingRunSecurityAvailable(),
+		CreateKeychain:            createPersistentSigningKeychain,
+		ImportIdentity:            importPersistentSigningIdentity,
+		KeychainSearchList:        runDeps.KeychainSearchList,
+		SetKeychainSearchList:     runDeps.SetKeychainSearchList,
+		RemoveKeychainSearchEntry: runDeps.RemoveKeychainSearchEntry,
+		DeleteKeychain:            runDeps.DeleteKeychain,
+	}
+}
+
+func createPersistentSigningKeychain(ctx context.Context, keychainPath string, password []byte) error {
+	if len(password) == 0 {
+		return fmt.Errorf("keychain password is empty")
+	}
+	if err := createKeychainWithSecurityFramework(keychainPath, password); err != nil {
+		return err
+	}
+	_, stderr, err := runSigningUtility(ctx, nil, "set-keychain-settings", "-l", keychainPath)
+	if err != nil {
+		configureErr := utilityFailure("configure persistent keychain", stderr, err)
+		if cleanupErr := deleteSigningRunKeychain(ctx, keychainPath); cleanupErr != nil {
+			return errors.Join(configureErr, fmt.Errorf("remove unconfigured keychain: %w", cleanupErr))
+		}
+		return configureErr
+	}
+	return nil
+}
+
+func importPersistentSigningIdentity(ctx context.Context, keychainPath string, keychainPassword, identityData, importPassword []byte, expectedSHA1 string) error {
+	if err := importPKCS12WithSecurityFramework(keychainPath, identityData, importPassword); err != nil {
+		return err
+	}
+	if err := withPersistentSigningKeychainPasswordInput(keychainPassword, func(stdin []byte) error {
+		_, stderr, err := runSigningUtility(ctx, stdin, "set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-t", "private", keychainPath)
+		if err != nil {
+			return utilityFailure("restrict key partition list", stderr, err)
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	stdout, stderr, err := runSigningUtility(ctx, nil, "find-certificate", "-a", "-Z", keychainPath)
+	if err != nil {
+		return utilityFailure("verify imported certificate", stderr, err)
+	}
+	certificates := parseSigningRunCertificateFingerprints(stdout)
+	if len(certificates) != 1 || !strings.EqualFold(certificates[0], expectedSHA1) {
+		return fmt.Errorf("verify imported certificate: expected only certificate %s, found %v", expectedSHA1, certificates)
+	}
+	_, stderr, err = runSigningUtility(ctx, nil, "find-key", "-s", "-t", "private", keychainPath)
+	if err != nil {
+		return utilityFailure("verify imported private key", stderr, err)
+	}
+	return verifySigningRunIdentityUsable(ctx, filepath.Dir(keychainPath), keychainPath, expectedSHA1)
+}
+
+func withPersistentSigningKeychainPasswordInput(password []byte, operation func([]byte) error) error {
+	stdin := make([]byte, len(password)+1)
+	copy(stdin, password)
+	stdin[len(stdin)-1] = '\n'
+	defer clear(stdin)
+	return operation(stdin)
+}

--- a/internal/cli/signing/signing_keychain_platform_darwin_test.go
+++ b/internal/cli/signing/signing_keychain_platform_darwin_test.go
@@ -3,9 +3,80 @@
 package signing
 
 import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestConfigurePersistentSigningKeychainCleansUpWithIndependentContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	configureErr := errors.New("configuration failed")
+	deleted := false
+	err := configurePersistentSigningKeychain(
+		ctx,
+		"/tmp/persistent.keychain-db",
+		func(runCtx context.Context, _ []byte, _ ...string) ([]byte, []byte, error) {
+			cancel()
+			return nil, nil, configureErr
+		},
+		func(cleanupCtx context.Context, path string) error {
+			if cleanupCtx.Err() != nil {
+				t.Fatalf("cleanup context is canceled: %v", cleanupCtx.Err())
+			}
+			if path != "/tmp/persistent.keychain-db" {
+				t.Fatalf("cleanup path = %q", path)
+			}
+			deleted = true
+			return nil
+		},
+	)
+	if !errors.Is(err, configureErr) || !deleted {
+		t.Fatalf("configure error = %v, deleted = %v", err, deleted)
+	}
+}
+
+func TestPersistentSigningProbeUsesPrivateTemporaryDirectory(t *testing.T) {
+	operatorDir := t.TempDir()
+	operatorProbe := filepath.Join(operatorDir, "codesign-probe")
+	if err := os.WriteFile(operatorProbe, []byte("operator-owned"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	keychainPath := filepath.Join(operatorDir, "persistent.keychain-db")
+	verified := false
+	err := withPersistentSigningProbe(
+		context.Background(),
+		keychainPath,
+		strings.Repeat("A", 40),
+		createSigningRunTempDir,
+		removeSigningRunTempDir,
+		func(_ context.Context, probeDir, gotKeychainPath, _ string) error {
+			if probeDir == operatorDir || filepath.Dir(probeDir) != filepath.Clean(os.TempDir()) {
+				t.Fatalf("probe directory = %q, operator directory = %q", probeDir, operatorDir)
+			}
+			if gotKeychainPath != keychainPath {
+				t.Fatalf("keychain path = %q", gotKeychainPath)
+			}
+			verified = true
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !verified {
+		t.Fatal("codesign probe did not run")
+	}
+	data, err := os.ReadFile(operatorProbe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "operator-owned" {
+		t.Fatalf("operator probe content = %q", data)
+	}
+}
 
 func TestValidatePersistentSigningCertificateFingerprintsAllowsCertificateChain(t *testing.T) {
 	leaf := strings.Repeat("A", 40)

--- a/internal/cli/signing/signing_keychain_platform_darwin_test.go
+++ b/internal/cli/signing/signing_keychain_platform_darwin_test.go
@@ -1,0 +1,28 @@
+//go:build darwin
+
+package signing
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidatePersistentSigningCertificateFingerprintsAllowsCertificateChain(t *testing.T) {
+	leaf := strings.Repeat("A", 40)
+	chain := []string{strings.Repeat("B", 40), leaf, strings.Repeat("C", 40)}
+	if err := validatePersistentSigningCertificateFingerprints(chain, strings.ToLower(leaf)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidatePersistentSigningCertificateFingerprintsRequiresLeafExactlyOnce(t *testing.T) {
+	leaf := strings.Repeat("A", 40)
+	for _, certificates := range [][]string{
+		{strings.Repeat("B", 40)},
+		{leaf, leaf},
+	} {
+		if err := validatePersistentSigningCertificateFingerprints(certificates, leaf); err == nil {
+			t.Fatalf("certificates = %v, want exact-leaf-count failure", certificates)
+		}
+	}
+}

--- a/internal/cli/signing/signing_keychain_platform_other.go
+++ b/internal/cli/signing/signing_keychain_platform_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin
+
+package signing
+
+func platformSigningKeychainInstallDeps() signingKeychainInstallDeps {
+	return signingKeychainInstallDeps{GOOS: "unsupported"}
+}

--- a/internal/cli/signing/signing_keychain_test.go
+++ b/internal/cli/signing/signing_keychain_test.go
@@ -160,6 +160,10 @@ func TestExecuteSigningKeychainInstallCreatesDedicatedKeychain(t *testing.T) {
 		GOOS:              "darwin",
 		SecurityAvailable: true,
 		Now:               func() time.Time { return fixture.now },
+		AcquireLock: func(context.Context) (func() error, error) {
+			events = append(events, "lock")
+			return func() error { events = append(events, "unlock"); return nil }, nil
+		},
 		CreateKeychain: func(_ context.Context, path string, password []byte) error {
 			events = append(events, "create")
 			if path != resolvedKeychainPath || string(password) != "keychain-secret" {
@@ -206,7 +210,7 @@ func TestExecuteSigningKeychainInstallCreatesDedicatedKeychain(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(events, []string{"list", "create", "import", "set"}) {
+	if !reflect.DeepEqual(events, []string{"lock", "list", "create", "import", "set", "unlock"}) {
 		t.Fatalf("events = %v", events)
 	}
 	if result.Action != "installed" || result.KeychainPath != resolvedKeychainPath || !result.SearchListUpdated {
@@ -263,6 +267,7 @@ func TestExecuteSigningKeychainInstallRejectsDigestMismatchBeforeCreation(t *tes
 		GOOS:                      "darwin",
 		SecurityAvailable:         true,
 		Now:                       func() time.Time { return fixture.now },
+		AcquireLock:               acquireSigningKeychainTestLock,
 		CreateKeychain:            func(context.Context, string, []byte) error { created = true; return nil },
 		ImportIdentity:            func(context.Context, string, []byte, []byte, []byte, string) error { return nil },
 		RemoveKeychainSearchEntry: func(context.Context, string) error { return nil },
@@ -294,6 +299,7 @@ func TestExecuteSigningKeychainInstallKeepsSearchListUnchangedByDefault(t *testi
 		GOOS:              "darwin",
 		SecurityAvailable: true,
 		Now:               func() time.Time { return fixture.now },
+		AcquireLock:       acquireSigningKeychainTestLock,
 		CreateKeychain:    func(context.Context, string, []byte) error { events = append(events, "create"); return nil },
 		ImportIdentity: func(context.Context, string, []byte, []byte, []byte, string) error {
 			events = append(events, "import")
@@ -332,6 +338,7 @@ func TestExecuteSigningKeychainInstallRollsBackAfterImportFailure(t *testing.T) 
 		GOOS:              "darwin",
 		SecurityAvailable: true,
 		Now:               func() time.Time { return fixture.now },
+		AcquireLock:       acquireSigningKeychainTestLock,
 		CreateKeychain:    func(context.Context, string, []byte) error { return nil },
 		ImportIdentity: func(context.Context, string, []byte, []byte, []byte, string) error {
 			return errors.New("import failed")
@@ -354,6 +361,54 @@ func TestExecuteSigningKeychainInstallRollsBackAfterImportFailure(t *testing.T) 
 	}
 }
 
+func TestExecuteSigningKeychainInstallRollsBackAfterCancellationWithIndependentContext(t *testing.T) {
+	fixture := newSigningRunFixture(t, signingRunFixtureOptions{})
+	identityPath := filepath.Join(t.TempDir(), "App.p12")
+	identityPasswordPath := filepath.Join(t.TempDir(), "identity-password")
+	keychainPasswordPath := filepath.Join(t.TempDir(), "keychain-password")
+	writePrivateTestFile(t, identityPath, fixture.identity)
+	writePrivateTestFile(t, identityPasswordPath, []byte(fixture.password))
+	writePrivateTestFile(t, keychainPasswordPath, []byte("keychain-secret"))
+	keychainPath := filepath.Join(t.TempDir(), "release.keychain-db")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	deleted := false
+	restored := false
+	_, err := executeSigningKeychainInstallWith(ctx, signingKeychainInstallOptions{
+		IdentityPath: identityPath, IdentityPasswordPath: identityPasswordPath,
+		KeychainPath: keychainPath, KeychainPasswordPath: keychainPasswordPath,
+		AddToSearchList: true,
+	}, signingKeychainInstallDeps{
+		GOOS:              "darwin",
+		SecurityAvailable: true,
+		Now:               func() time.Time { return fixture.now },
+		AcquireLock:       acquireSigningKeychainTestLock,
+		CreateKeychain:    func(context.Context, string, []byte) error { return nil },
+		ImportIdentity: func(context.Context, string, []byte, []byte, []byte, string) error {
+			cancel()
+			return context.Canceled
+		},
+		KeychainSearchList: func(context.Context) ([]string, error) { return []string{"login.keychain-db"}, nil },
+		SetKeychainSearchList: func(cleanupCtx context.Context, paths []string) error {
+			if cleanupCtx.Err() != nil {
+				t.Fatalf("rollback search-list context is canceled: %v", cleanupCtx.Err())
+			}
+			restored = reflect.DeepEqual(paths, []string{"login.keychain-db"})
+			return nil
+		},
+		DeleteKeychain: func(cleanupCtx context.Context, _ string) error {
+			if cleanupCtx.Err() != nil {
+				t.Fatalf("rollback deletion context is canceled: %v", cleanupCtx.Err())
+			}
+			deleted = true
+			return nil
+		},
+	})
+	if !errors.Is(err, context.Canceled) || !deleted || !restored {
+		t.Fatalf("error=%v deleted=%v restored=%v", err, deleted, restored)
+	}
+}
+
 func TestExecuteSigningKeychainInstallRollsBackAfterSearchListFailure(t *testing.T) {
 	fixture := newSigningRunFixture(t, signingRunFixtureOptions{})
 	identityPath := filepath.Join(t.TempDir(), "App.p12")
@@ -371,6 +426,7 @@ func TestExecuteSigningKeychainInstallRollsBackAfterSearchListFailure(t *testing
 		GOOS:              "darwin",
 		SecurityAvailable: true,
 		Now:               func() time.Time { return fixture.now },
+		AcquireLock:       acquireSigningKeychainTestLock,
 		CreateKeychain:    func(context.Context, string, []byte) error { return nil },
 		ImportIdentity:    func(context.Context, string, []byte, []byte, []byte, string) error { return nil },
 		KeychainSearchList: func(context.Context) ([]string, error) {
@@ -422,6 +478,7 @@ func TestExecuteSigningKeychainInstallRollbackPreservesPreexistingStaleSearchEnt
 		GOOS:              "darwin",
 		SecurityAvailable: true,
 		Now:               func() time.Time { return fixture.now },
+		AcquireLock:       acquireSigningKeychainTestLock,
 		CreateKeychain:    func(context.Context, string, []byte) error { return nil },
 		ImportIdentity: func(context.Context, string, []byte, []byte, []byte, string) error {
 			return errors.New("import failed")
@@ -506,4 +563,8 @@ func canonicalSigningKeychainTestPath(t *testing.T, path string) string {
 		t.Fatal(err)
 	}
 	return filepath.Join(parent, filepath.Base(path))
+}
+
+func acquireSigningKeychainTestLock(context.Context) (func() error, error) {
+	return func() error { return nil }, nil
 }

--- a/internal/cli/signing/signing_keychain_test.go
+++ b/internal/cli/signing/signing_keychain_test.go
@@ -33,10 +33,22 @@ func TestSigningCommandIncludesKeychainInstall(t *testing.T) {
 
 func TestSigningKeychainInstallCommandThreadsOptions(t *testing.T) {
 	previous := installSigningKeychainFn
-	t.Cleanup(func() { installSigningKeychainFn = previous })
+	previousContext := signingKeychainInstallContext
+	t.Cleanup(func() {
+		installSigningKeychainFn = previous
+		signingKeychainInstallContext = previousContext
+	})
 
 	var got signingKeychainInstallOptions
-	installSigningKeychainFn = func(_ context.Context, options signingKeychainInstallOptions) (*asc.SigningKeychainInstallResult, error) {
+	type installContextKey struct{}
+	contextStopped := false
+	signingKeychainInstallContext = func(ctx context.Context) (context.Context, func()) {
+		return context.WithValue(ctx, installContextKey{}, true), func() { contextStopped = true }
+	}
+	installSigningKeychainFn = func(ctx context.Context, options signingKeychainInstallOptions) (*asc.SigningKeychainInstallResult, error) {
+		if wrapped, _ := ctx.Value(installContextKey{}).(bool); !wrapped {
+			t.Fatal("install context was not wrapped for termination signals")
+		}
 		got = options
 		return &asc.SigningKeychainInstallResult{Action: "installed"}, nil
 	}
@@ -72,6 +84,9 @@ func TestSigningKeychainInstallCommandThreadsOptions(t *testing.T) {
 	}
 	if !strings.Contains(stdout, `"action":"installed"`) {
 		t.Fatalf("stdout = %q, want JSON result", stdout)
+	}
+	if !contextStopped {
+		t.Fatal("install signal context was not stopped")
 	}
 }
 

--- a/internal/cli/signing/signing_keychain_test.go
+++ b/internal/cli/signing/signing_keychain_test.go
@@ -285,6 +285,8 @@ func TestExecuteSigningKeychainInstallRejectsDigestMismatchBeforeCreation(t *tes
 		AcquireLock:               acquireSigningKeychainTestLock,
 		CreateKeychain:            func(context.Context, string, []byte) error { created = true; return nil },
 		ImportIdentity:            func(context.Context, string, []byte, []byte, []byte, string) error { return nil },
+		KeychainSearchList:        func(context.Context) ([]string, error) { return nil, nil },
+		SetKeychainSearchList:     func(context.Context, []string) error { return nil },
 		RemoveKeychainSearchEntry: func(context.Context, string) error { return nil },
 		DeleteKeychain:            func(context.Context, string) error { return nil },
 	})
@@ -315,7 +317,15 @@ func TestExecuteSigningKeychainInstallKeepsSearchListUnchangedByDefault(t *testi
 		SecurityAvailable: true,
 		Now:               func() time.Time { return fixture.now },
 		AcquireLock:       acquireSigningKeychainTestLock,
-		CreateKeychain:    func(context.Context, string, []byte) error { events = append(events, "create"); return nil },
+		KeychainSearchList: func(context.Context) ([]string, error) {
+			events = append(events, "list")
+			return nil, nil
+		},
+		SetKeychainSearchList: func(context.Context, []string) error {
+			t.Fatal("search list restored after successful install")
+			return nil
+		},
+		CreateKeychain: func(context.Context, string, []byte) error { events = append(events, "create"); return nil },
 		ImportIdentity: func(context.Context, string, []byte, []byte, []byte, string) error {
 			events = append(events, "import")
 			return nil
@@ -329,7 +339,7 @@ func TestExecuteSigningKeychainInstallKeepsSearchListUnchangedByDefault(t *testi
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(events, []string{"create", "remove-search-entry", "import"}) {
+	if !reflect.DeepEqual(events, []string{"list", "create", "remove-search-entry", "import"}) {
 		t.Fatalf("events = %v", events)
 	}
 	if result.SearchListUpdated {
@@ -358,6 +368,8 @@ func TestExecuteSigningKeychainInstallRollsBackAfterImportFailure(t *testing.T) 
 		ImportIdentity: func(context.Context, string, []byte, []byte, []byte, string) error {
 			return errors.New("import failed")
 		},
+		KeychainSearchList:        func(context.Context) ([]string, error) { return nil, nil },
+		SetKeychainSearchList:     func(context.Context, []string) error { return nil },
 		RemoveKeychainSearchEntry: func(context.Context, string) error { return nil },
 		DeleteKeychain: func(_ context.Context, path string) error {
 			deleted = true
@@ -373,6 +385,60 @@ func TestExecuteSigningKeychainInstallRollsBackAfterImportFailure(t *testing.T) 
 	}, deps)
 	if err == nil || !strings.Contains(err.Error(), "import failed") || !deleted {
 		t.Fatalf("error = %v deleted=%v", err, deleted)
+	}
+}
+
+func TestExecuteSigningKeychainInstallRestoresStaleSearchListEntryAfterFailure(t *testing.T) {
+	fixture := newSigningRunFixture(t, signingRunFixtureOptions{})
+	identityPath := filepath.Join(t.TempDir(), "App.p12")
+	identityPasswordPath := filepath.Join(t.TempDir(), "identity-password")
+	keychainPasswordPath := filepath.Join(t.TempDir(), "keychain-password")
+	writePrivateTestFile(t, identityPath, fixture.identity)
+	writePrivateTestFile(t, identityPasswordPath, []byte(fixture.password))
+	writePrivateTestFile(t, keychainPasswordPath, []byte("keychain-secret"))
+	keychainPath := filepath.Join(t.TempDir(), "release.keychain-db")
+	resolvedKeychainPath := canonicalSigningKeychainTestPath(t, keychainPath)
+	originalSearchList := []string{"login.keychain-db", resolvedKeychainPath}
+
+	deleted := false
+	removeCalls := 0
+	var restoredSearchList []string
+	_, err := executeSigningKeychainInstallWith(context.Background(), signingKeychainInstallOptions{
+		IdentityPath: identityPath, IdentityPasswordPath: identityPasswordPath,
+		KeychainPath: keychainPath, KeychainPasswordPath: keychainPasswordPath,
+	}, signingKeychainInstallDeps{
+		GOOS:              "darwin",
+		SecurityAvailable: true,
+		Now:               func() time.Time { return fixture.now },
+		AcquireLock:       acquireSigningKeychainTestLock,
+		CreateKeychain:    func(context.Context, string, []byte) error { return nil },
+		ImportIdentity: func(context.Context, string, []byte, []byte, []byte, string) error {
+			return errors.New("import failed")
+		},
+		KeychainSearchList: func(context.Context) ([]string, error) {
+			return append([]string(nil), originalSearchList...), nil
+		},
+		SetKeychainSearchList: func(_ context.Context, paths []string) error {
+			restoredSearchList = append([]string(nil), paths...)
+			return nil
+		},
+		RemoveKeychainSearchEntry: func(context.Context, string) error {
+			removeCalls++
+			return nil
+		},
+		DeleteKeychain: func(context.Context, string) error {
+			deleted = true
+			return nil
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "import failed") {
+		t.Fatalf("error = %v, want import failure", err)
+	}
+	if !deleted || removeCalls != 1 {
+		t.Fatalf("deleted=%v removeCalls=%d", deleted, removeCalls)
+	}
+	if !reflect.DeepEqual(restoredSearchList, originalSearchList) {
+		t.Fatalf("restored search list = %v, want %v", restoredSearchList, originalSearchList)
 	}
 }
 

--- a/internal/cli/signing/signing_keychain_test.go
+++ b/internal/cli/signing/signing_keychain_test.go
@@ -490,6 +490,52 @@ func TestExecuteSigningKeychainInstallRollsBackAfterCancellationWithIndependentC
 	}
 }
 
+func TestExecuteSigningKeychainInstallRollsBackWhenCanceledAfterFinalMutation(t *testing.T) {
+	fixture := newSigningRunFixture(t, signingRunFixtureOptions{})
+	identityPath := filepath.Join(t.TempDir(), "App.p12")
+	identityPasswordPath := filepath.Join(t.TempDir(), "identity-password")
+	keychainPasswordPath := filepath.Join(t.TempDir(), "keychain-password")
+	writePrivateTestFile(t, identityPath, fixture.identity)
+	writePrivateTestFile(t, identityPasswordPath, []byte(fixture.password))
+	writePrivateTestFile(t, keychainPasswordPath, []byte("keychain-secret"))
+	keychainPath := filepath.Join(t.TempDir(), "release.keychain-db")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	deleted := false
+	restored := false
+	_, err := executeSigningKeychainInstallWith(ctx, signingKeychainInstallOptions{
+		IdentityPath: identityPath, IdentityPasswordPath: identityPasswordPath,
+		KeychainPath: keychainPath, KeychainPasswordPath: keychainPasswordPath,
+		AddToSearchList: true,
+	}, signingKeychainInstallDeps{
+		GOOS:               "darwin",
+		SecurityAvailable:  true,
+		Now:                func() time.Time { return fixture.now },
+		AcquireLock:        acquireSigningKeychainTestLock,
+		CreateKeychain:     func(context.Context, string, []byte) error { return nil },
+		ImportIdentity:     func(context.Context, string, []byte, []byte, []byte, string) error { return nil },
+		KeychainSearchList: func(context.Context) ([]string, error) { return []string{"login.keychain-db"}, nil },
+		SetKeychainSearchList: func(_ context.Context, paths []string) error {
+			if len(paths) == 2 {
+				cancel()
+				return nil
+			}
+			restored = reflect.DeepEqual(paths, []string{"login.keychain-db"})
+			return nil
+		},
+		DeleteKeychain: func(cleanupCtx context.Context, _ string) error {
+			if cleanupCtx.Err() != nil {
+				t.Fatalf("rollback deletion context is canceled: %v", cleanupCtx.Err())
+			}
+			deleted = true
+			return nil
+		},
+	})
+	if !errors.Is(err, context.Canceled) || !deleted || !restored {
+		t.Fatalf("error=%v deleted=%v restored=%v", err, deleted, restored)
+	}
+}
+
 func TestExecuteSigningKeychainInstallRollsBackAfterSearchListFailure(t *testing.T) {
 	fixture := newSigningRunFixture(t, signingRunFixtureOptions{})
 	identityPath := filepath.Join(t.TempDir(), "App.p12")

--- a/internal/cli/signing/signing_keychain_test.go
+++ b/internal/cli/signing/signing_keychain_test.go
@@ -1,0 +1,509 @@
+package signing
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+func TestSigningCommandIncludesKeychainInstall(t *testing.T) {
+	command := SigningCommand()
+	for _, subcommand := range command.Subcommands {
+		if subcommand == nil || subcommand.Name != "keychain" {
+			continue
+		}
+		for _, nested := range subcommand.Subcommands {
+			if nested != nil && nested.Name == "install" {
+				return
+			}
+		}
+	}
+	t.Fatal("expected signing keychain install subcommand")
+}
+
+func TestSigningKeychainInstallCommandThreadsOptions(t *testing.T) {
+	previous := installSigningKeychainFn
+	t.Cleanup(func() { installSigningKeychainFn = previous })
+
+	var got signingKeychainInstallOptions
+	installSigningKeychainFn = func(_ context.Context, options signingKeychainInstallOptions) (*asc.SigningKeychainInstallResult, error) {
+		got = options
+		return &asc.SigningKeychainInstallResult{Action: "installed"}, nil
+	}
+	command := SigningKeychainInstallCommand()
+	command.FlagSet.SetOutput(&strings.Builder{})
+	if err := command.Parse([]string{
+		"--identity", "App.p12",
+		"--identity-password-file", "p12-password",
+		"--keychain", "release.keychain-db",
+		"--keychain-password-file", "keychain-password",
+		"--expected-certificate-sha256", strings.Repeat("a", 64),
+		"--add-to-search-list",
+		"--confirm",
+		"--output", "json",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var runErr error
+	stdout, _ := captureOutput(t, func() { runErr = command.Run(context.Background()) })
+	if runErr != nil {
+		t.Fatal(runErr)
+	}
+	want := signingKeychainInstallOptions{
+		IdentityPath:              "App.p12",
+		IdentityPasswordPath:      "p12-password",
+		KeychainPath:              "release.keychain-db",
+		KeychainPasswordPath:      "keychain-password",
+		ExpectedCertificateSHA256: strings.Repeat("A", 64),
+		AddToSearchList:           true,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("options = %+v, want %+v", got, want)
+	}
+	if !strings.Contains(stdout, `"action":"installed"`) {
+		t.Fatalf("stdout = %q, want JSON result", stdout)
+	}
+}
+
+func TestSigningKeychainInstallCommandValidatesBeforeExecution(t *testing.T) {
+	previous := installSigningKeychainFn
+	t.Cleanup(func() { installSigningKeychainFn = previous })
+	called := false
+	installSigningKeychainFn = func(context.Context, signingKeychainInstallOptions) (*asc.SigningKeychainInstallResult, error) {
+		called = true
+		return nil, nil
+	}
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{name: "identity required", args: []string{"--identity-password-file", "a", "--keychain", "b", "--keychain-password-file", "c", "--confirm"}, wantErr: "--identity is required"},
+		{name: "identity password required", args: []string{"--identity", "a", "--keychain", "b", "--keychain-password-file", "c", "--confirm"}, wantErr: "--identity-password-file is required"},
+		{name: "keychain required", args: []string{"--identity", "a", "--identity-password-file", "b", "--keychain-password-file", "c", "--confirm"}, wantErr: "--keychain is required"},
+		{name: "keychain password required", args: []string{"--identity", "a", "--identity-password-file", "b", "--keychain", "c", "--confirm"}, wantErr: "--keychain-password-file is required"},
+		{name: "confirm required", args: []string{"--identity", "a", "--identity-password-file", "b", "--keychain", "c", "--keychain-password-file", "d"}, wantErr: "--confirm is required"},
+		{name: "unexpected argument", args: []string{"--identity", "a", "--identity-password-file", "b", "--keychain", "c", "--keychain-password-file", "d", "--confirm", "extra"}, wantErr: "unexpected argument"},
+		{name: "invalid digest", args: []string{"--identity", "a", "--identity-password-file", "b", "--keychain", "c", "--keychain-password-file", "d", "--expected-certificate-sha256", "short", "--confirm"}, wantErr: "64-character hexadecimal"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			called = false
+			command := SigningKeychainInstallCommand()
+			command.FlagSet.SetOutput(&strings.Builder{})
+			if err := command.Parse(test.args); err != nil {
+				t.Fatal(err)
+			}
+			err := command.Run(context.Background())
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("error = %v, want %q", err, test.wantErr)
+			}
+			if !errors.Is(err, flag.ErrHelp) || shared.ClassifyUsageError(err) == "" {
+				t.Fatalf("error = %v, want classified usage error", err)
+			}
+			if called {
+				t.Fatal("executor called after command validation failure")
+			}
+		})
+	}
+}
+
+func TestSigningKeychainInstallFlagsAreExperimental(t *testing.T) {
+	command := SigningKeychainInstallCommand()
+	group := SigningKeychainCommand()
+	if !strings.Contains(group.ShortHelp, "[experimental]") || !strings.Contains(group.LongHelp, "[experimental]") {
+		t.Fatalf("keychain group help is missing experimental lifecycle marker")
+	}
+	for _, name := range []string{
+		"identity", "identity-password-file", "keychain", "keychain-password-file",
+		"expected-certificate-sha256", "add-to-search-list", "confirm",
+	} {
+		definition := command.FlagSet.Lookup(name)
+		if definition == nil {
+			t.Fatalf("missing --%s flag", name)
+		}
+		if !strings.Contains(definition.Usage, "[experimental]") {
+			t.Errorf("--%s usage = %q, want experimental lifecycle marker", name, definition.Usage)
+		}
+	}
+}
+
+func TestExecuteSigningKeychainInstallCreatesDedicatedKeychain(t *testing.T) {
+	fixture := newSigningRunFixture(t, signingRunFixtureOptions{})
+	identityPath := filepath.Join(t.TempDir(), "App.p12")
+	identityPasswordPath := filepath.Join(t.TempDir(), "identity-password")
+	keychainPasswordPath := filepath.Join(t.TempDir(), "keychain-password")
+	writePrivateTestFile(t, identityPath, fixture.identity)
+	writePrivateTestFile(t, identityPasswordPath, []byte(fixture.password+"\n"))
+	writePrivateTestFile(t, keychainPasswordPath, []byte("keychain-secret\r\n"))
+	keychainPath := filepath.Join(t.TempDir(), "release.keychain-db")
+	resolvedKeychainPath := canonicalSigningKeychainTestPath(t, keychainPath)
+
+	inspection, err := inspectSigningRunIdentity(fixture.identity, []byte(fixture.password), fixture.now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var events []string
+	deps := signingKeychainInstallDeps{
+		GOOS:              "darwin",
+		SecurityAvailable: true,
+		Now:               func() time.Time { return fixture.now },
+		CreateKeychain: func(_ context.Context, path string, password []byte) error {
+			events = append(events, "create")
+			if path != resolvedKeychainPath || string(password) != "keychain-secret" {
+				t.Fatalf("create path=%q password=%q", path, password)
+			}
+			return nil
+		},
+		ImportIdentity: func(_ context.Context, path string, keychainPassword, identityData, identityPassword []byte, expectedSHA1 string) error {
+			events = append(events, "import")
+			if path != resolvedKeychainPath || string(keychainPassword) != "keychain-secret" || string(identityPassword) != fixture.password {
+				t.Fatalf("unexpected import inputs")
+			}
+			if !reflect.DeepEqual(identityData, fixture.identity) || expectedSHA1 != inspection.CertificateSHA1 {
+				t.Fatalf("identity import mismatch")
+			}
+			return nil
+		},
+		KeychainSearchList: func(context.Context) ([]string, error) {
+			events = append(events, "list")
+			return []string{"/Users/me/Library/Keychains/login.keychain-db"}, nil
+		},
+		SetKeychainSearchList: func(_ context.Context, paths []string) error {
+			events = append(events, "set")
+			want := []string{"/Users/me/Library/Keychains/login.keychain-db", resolvedKeychainPath}
+			if !reflect.DeepEqual(paths, want) {
+				t.Fatalf("search list = %v, want %v", paths, want)
+			}
+			return nil
+		},
+		DeleteKeychain: func(context.Context, string) error {
+			events = append(events, "delete")
+			return nil
+		},
+	}
+
+	result, err := executeSigningKeychainInstallWith(context.Background(), signingKeychainInstallOptions{
+		IdentityPath:              identityPath,
+		IdentityPasswordPath:      identityPasswordPath,
+		KeychainPath:              keychainPath,
+		KeychainPasswordPath:      keychainPasswordPath,
+		ExpectedCertificateSHA256: inspection.CertificateSHA256,
+		AddToSearchList:           true,
+	}, deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(events, []string{"list", "create", "import", "set"}) {
+		t.Fatalf("events = %v", events)
+	}
+	if result.Action != "installed" || result.KeychainPath != resolvedKeychainPath || !result.SearchListUpdated {
+		t.Fatalf("result = %+v", result)
+	}
+	if result.CertificateSHA256 != inspection.CertificateSHA256 || result.CertificateSHA1 != inspection.CertificateSHA1 || result.TeamID != fixture.teamID {
+		t.Fatalf("certificate result = %+v", result)
+	}
+}
+
+func TestExecuteSigningKeychainInstallRejectsExistingDestinationBeforeSecrets(t *testing.T) {
+	keychainPath := filepath.Join(t.TempDir(), "existing.keychain-db")
+	if err := os.WriteFile(keychainPath, []byte("existing"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := executeSigningKeychainInstallWith(context.Background(), signingKeychainInstallOptions{
+		IdentityPath:         filepath.Join(t.TempDir(), "missing-identity"),
+		IdentityPasswordPath: filepath.Join(t.TempDir(), "missing-identity-password"),
+		KeychainPath:         keychainPath,
+		KeychainPasswordPath: filepath.Join(t.TempDir(), "missing-keychain-password"),
+	}, signingKeychainInstallDeps{GOOS: "darwin", SecurityAvailable: true})
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("error = %v, want existing destination error", err)
+	}
+}
+
+func TestExecuteSigningKeychainInstallRejectsUnsupportedPlatformBeforeSecrets(t *testing.T) {
+	_, err := executeSigningKeychainInstallWith(context.Background(), signingKeychainInstallOptions{
+		IdentityPath:         "missing-identity",
+		IdentityPasswordPath: "missing-identity-password",
+		KeychainPath:         "missing-keychain",
+		KeychainPasswordPath: "missing-keychain-password",
+	}, signingKeychainInstallDeps{GOOS: "linux"})
+	if err == nil || !strings.Contains(err.Error(), "supported only on macOS") {
+		t.Fatalf("error = %v, want platform error", err)
+	}
+}
+
+func TestExecuteSigningKeychainInstallRejectsDigestMismatchBeforeCreation(t *testing.T) {
+	fixture := newSigningRunFixture(t, signingRunFixtureOptions{})
+	identityPath := filepath.Join(t.TempDir(), "App.p12")
+	identityPasswordPath := filepath.Join(t.TempDir(), "identity-password")
+	keychainPasswordPath := filepath.Join(t.TempDir(), "keychain-password")
+	writePrivateTestFile(t, identityPath, fixture.identity)
+	writePrivateTestFile(t, identityPasswordPath, []byte(fixture.password))
+	writePrivateTestFile(t, keychainPasswordPath, []byte("keychain-secret"))
+
+	created := false
+	_, err := executeSigningKeychainInstallWith(context.Background(), signingKeychainInstallOptions{
+		IdentityPath: identityPath, IdentityPasswordPath: identityPasswordPath,
+		KeychainPath: filepath.Join(t.TempDir(), "release.keychain-db"), KeychainPasswordPath: keychainPasswordPath,
+		ExpectedCertificateSHA256: strings.Repeat("A", 64),
+	}, signingKeychainInstallDeps{
+		GOOS:                      "darwin",
+		SecurityAvailable:         true,
+		Now:                       func() time.Time { return fixture.now },
+		CreateKeychain:            func(context.Context, string, []byte) error { created = true; return nil },
+		ImportIdentity:            func(context.Context, string, []byte, []byte, []byte, string) error { return nil },
+		RemoveKeychainSearchEntry: func(context.Context, string) error { return nil },
+		DeleteKeychain:            func(context.Context, string) error { return nil },
+	})
+	if err == nil || !strings.Contains(err.Error(), "does not match --expected-certificate-sha256") {
+		t.Fatalf("error = %v, want digest mismatch", err)
+	}
+	if created {
+		t.Fatal("keychain created after digest mismatch")
+	}
+}
+
+func TestExecuteSigningKeychainInstallKeepsSearchListUnchangedByDefault(t *testing.T) {
+	fixture := newSigningRunFixture(t, signingRunFixtureOptions{})
+	identityPath := filepath.Join(t.TempDir(), "App.p12")
+	identityPasswordPath := filepath.Join(t.TempDir(), "identity-password")
+	keychainPasswordPath := filepath.Join(t.TempDir(), "keychain-password")
+	writePrivateTestFile(t, identityPath, fixture.identity)
+	writePrivateTestFile(t, identityPasswordPath, []byte(fixture.password))
+	writePrivateTestFile(t, keychainPasswordPath, []byte("keychain-secret"))
+	keychainPath := filepath.Join(t.TempDir(), "release.keychain-db")
+
+	var events []string
+	result, err := executeSigningKeychainInstallWith(context.Background(), signingKeychainInstallOptions{
+		IdentityPath: identityPath, IdentityPasswordPath: identityPasswordPath,
+		KeychainPath: keychainPath, KeychainPasswordPath: keychainPasswordPath,
+	}, signingKeychainInstallDeps{
+		GOOS:              "darwin",
+		SecurityAvailable: true,
+		Now:               func() time.Time { return fixture.now },
+		CreateKeychain:    func(context.Context, string, []byte) error { events = append(events, "create"); return nil },
+		ImportIdentity: func(context.Context, string, []byte, []byte, []byte, string) error {
+			events = append(events, "import")
+			return nil
+		},
+		RemoveKeychainSearchEntry: func(context.Context, string) error {
+			events = append(events, "remove-search-entry")
+			return nil
+		},
+		DeleteKeychain: func(context.Context, string) error { events = append(events, "delete"); return nil },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(events, []string{"create", "remove-search-entry", "import"}) {
+		t.Fatalf("events = %v", events)
+	}
+	if result.SearchListUpdated {
+		t.Fatalf("result = %+v, want unchanged search list", result)
+	}
+}
+
+func TestExecuteSigningKeychainInstallRollsBackAfterImportFailure(t *testing.T) {
+	fixture := newSigningRunFixture(t, signingRunFixtureOptions{})
+	identityPath := filepath.Join(t.TempDir(), "App.p12")
+	identityPasswordPath := filepath.Join(t.TempDir(), "identity-password")
+	keychainPasswordPath := filepath.Join(t.TempDir(), "keychain-password")
+	writePrivateTestFile(t, identityPath, fixture.identity)
+	writePrivateTestFile(t, identityPasswordPath, []byte(fixture.password))
+	writePrivateTestFile(t, keychainPasswordPath, []byte("keychain-secret"))
+	keychainPath := filepath.Join(t.TempDir(), "release.keychain-db")
+	resolvedKeychainPath := canonicalSigningKeychainTestPath(t, keychainPath)
+
+	deleted := false
+	deps := signingKeychainInstallDeps{
+		GOOS:              "darwin",
+		SecurityAvailable: true,
+		Now:               func() time.Time { return fixture.now },
+		CreateKeychain:    func(context.Context, string, []byte) error { return nil },
+		ImportIdentity: func(context.Context, string, []byte, []byte, []byte, string) error {
+			return errors.New("import failed")
+		},
+		RemoveKeychainSearchEntry: func(context.Context, string) error { return nil },
+		DeleteKeychain: func(_ context.Context, path string) error {
+			deleted = true
+			if path != resolvedKeychainPath {
+				t.Fatalf("rollback path = %q", path)
+			}
+			return nil
+		},
+	}
+	_, err := executeSigningKeychainInstallWith(context.Background(), signingKeychainInstallOptions{
+		IdentityPath: identityPath, IdentityPasswordPath: identityPasswordPath,
+		KeychainPath: keychainPath, KeychainPasswordPath: keychainPasswordPath,
+	}, deps)
+	if err == nil || !strings.Contains(err.Error(), "import failed") || !deleted {
+		t.Fatalf("error = %v deleted=%v", err, deleted)
+	}
+}
+
+func TestExecuteSigningKeychainInstallRollsBackAfterSearchListFailure(t *testing.T) {
+	fixture := newSigningRunFixture(t, signingRunFixtureOptions{})
+	identityPath := filepath.Join(t.TempDir(), "App.p12")
+	identityPasswordPath := filepath.Join(t.TempDir(), "identity-password")
+	keychainPasswordPath := filepath.Join(t.TempDir(), "keychain-password")
+	writePrivateTestFile(t, identityPath, fixture.identity)
+	writePrivateTestFile(t, identityPasswordPath, []byte(fixture.password))
+	writePrivateTestFile(t, keychainPasswordPath, []byte("keychain-secret"))
+	keychainPath := filepath.Join(t.TempDir(), "release.keychain-db")
+
+	originalSearchList := []string{"login.keychain-db"}
+	deleted := false
+	var setCalls [][]string
+	deps := signingKeychainInstallDeps{
+		GOOS:              "darwin",
+		SecurityAvailable: true,
+		Now:               func() time.Time { return fixture.now },
+		CreateKeychain:    func(context.Context, string, []byte) error { return nil },
+		ImportIdentity:    func(context.Context, string, []byte, []byte, []byte, string) error { return nil },
+		KeychainSearchList: func(context.Context) ([]string, error) {
+			return append([]string(nil), originalSearchList...), nil
+		},
+		SetKeychainSearchList: func(_ context.Context, paths []string) error {
+			setCalls = append(setCalls, append([]string(nil), paths...))
+			if len(setCalls) == 1 {
+				return errors.New("search list failed")
+			}
+			return nil
+		},
+		DeleteKeychain: func(context.Context, string) error {
+			deleted = true
+			return nil
+		},
+	}
+	_, err := executeSigningKeychainInstallWith(context.Background(), signingKeychainInstallOptions{
+		IdentityPath: identityPath, IdentityPasswordPath: identityPasswordPath,
+		KeychainPath: keychainPath, KeychainPasswordPath: keychainPasswordPath,
+		AddToSearchList: true,
+	}, deps)
+	if err == nil || !strings.Contains(err.Error(), "search list failed") || !deleted {
+		t.Fatalf("error = %v deleted=%v", err, deleted)
+	}
+	if len(setCalls) != 2 || !reflect.DeepEqual(setCalls[1], originalSearchList) {
+		t.Fatalf("search-list calls = %v, want failed activation followed by exact restoration", setCalls)
+	}
+}
+
+func TestExecuteSigningKeychainInstallRollbackPreservesPreexistingStaleSearchEntry(t *testing.T) {
+	fixture := newSigningRunFixture(t, signingRunFixtureOptions{})
+	identityPath := filepath.Join(t.TempDir(), "App.p12")
+	identityPasswordPath := filepath.Join(t.TempDir(), "identity-password")
+	keychainPasswordPath := filepath.Join(t.TempDir(), "keychain-password")
+	writePrivateTestFile(t, identityPath, fixture.identity)
+	writePrivateTestFile(t, identityPasswordPath, []byte(fixture.password))
+	writePrivateTestFile(t, keychainPasswordPath, []byte("keychain-secret"))
+	keychainPath := filepath.Join(t.TempDir(), "release.keychain-db")
+	resolvedKeychainPath := canonicalSigningKeychainTestPath(t, keychainPath)
+	originalSearchList := []string{"login.keychain-db", resolvedKeychainPath}
+
+	var restored []string
+	_, err := executeSigningKeychainInstallWith(context.Background(), signingKeychainInstallOptions{
+		IdentityPath: identityPath, IdentityPasswordPath: identityPasswordPath,
+		KeychainPath: keychainPath, KeychainPasswordPath: keychainPasswordPath,
+		AddToSearchList: true,
+	}, signingKeychainInstallDeps{
+		GOOS:              "darwin",
+		SecurityAvailable: true,
+		Now:               func() time.Time { return fixture.now },
+		CreateKeychain:    func(context.Context, string, []byte) error { return nil },
+		ImportIdentity: func(context.Context, string, []byte, []byte, []byte, string) error {
+			return errors.New("import failed")
+		},
+		KeychainSearchList:    func(context.Context) ([]string, error) { return append([]string(nil), originalSearchList...), nil },
+		SetKeychainSearchList: func(_ context.Context, paths []string) error { restored = append([]string(nil), paths...); return nil },
+		DeleteKeychain:        func(context.Context, string) error { return nil },
+	})
+	if err == nil || !strings.Contains(err.Error(), "import failed") {
+		t.Fatalf("error = %v, want import failure", err)
+	}
+	if !reflect.DeepEqual(restored, originalSearchList) {
+		t.Fatalf("restored search list = %v, want %v", restored, originalSearchList)
+	}
+}
+
+func TestSigningKeychainInstallLiveDedicatedKeychain(t *testing.T) {
+	if os.Getenv("ASC_SIGNING_KEYCHAIN_INSTALL_LIVE_TEST") != "1" {
+		t.Skip("set ASC_SIGNING_KEYCHAIN_INSTALL_LIVE_TEST=1 to exercise a disposable persistent keychain")
+	}
+	deps := platformSigningKeychainInstallDeps()
+	if deps.GOOS != "darwin" || !deps.SecurityAvailable {
+		t.Skip("requires a cgo-enabled macOS build")
+	}
+	before, err := deps.KeychainSearchList(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fixture := newSigningRunFixture(t, signingRunFixtureOptions{})
+	directory := t.TempDir()
+	identityPath := filepath.Join(directory, "App.p12")
+	identityPasswordPath := filepath.Join(directory, "identity-password")
+	keychainPasswordPath := filepath.Join(directory, "keychain-password")
+	keychainPath := filepath.Join(directory, "release.keychain-db")
+	writePrivateTestFile(t, identityPath, fixture.identity)
+	writePrivateTestFile(t, identityPasswordPath, []byte(fixture.password))
+	writePrivateTestFile(t, keychainPasswordPath, []byte("live-keychain-secret"))
+	resolvedKeychainPath := canonicalSigningKeychainTestPath(t, keychainPath)
+	t.Cleanup(func() {
+		_ = deps.RemoveKeychainSearchEntry(context.Background(), resolvedKeychainPath)
+		_ = deps.DeleteKeychain(context.Background(), resolvedKeychainPath)
+	})
+
+	result, err := executeSigningKeychainInstallWith(context.Background(), signingKeychainInstallOptions{
+		IdentityPath: identityPath, IdentityPasswordPath: identityPasswordPath,
+		KeychainPath: keychainPath, KeychainPasswordPath: keychainPasswordPath,
+		AddToSearchList: true,
+	}, deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Action != "installed" || !result.SearchListUpdated {
+		t.Fatalf("result = %+v", result)
+	}
+	installedList, err := deps.KeychainSearchList(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(installedList, resolvedKeychainPath) {
+		t.Fatalf("installed keychain is missing from search list: %v", installedList)
+	}
+	if err := deps.RemoveKeychainSearchEntry(context.Background(), resolvedKeychainPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := deps.DeleteKeychain(context.Background(), resolvedKeychainPath); err != nil {
+		t.Fatal(err)
+	}
+	after, err := deps.KeychainSearchList(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("keychain search list changed: before=%v after=%v", before, after)
+	}
+}
+
+func canonicalSigningKeychainTestPath(t *testing.T, path string) string {
+	t.Helper()
+	parent, err := filepath.EvalSymlinks(filepath.Dir(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return filepath.Join(parent, filepath.Base(path))
+}

--- a/internal/cli/signing/signing_run_security_darwin.go
+++ b/internal/cli/signing/signing_run_security_darwin.go
@@ -74,7 +74,7 @@ static OSStatus asc_signing_keychain_import_pkcs12(
     const void *values[] = { application };
     applications = CFArrayCreate(NULL, values, 1, &kCFTypeArrayCallBacks);
     if (applications == NULL) { status = errSecAllocate; goto cleanup; }
-    status = SecAccessCreate(CFSTR("ASC ephemeral signing"), applications, &access);
+    status = SecAccessCreate(CFSTR("ASC signing identity"), applications, &access);
     if (status != errSecSuccess) goto cleanup;
 
     SecItemImportExportKeyParameters parameters = {

--- a/internal/cli/signing/signing_run_security_darwin.go
+++ b/internal/cli/signing/signing_run_security_darwin.go
@@ -9,11 +9,18 @@ package signing
 #include <Security/Security.h>
 #include <stdlib.h>
 
-static OSStatus asc_signing_keychain_create(
+typedef struct {
+    OSStatus operation_status;
+    OSStatus cleanup_status;
+} ASCSigningKeychainCreateResult;
+
+static ASCSigningKeychainCreateResult asc_signing_keychain_create(
     const char *path,
     const unsigned char *password,
-    size_t password_length
+    size_t password_length,
+    Boolean delete_on_unlock_failure
 ) {
+    ASCSigningKeychainCreateResult result = { errSecSuccess, errSecSuccess };
     SecKeychainRef keychain = NULL;
     OSStatus status = SecKeychainCreate(
         path,
@@ -30,11 +37,15 @@ static OSStatus asc_signing_keychain_create(
             password,
             true
         );
+        if (status != errSecSuccess && delete_on_unlock_failure) {
+            result.cleanup_status = SecKeychainDelete(keychain);
+        }
     }
+    result.operation_status = status;
     if (keychain != NULL) {
         CFRelease(keychain);
     }
-    return status;
+    return result;
 }
 
 static OSStatus asc_signing_keychain_import_pkcs12(
@@ -112,6 +123,7 @@ cleanup:
 import "C"
 
 import (
+	"errors"
 	"fmt"
 	"unsafe"
 )
@@ -119,20 +131,42 @@ import (
 func signingRunSecurityAvailable() bool { return true }
 
 func createKeychainWithSecurityFramework(path string, password []byte) error {
+	return createKeychainWithSecurityFrameworkMode(path, password, false)
+}
+
+func createPersistentKeychainWithSecurityFramework(path string, password []byte) error {
+	return createKeychainWithSecurityFrameworkMode(path, password, true)
+}
+
+func createKeychainWithSecurityFrameworkMode(path string, password []byte, deleteOnUnlockFailure bool) error {
 	if len(password) == 0 {
 		return fmt.Errorf("keychain password is empty")
 	}
 	cPath := C.CString(path)
 	defer C.free(unsafe.Pointer(cPath))
-	status := C.asc_signing_keychain_create(
+	deleteOnUnlockFailureValue := C.Boolean(0)
+	if deleteOnUnlockFailure {
+		deleteOnUnlockFailureValue = C.Boolean(1)
+	}
+	result := C.asc_signing_keychain_create(
 		cPath,
 		(*C.uchar)(unsafe.Pointer(&password[0])),
 		C.size_t(len(password)),
+		deleteOnUnlockFailureValue,
 	)
-	if status != 0 {
-		return fmt.Errorf("security framework status %d", int32(status))
+	return securityFrameworkKeychainCreationError(int32(result.operation_status), int32(result.cleanup_status))
+}
+
+func securityFrameworkKeychainCreationError(operationStatus, cleanupStatus int32) error {
+	var operationErr error
+	if operationStatus != 0 {
+		operationErr = fmt.Errorf("security framework status %d", operationStatus)
 	}
-	return nil
+	var cleanupErr error
+	if cleanupStatus != 0 {
+		cleanupErr = fmt.Errorf("security framework keychain cleanup status %d", cleanupStatus)
+	}
+	return errors.Join(operationErr, cleanupErr)
 }
 
 func importPKCS12WithSecurityFramework(keychainPath string, data, password []byte) error {

--- a/internal/cli/signing/signing_run_security_darwin_nocgo.go
+++ b/internal/cli/signing/signing_run_security_darwin_nocgo.go
@@ -10,6 +10,10 @@ func createKeychainWithSecurityFramework(string, []byte) error {
 	return fmt.Errorf("signing run requires a cgo-enabled macOS build")
 }
 
+func createPersistentKeychainWithSecurityFramework(string, []byte) error {
+	return fmt.Errorf("signing run requires a cgo-enabled macOS build")
+}
+
 func importPKCS12WithSecurityFramework(string, []byte, []byte) error {
 	return fmt.Errorf("signing run requires a cgo-enabled macOS build")
 }


### PR DESCRIPTION
## Summary

- add experimental `asc signing keychain install` for one verified PKCS#12 identity in a new dedicated macOS keychain
- require protected password files and `--confirm`, refuse existing destinations, and keep the default keychain unchanged
- optionally append the new keychain to the user search list while preserving order
- document the persistent workflow, CI cleanup contract, output receipt, limitations, and rollback behavior

## Safety and behavior

The command validates the destination, private input-file permissions, PKCS#12 private-key binding, certificate validity and code-signing usage, team identifier, optional SHA-256 fingerprint, and output format before creating the keychain. Passwords are passed through the Security framework or stdin, never subprocess arguments or output.

The destination is a new dedicated keychain, so partition-list changes cannot affect unrelated identities. Import and codesigning are verified before success. Any failure after creation deletes the keychain and restores the original search list. Without `--add-to-search-list`, an automatic host-created entry is removed.

The public receipt reports only the absolute keychain path, certificate fingerprints, team ID, and whether the search list changed. Provisioning profiles remain an explicit `asc profiles local install` step.

## Verification

- `make format`
- `make check-docs`
- `make build`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- focused cgo-disabled and Linux/Windows compile checks
- disposable macOS keychain integration test, including identity import, codesign probe, search-list activation, removal, and deletion
- built CLI missing-confirm check: exit 2, empty stdout


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the experimental `signing keychain install` command for persistent macOS keychain setup.
  * Supports validated PKCS#12 identity installation, fingerprint checks, search-list activation, and cleanup after failures or cancellation.
  * Added human-readable and JSON installation receipts with keychain, certificate, and team metadata.
* **Documentation**
  * Expanded signing and CI guidance with profile selection, multi-target pulls, profile matching, migration handling, lifecycle management, and embedded-target export examples.
* **Bug Fixes**
  * Improved signing identity labeling and strengthened cleanup and rollback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->