### PR TITLE
feat(signing): sync direct distribution identities

### DIFF
--- a/commands/signing.mdx
+++ b/commands/signing.mdx
@@ -274,7 +274,7 @@ asc signing sync push \
 
 `--private-key` accepts RSA or EC PEM keys and always requires the certificate fingerprint. The CLI checks the private key's public half against the selected active, unexpired App Store Connect certificate and the certificate embedded in the profile.
 
-Private identity sync does not yet support `MAC_APP_DIRECT` or `MAC_CATALYST_APP_DIRECT`. Certificate-and-profile-only sync still works for those types when `--identity` and `--private-key` are omitted.
+Private identity sync supports `MAC_APP_DIRECT` and `MAC_CATALYST_APP_DIRECT` with the same protected `--identity` or `--private-key` inputs. The command requires the exact active API profile type, resolves the associated Developer ID Application certificate, and verifies the local private key, API certificate, embedded profile certificate, team, bundle ID, and signed profile as one identity before publication.
 
 ### Sync an app and embedded targets together
 

--- a/commands/signing.mdx
+++ b/commands/signing.mdx
@@ -274,7 +274,7 @@ asc signing sync push \
 
 `--private-key` accepts RSA or EC PEM keys and always requires the certificate fingerprint. The CLI checks the private key's public half against the selected active, unexpired App Store Connect certificate and the certificate embedded in the profile.
 
-Private identity sync supports `MAC_APP_DIRECT` and `MAC_CATALYST_APP_DIRECT` with the same protected `--identity` or `--private-key` inputs. The command requires the exact active API profile type, resolves the associated Developer ID Application certificate, and verifies the local private key, API certificate, embedded profile certificate, team, bundle ID, and signed profile as one identity before publication.
+Private identity sync supports `MAC_APP_DIRECT` and `MAC_CATALYST_APP_DIRECT` with the same protected `--identity` or `--private-key` inputs. The command requires the exact active API profile type, accepts associated Developer ID Application certificates from either supported generation, and verifies the local private key, API certificate, embedded profile certificate, signed macOS platform and all-device claims, team, bundle ID, and signed profile as one identity before publication.
 
 ### Sync an app and embedded targets together
 

--- a/commands/signing.mdx
+++ b/commands/signing.mdx
@@ -164,6 +164,7 @@ The command does not overwrite output files. This prevents a failed write from s
 | `MAC_APP_DIRECT` | Developer ID distribution | Developer ID Application | No |
 | `MAC_CATALYST_APP_STORE` | Mac Catalyst App Store | Mac distribution | No |
 | `MAC_CATALYST_APP_DEVELOPMENT` | Mac Catalyst development | Mac development | Yes |
+| `MAC_CATALYST_APP_DIRECT` | Mac Catalyst Developer ID distribution | Developer ID Application | No |
 
 Use `--certificate-type` only when the inferred type is not the one you need.
 

--- a/docs/design/signing-private-identity-sync.md
+++ b/docs/design/signing-private-identity-sync.md
@@ -22,6 +22,14 @@ asc signing sync push \
   --password-file ~/.config/asc/signing-sync-password \
   --private-key ./distribution-key.pem \
   --identity-sha256 <64-hex-ASC-certificate-fingerprint>
+
+asc signing sync push \
+  --bundle-id com.example.mac \
+  --profile-type MAC_APP_DIRECT \
+  --repo git@github.com:team/signing.git \
+  --password-file ~/.config/asc/signing-sync-password \
+  --identity ./developer-id-application.p12 \
+  --identity-password-file ~/.config/asc/developer-id-password
 ```
 
 `--identity` and `--private-key` are mutually exclusive. A PKCS#12 containing
@@ -43,11 +51,21 @@ result reports `identityPresent: false`. Pull results list decrypted identity
 artifacts separately in `sensitiveFiles`. Sensitive identities are new-only and
 mode `0600`; new ordinary outputs also use `0600`, while existing ordinary
 certificate/profile outputs retain their prior mode during atomic replacement.
-Private identity sync rejects `MAC_APP_DIRECT` and `MAC_CATALYST_APP_DIRECT`
-before reading secrets or mutating App Store Connect because their signed-profile
-semantics are not supported yet; certificate/profile-only sync remains available.
+Private identity sync also accepts `MAC_APP_DIRECT` and
+`MAC_CATALYST_APP_DIRECT`. Their signed distribution claims overlap with store
+profiles, so the command does not infer the exact type from the profile plist.
+It requires the exact active profile type returned by App Store Connect,
+resolves the associated Developer ID Application certificate, and verifies
+that the local private key, API certificate, embedded profile certificate,
+team, bundle ID, and signed profile all agree before publication.
 Data is written to stdout, progress and deprecation warnings to stderr, invalid
 flag combinations use exit code 2, and operational failures use exit code 1.
+
+The direct-distribution extension is additive: existing iOS, tvOS, Mac App
+Store, certificate-only, single-target, and multi-target invocations keep their
+behavior and output. No new secret source or output field is introduced. A
+missing local identity is therefore an operational input failure for direct
+profiles, not an unsupported-flag usage error.
 
 ## Identity validation and storage
 
@@ -92,16 +110,36 @@ all encrypted artifacts are published successfully; any local multi-file write
 failure returns before Git commit and cleanup removes the clone, so no partial
 identity graph reaches the remote repository.
 
+Treating every signed profile with no devices as direct distribution was
+rejected because App Store profiles have overlapping signed claims. Treating a
+filename or repository directory as authoritative was also rejected because
+those values are local conventions. The selected App Store Connect resource's
+exact `profileType` is the authoritative discriminator; the signed profile and
+associated Developer ID certificate then provide the cryptographic binding.
+
+If the API resource type is absent or differs from `--profile-type`, the
+command stops before publication. It also stops when the associated certificate
+does not match the local private key or embedded profile certificate, or when
+the profile team, bundle identifier, state, or expiration is invalid. Profile
+creation, when requested, still uses the existing preflight-before-mutation
+boundary and only the matching certificate.
+
 ## Tests and verification
 
 RED-GREEN coverage includes public flag validation and password-source
 compatibility, protected no-follow input reads, RSA and EC keys, single and
 multi-identity PKCS#12 parsing, certificate mismatch, profile/certificate/team
-and expiration checks, normalized PKCS#12 round trips, versioned authenticated
+and expiration checks, native Mac and Mac Catalyst direct-distribution
+identity validation, normalized PKCS#12 round trips, versioned authenticated
 envelopes, legacy envelope reads, `sensitiveFiles`, `0600` pull output, and
 secret canaries across output and errors. Focused signing packages, generated
 command docs, a command-level mock-ASC/local-Git push-pull round trip, and the normal repository gate
-complete verification. Live keychain or account mutation is outside this PR.
+complete verification. The direct extension adds synthetic signed-profile
+coverage for both native Mac and Mac Catalyst plus command-boundary coverage
+showing that local identity failures remain operational errors. Live account
+or keychain mutation is outside this extension; its remaining risk is provider
+data whose associated Developer ID certificate or profile content differs from
+the documented API contract, which fails closed before Git publication.
 
 ## Alternatives
 

--- a/docs/design/signing-private-identity-sync.md
+++ b/docs/design/signing-private-identity-sync.md
@@ -53,11 +53,12 @@ mode `0600`; new ordinary outputs also use `0600`, while existing ordinary
 certificate/profile outputs retain their prior mode during atomic replacement.
 Private identity sync also accepts `MAC_APP_DIRECT` and
 `MAC_CATALYST_APP_DIRECT`. Their signed distribution claims overlap with store
-profiles, so the command does not infer the exact type from the profile plist.
-It requires the exact active profile type returned by App Store Connect,
-resolves the associated Developer ID Application certificate, and verifies
-that the local private key, API certificate, embedded profile certificate,
-team, bundle ID, and signed profile all agree before publication.
+profiles in some fields, but direct profiles carry the all-device claim. The
+command requires that claim, the signed macOS platform claim, and the exact
+active profile type returned by App Store Connect, resolves associated Developer
+ID Application certificates from either supported generation, and verifies that
+the local private key, API certificate, embedded profile certificate, team,
+bundle ID, and signed profile all agree before publication.
 Data is written to stdout, progress and deprecation warnings to stderr, invalid
 flag combinations use exit code 2, and operational failures use exit code 1.
 
@@ -110,12 +111,15 @@ all encrypted artifacts are published successfully; any local multi-file write
 failure returns before Git commit and cleanup removes the clone, so no partial
 identity graph reaches the remote repository.
 
-Treating every signed profile with no devices as direct distribution was
-rejected because App Store profiles have overlapping signed claims. Treating a
-filename or repository directory as authoritative was also rejected because
-those values are local conventions. The selected App Store Connect resource's
-exact `profileType` is the authoritative discriminator; the signed profile and
-associated Developer ID certificate then provide the cryptographic binding.
+Treating every signed all-device profile as an exact direct-distribution type
+was rejected because that claim does not distinguish native Mac from Mac
+Catalyst and is also used by other distribution families. Treating a filename
+or repository directory as authoritative was also rejected because those values
+are local conventions. The all-device and macOS platform claims establish
+direct-distribution semantics, while the selected App Store Connect resource's
+exact `profileType` is the native Mac versus Mac Catalyst discriminator. The
+signed profile and associated Developer ID certificate then provide the
+cryptographic binding.
 
 If the API resource type is absent or differs from `--profile-type`, the
 command stops before publication. It also stops when the associated certificate
@@ -135,8 +139,9 @@ envelopes, legacy envelope reads, `sensitiveFiles`, `0600` pull output, and
 secret canaries across output and errors. Focused signing packages, generated
 command docs, a command-level mock-ASC/local-Git push-pull round trip, and the normal repository gate
 complete verification. The direct extension adds synthetic signed-profile
-coverage for both native Mac and Mac Catalyst plus command-boundary coverage
-showing that local identity failures remain operational errors. Live account
+coverage for both native Mac and Mac Catalyst, including missing and non-macOS
+platform-claim rejection, plus command-boundary coverage showing that local
+identity failures remain operational errors. Live account
 or keychain mutation is outside this extension; its remaining risk is provider
 data whose associated Developer ID certificate or profile content differs from
 the documented API contract, which fails closed before Git publication.

--- a/internal/cli/signing/signing_fetch.go
+++ b/internal/cli/signing/signing_fetch.go
@@ -631,13 +631,13 @@ func inferCertificateType(profileType string) (string, error) {
 	case strings.Contains(normalized, "MAC_CATALYST_APP_STORE"):
 		return "MAC_APP_DISTRIBUTION,DISTRIBUTION", nil
 	case strings.Contains(normalized, "MAC_CATALYST_APP_DIRECT"):
-		return "DEVELOPER_ID_APPLICATION", nil
+		return "DEVELOPER_ID_APPLICATION,DEVELOPER_ID_APPLICATION_G2", nil
 	case strings.Contains(normalized, "MAC_APP_DEVELOPMENT"):
 		return "MAC_APP_DEVELOPMENT,DEVELOPMENT", nil
 	case strings.Contains(normalized, "MAC_APP_STORE"):
 		return "MAC_APP_DISTRIBUTION,DISTRIBUTION", nil
 	case strings.Contains(normalized, "MAC_APP_DIRECT"):
-		return "DEVELOPER_ID_APPLICATION", nil
+		return "DEVELOPER_ID_APPLICATION,DEVELOPER_ID_APPLICATION_G2", nil
 	default:
 		return "", fmt.Errorf("unable to infer certificate type for profile type %s; use --certificate-type", profileType)
 	}

--- a/internal/cli/signing/signing_fetch_test.go
+++ b/internal/cli/signing/signing_fetch_test.go
@@ -855,6 +855,8 @@ func TestResolveSigningCertificateTypesIncludesCompatibleCertificatesForMacProfi
 		{profileType: "MAC_CATALYST_APP_DEVELOPMENT", want: "MAC_APP_DEVELOPMENT,DEVELOPMENT"},
 		{profileType: "MAC_APP_STORE", want: "MAC_APP_DISTRIBUTION,DISTRIBUTION"},
 		{profileType: "MAC_CATALYST_APP_STORE", want: "MAC_APP_DISTRIBUTION,DISTRIBUTION"},
+		{profileType: "MAC_APP_DIRECT", want: "DEVELOPER_ID_APPLICATION,DEVELOPER_ID_APPLICATION_G2"},
+		{profileType: "MAC_CATALYST_APP_DIRECT", want: "DEVELOPER_ID_APPLICATION,DEVELOPER_ID_APPLICATION_G2"},
 	}
 
 	for _, tt := range tests {

--- a/internal/cli/signing/signing_identity.go
+++ b/internal/cli/signing/signing_identity.go
@@ -303,7 +303,6 @@ type identityMobileProvision struct {
 	ExpirationDate              time.Time      `plist:"ExpirationDate"`
 	DeveloperCertificates       [][]byte       `plist:"DeveloperCertificates"`
 	Entitlements                map[string]any `plist:"Entitlements"`
-	Platform                    []string       `plist:"Platform"`
 	UUID                        string         `plist:"UUID"`
 	ProvisionedDevices          []string       `plist:"ProvisionedDevices"`
 	ProvisionsAllDevices        bool           `plist:"ProvisionsAllDevices"`

--- a/internal/cli/signing/signing_identity.go
+++ b/internal/cli/signing/signing_identity.go
@@ -302,6 +302,7 @@ type identityMobileProvision struct {
 	ExpirationDate              time.Time      `plist:"ExpirationDate"`
 	DeveloperCertificates       [][]byte       `plist:"DeveloperCertificates"`
 	Entitlements                map[string]any `plist:"Entitlements"`
+	Platform                    []string       `plist:"Platform"`
 	UUID                        string         `plist:"UUID"`
 	ProvisionedDevices          []string       `plist:"ProvisionedDevices"`
 	ProvisionsAllDevices        bool           `plist:"ProvisionsAllDevices"`

--- a/internal/cli/signing/signing_identity_test.go
+++ b/internal/cli/signing/signing_identity_test.go
@@ -192,6 +192,44 @@ func TestValidateIdentityForResolvedAssetsChecksProfileCertificateTeamAndBundle(
 	}
 }
 
+func TestValidateIdentityForResolvedAssetsAcceptsDirectDistributionProfiles(t *testing.T) {
+	key := mustECKey(t)
+	certificate := mustSigningCertificate(t, key, 41)
+	profilePlist, err := plist.Marshal(map[string]any{
+		"TeamIdentifier":              []string{"TEAM123"},
+		"ApplicationIdentifierPrefix": []string{"TEAM123"},
+		"ExpirationDate":              time.Now().Add(time.Hour),
+		"DeveloperCertificates":       [][]byte{certificate.Raw},
+		"Platform":                    []string{"OSX"},
+		"Entitlements": map[string]any{
+			"application-identifier": "TEAM123.com.example.mac",
+			"get-task-allow":         false,
+		},
+	}, plist.XMLFormat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certificates := &asc.CertificatesResponse{Data: []asc.Resource[asc.CertificateAttributes]{
+		identityCertificateResource(certificate),
+	}}
+	for _, profileType := range []string{"MAC_APP_DIRECT", "MAC_CATALYST_APP_DIRECT"} {
+		t.Run(profileType, func(t *testing.T) {
+			profile := &asc.ProfileResponse{Data: asc.Resource[asc.ProfileAttributes]{
+				ID: "profile-direct",
+				Attributes: asc.ProfileAttributes{
+					ProfileContent: base64.StdEncoding.EncodeToString(mustSignedCMS(t, profilePlist, certificate, key)),
+					ProfileType:    profileType,
+					ProfileState:   asc.ProfileStateActive,
+				},
+			}}
+			identity := &signingIdentity{PrivateKey: key}
+			if err := validateIdentityForResolvedAssets(identity, profile, certificates, "com.example.mac", profileType, time.Now()); err != nil {
+				t.Fatalf("validate direct-distribution identity: %v", err)
+			}
+		})
+	}
+}
+
 func TestValidateIdentityForResolvedAssetsRequiresExactBundleAndProfileType(t *testing.T) {
 	key := mustECKey(t)
 	certificate := mustSigningCertificate(t, key, 9)

--- a/internal/cli/signing/signing_identity_test.go
+++ b/internal/cli/signing/signing_identity_test.go
@@ -201,6 +201,7 @@ func TestValidateIdentityForResolvedAssetsAcceptsDirectDistributionProfiles(t *t
 		"ExpirationDate":              time.Now().Add(time.Hour),
 		"DeveloperCertificates":       [][]byte{certificate.Raw},
 		"Platform":                    []string{"OSX"},
+		"ProvisionsAllDevices":        true,
 		"Entitlements": map[string]any{
 			"application-identifier": "TEAM123.com.example.mac",
 			"get-task-allow":         false,

--- a/internal/cli/signing/signing_sync.go
+++ b/internal/cli/signing/signing_sync.go
@@ -234,9 +234,6 @@ func syncPushCommand() *ffcli.Command {
 			if privateKeyInput != "" && strings.TrimSpace(*identitySHA256) == "" {
 				return shared.UsageError("--identity-sha256 is required with --private-key to select one App Store Connect certificate")
 			}
-			if (identityInput != "" || privateKeyInput != "") && isDirectDistributionProfile(profType) {
-				return shared.UsageErrorf("private identity sync does not support --profile-type %s yet; omit --identity/--private-key", profType)
-			}
 			requestedFingerprint, fingerprintErr := normalizeCertificateFingerprint(*identitySHA256)
 			if fingerprintErr != nil {
 				return shared.UsageError(fingerprintErr.Error())
@@ -817,6 +814,11 @@ func identityProfileTypeMatches(profile *identityMobileProvision, profileType st
 	case strings.Contains(normalized, "INHOUSE"), strings.Contains(normalized, "IN_HOUSE"):
 		return !getTaskAllow && profile.ProvisionsAllDevices
 	case strings.Contains(normalized, "STORE"):
+		return !getTaskAllow && len(profile.ProvisionedDevices) == 0 && !profile.ProvisionsAllDevices
+	case isDirectDistributionProfile(normalized):
+		// The signed distribution claims overlap with store profiles. Exact
+		// direct-distribution provenance comes from the API profile type, and
+		// the resolved Developer ID certificate is still matched byte-for-byte.
 		return !getTaskAllow && len(profile.ProvisionedDevices) == 0 && !profile.ProvisionsAllDevices
 	default:
 		return false

--- a/internal/cli/signing/signing_sync.go
+++ b/internal/cli/signing/signing_sync.go
@@ -939,17 +939,15 @@ func identityProfileTypeMatches(profile *identityMobileProvision, profileType st
 	case strings.Contains(normalized, "ADHOC"), strings.Contains(normalized, "AD_HOC"):
 		return !getTaskAllow && len(profile.ProvisionedDevices) > 0 && !profile.ProvisionsAllDevices
 	case isDirectDistributionProfile(normalized):
-		return !getTaskAllow && profile.ProvisionsAllDevices
-	case strings.Contains(normalized, "INHOUSE"), strings.Contains(normalized, "IN_HOUSE"):
-		return !getTaskAllow && profile.ProvisionsAllDevices
-	case strings.Contains(normalized, "STORE"):
-		return !getTaskAllow && len(profile.ProvisionedDevices) == 0 && !profile.ProvisionsAllDevices
-	case isDirectDistributionProfile(normalized):
 		// Direct profiles use the all-device claim. Exact native Mac versus Mac
 		// Catalyst provenance still comes from the API profile type, and the
 		// resolved Developer ID certificate is matched byte-for-byte.
 		return !getTaskAllow && len(profile.ProvisionedDevices) == 0 && profile.ProvisionsAllDevices &&
 			len(profile.Platform) == 1 && strings.EqualFold(strings.TrimSpace(profile.Platform[0]), "OSX")
+	case strings.Contains(normalized, "INHOUSE"), strings.Contains(normalized, "IN_HOUSE"):
+		return !getTaskAllow && profile.ProvisionsAllDevices
+	case strings.Contains(normalized, "STORE"):
+		return !getTaskAllow && len(profile.ProvisionedDevices) == 0 && !profile.ProvisionsAllDevices
 	default:
 		return false
 	}

--- a/internal/cli/signing/signing_sync.go
+++ b/internal/cli/signing/signing_sync.go
@@ -816,10 +816,11 @@ func identityProfileTypeMatches(profile *identityMobileProvision, profileType st
 	case strings.Contains(normalized, "STORE"):
 		return !getTaskAllow && len(profile.ProvisionedDevices) == 0 && !profile.ProvisionsAllDevices
 	case isDirectDistributionProfile(normalized):
-		// The signed distribution claims overlap with store profiles. Exact
-		// direct-distribution provenance comes from the API profile type, and
-		// the resolved Developer ID certificate is still matched byte-for-byte.
-		return !getTaskAllow && len(profile.ProvisionedDevices) == 0 && !profile.ProvisionsAllDevices
+		// Direct profiles use the all-device claim. Exact native Mac versus Mac
+		// Catalyst provenance still comes from the API profile type, and the
+		// resolved Developer ID certificate is matched byte-for-byte.
+		return !getTaskAllow && len(profile.ProvisionedDevices) == 0 && profile.ProvisionsAllDevices &&
+			len(profile.Platform) == 1 && strings.EqualFold(strings.TrimSpace(profile.Platform[0]), "OSX")
 	default:
 		return false
 	}

--- a/internal/cli/signing/signing_sync_test.go
+++ b/internal/cli/signing/signing_sync_test.go
@@ -1043,7 +1043,8 @@ func TestSigningSyncRejectsBlankPasswordFile(t *testing.T) {
 	}
 }
 
-func TestSigningSyncPushRejectsDirectDistributionIdentityBeforeSecretReads(t *testing.T) {
+func TestSigningSyncPushDirectDistributionIdentityLoadFailureIsOperational(t *testing.T) {
+	t.Setenv(signingSyncPasswordEnvVar, "repository-password")
 	for _, profileType := range []string{"MAC_APP_DIRECT", "MAC_CATALYST_APP_DIRECT"} {
 		t.Run(profileType, func(t *testing.T) {
 			cmd := syncPushCommand()
@@ -1056,9 +1057,11 @@ func TestSigningSyncPushRejectsDirectDistributionIdentityBeforeSecretReads(t *te
 				t.Fatal(err)
 			}
 			err := cmd.Run(context.Background())
-			want := "private identity sync does not support --profile-type " + profileType + " yet; omit --identity/--private-key"
-			if err == nil || err.Error() != want || !errors.Is(err, flag.ErrHelp) {
-				t.Fatalf("error = %v, want usage error %q", err, want)
+			if err == nil || !strings.Contains(err.Error(), "signing sync push: signing identity") {
+				t.Fatalf("error = %v, want operational identity-load failure", err)
+			}
+			if errors.Is(err, flag.ErrHelp) {
+				t.Fatalf("error = %v, want operational error", err)
 			}
 		})
 	}

--- a/internal/cli/signing/signing_sync_test.go
+++ b/internal/cli/signing/signing_sync_test.go
@@ -1067,6 +1067,50 @@ func TestSigningSyncPushDirectDistributionIdentityLoadFailureIsOperational(t *te
 	}
 }
 
+func TestIdentityProfileTypeMatchesDirectRequiresAllDeviceClaim(t *testing.T) {
+	profile := &identityMobileProvision{
+		Entitlements: map[string]any{"get-task-allow": false},
+		Platform:     []string{"OSX"},
+	}
+	for _, profileType := range []string{"MAC_APP_DIRECT", "MAC_CATALYST_APP_DIRECT"} {
+		if identityProfileTypeMatches(profile, profileType) {
+			t.Fatalf("%s matched without the all-device claim", profileType)
+		}
+		profile.ProvisionsAllDevices = true
+		if !identityProfileTypeMatches(profile, profileType) {
+			t.Fatalf("%s did not match its all-device claim", profileType)
+		}
+		profile.ProvisionedDevices = []string{"DEVICE1"}
+		if identityProfileTypeMatches(profile, profileType) {
+			t.Fatalf("%s matched with an explicit device list", profileType)
+		}
+		profile.ProvisionedDevices = nil
+		profile.ProvisionsAllDevices = false
+	}
+	profile.ProvisionsAllDevices = true
+	profile.Entitlements["get-task-allow"] = true
+	if identityProfileTypeMatches(profile, "MAC_APP_DIRECT") {
+		t.Fatal("direct profile matched with debugging enabled")
+	}
+}
+
+func TestIdentityProfileTypeMatchesDirectRequiresMacOSPlatformClaim(t *testing.T) {
+	profile := &identityMobileProvision{
+		Entitlements:         map[string]any{"get-task-allow": false},
+		ProvisionsAllDevices: true,
+	}
+	for _, platform := range [][]string{nil, {}, {"iOS"}, {"OSX", "iOS"}} {
+		profile.Platform = platform
+		if identityProfileTypeMatches(profile, "MAC_APP_DIRECT") {
+			t.Fatalf("direct profile matched platform claim %v", platform)
+		}
+	}
+	profile.Platform = []string{"OSX"}
+	if !identityProfileTypeMatches(profile, "MAC_APP_DIRECT") {
+		t.Fatal("direct profile did not match its macOS platform claim")
+	}
+}
+
 func TestSigningSyncPushIdentityLoadFailureIsOperational(t *testing.T) {
 	t.Setenv(signingSyncPasswordEnvVar, "repository-password")
 	cmd := syncPushCommand()


### PR DESCRIPTION
## Summary
- allow protected PKCS#12 and PEM private identity sync for `MAC_APP_DIRECT` and `MAC_CATALYST_APP_DIRECT`
- require the signed macOS platform and all-device claims while keeping exact API `profileType` as the authoritative native Mac versus Mac Catalyst discriminator
- accept associated Developer ID Application certificates from both supported generations
- verify the local key, active associated certificate, embedded profile certificate, team, bundle ID, profile state, and expiration before Git publication
- document the invocation, compatibility boundary, failure modes, tradeoffs, and remaining live-verification limit

## Behavior and safety
The command uses the existing `asc signing sync push` flags and output. Direct-distribution input errors are operational failures instead of unsupported-flag usage errors. No new secret source or output field is introduced.

A direct profile must carry the signed macOS platform and all-device claims, must not list explicit devices, and must disable debugging. Those signed claims establish the distribution family but do not distinguish native Mac from Mac Catalyst, so the exact active App Store Connect resource type must still match `--profile-type`. The associated certificate may use either supported Developer ID Application generation and must match both the local private key and the certificate embedded in the signed profile. Every validation completes before the encrypted repository is committed or pushed.

## Compatibility
Existing certificate-only, iOS, tvOS, Mac App Store, single-target, and multi-target workflows retain their behavior and JSON shape. The extension is additive and remains within the experimental signing-sync surface.

## Alternatives and tradeoffs
Treating every all-device profile as an exact direct-distribution type was rejected because the claim does not distinguish native Mac from Mac Catalyst and appears in other distribution families. Adding a separate command would duplicate the existing encrypted identity graph and publication boundary. Combining signed distribution-family claims with the exact API resource type keeps one store while failing closed on absent, mismatched, inactive, expired, or cryptographically inconsistent data.

## Verification
- RED: direct profiles failed when the real all-device claim was present; default certificate inference omitted the second supported generation; missing and non-macOS signed platform claims were accepted
- GREEN: both exact direct types require macOS/all-device claims, accept either certificate generation, and reject malformed signed claims
- focused signing regressions and signing package tests
- `make format`
- `make check-docs`
- `make build`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- repository commit gate

A read-only live account query confirmed the certificate endpoint exposes a Developer ID Application certificate. The account had no active direct-distribution profiles, so this PR does not claim live profile-content validation and performs no account mutation.

## Remaining risk
Provider data that omits the exact profile type or does not bind the associated certificate as documented will fail before Git publication. Live creation was intentionally not attempted on a non-disposable signing setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added password rotation for signing repositories.
  * Added persistent macOS keychain installation workflows with validation, cleanup, and receipts.
  * Added selective signing-asset pulls by bundle or profile type.
  * Added support for macOS and Mac Catalyst direct-distribution profiles.

* **Bug Fixes**
  * Improved validation of certificates, provisioning profiles, platform claims, and distribution settings.
  * Added support for both Developer ID Application certificate generations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
