### PR TITLE
Add version rating reset commands

### DIFF
--- a/commands/versions.mdx
+++ b/commands/versions.mdx
@@ -317,6 +317,60 @@ asc versions release --version-id "VERSION_ID" --confirm
 
 ***
 
+### `asc versions rating-reset`
+
+**[experimental]** Schedule, inspect, or cancel the overview-rating reset for
+an App Store version. Apple doesn't include this web-session endpoint in its
+published OpenAPI specification, so the resource may change without notice.
+
+The reset affects every country or region for the selected platform when the
+version is released. Written reviews remain visible. After release, the
+previous overview rating can't be restored.
+
+These commands use an authenticated Apple Account web session. Run `asc web
+auth login` first when no valid cached session is available. Use `--apple-id`
+to select a specific cached account and `--provider-id` or
+`--public-provider-id` to select its App Store Connect provider.
+
+View the current request:
+
+```bash  theme={null}
+asc versions rating-reset view --version-id "VERSION_ID"
+```
+
+Schedule a reset:
+
+```bash  theme={null}
+asc versions rating-reset create --version-id "VERSION_ID" --confirm
+```
+
+Cancel it before release:
+
+```bash  theme={null}
+asc versions rating-reset delete --id "RESET_REQUEST_ID" --confirm
+```
+
+The create command returns:
+
+```json  theme={null}
+{
+  "ratingResetRequestId": "RESET_REQUEST_ID",
+  "versionId": "VERSION_ID",
+  "scheduled": true
+}
+```
+
+The delete command returns:
+
+```json  theme={null}
+{
+  "ratingResetRequestId": "RESET_REQUEST_ID",
+  "cancelled": true
+}
+```
+
+***
+
 ## Common Usage Patterns
 
 ### Create a new version and attach a build

--- a/internal/asc/output_registry_init.go
+++ b/internal/asc/output_registry_init.go
@@ -407,6 +407,8 @@ func registerAllOutputRenderers() {
 	registerRowsWithSingleToListAdapter[ReviewSubmissionItemResponse, ReviewSubmissionItemsResponse](reviewSubmissionItemsRows)
 	registerRows(reviewSubmissionItemDeleteResultRows)
 	registerRows(appStoreVersionReleaseRequestRows)
+	registerRows(appStoreVersionRatingResetCreateRows)
+	registerRows(appStoreVersionRatingResetDeleteRows)
 	registerRows(appStoreVersionPromotionCreateRows)
 	registerRows(appStoreVersionPhasedReleaseRows)
 	registerRows(appStoreVersionPhasedReleaseDeleteResultRows)

--- a/internal/asc/output_versions.go
+++ b/internal/asc/output_versions.go
@@ -70,6 +70,19 @@ type AppStoreVersionReleaseRequestResult struct {
 	VersionID        string `json:"versionId"`
 }
 
+// AppStoreVersionRatingResetCreateResult represents CLI output for scheduling a rating reset.
+type AppStoreVersionRatingResetCreateResult struct {
+	RatingResetRequestID string `json:"ratingResetRequestId"`
+	VersionID            string `json:"versionId"`
+	Scheduled            bool   `json:"scheduled"`
+}
+
+// AppStoreVersionRatingResetDeleteResult represents CLI output for cancelling a rating reset.
+type AppStoreVersionRatingResetDeleteResult struct {
+	RatingResetRequestID string `json:"ratingResetRequestId"`
+	Cancelled            bool   `json:"cancelled"`
+}
+
 // AppStoreVersionsLatestResult represents a computed latest-version list.
 // Unlike a raw API response, its pagination fields describe only the selected
 // items and cannot retain stale metadata from the aggregated source pages.
@@ -187,5 +200,17 @@ func appStoreVersionAttachBuildRows(result *AppStoreVersionAttachBuildResult) ([
 func appStoreVersionReleaseRequestRows(result *AppStoreVersionReleaseRequestResult) ([]string, [][]string) {
 	headers := []string{"Release Request ID", "Version ID"}
 	rows := [][]string{{result.ReleaseRequestID, result.VersionID}}
+	return headers, rows
+}
+
+func appStoreVersionRatingResetCreateRows(result *AppStoreVersionRatingResetCreateResult) ([]string, [][]string) {
+	headers := []string{"Rating Reset Request ID", "Version ID", "Scheduled"}
+	rows := [][]string{{result.RatingResetRequestID, result.VersionID, fmt.Sprintf("%t", result.Scheduled)}}
+	return headers, rows
+}
+
+func appStoreVersionRatingResetDeleteRows(result *AppStoreVersionRatingResetDeleteResult) ([]string, [][]string) {
+	headers := []string{"Rating Reset Request ID", "Cancelled"}
+	rows := [][]string{{result.RatingResetRequestID, fmt.Sprintf("%t", result.Cancelled)}}
 	return headers, rows
 }

--- a/internal/asc/output_versions_test.go
+++ b/internal/asc/output_versions_test.go
@@ -209,3 +209,36 @@ func TestSubmissionAndVersionDetailRows_UseDisplayPlatform(t *testing.T) {
 		t.Fatalf("expected unknown detail platform passthrough CAR_OS, got %q", detailRows[0][2])
 	}
 }
+
+func TestPrintTable_AppStoreVersionRatingResetCreateResult(t *testing.T) {
+	result := &AppStoreVersionRatingResetCreateResult{
+		RatingResetRequestID: "reset-123",
+		VersionID:            "version-123",
+		Scheduled:            true,
+	}
+
+	output := captureStdout(t, func() error {
+		return PrintTable(result)
+	})
+	for _, want := range []string{"Rating Reset Request ID", "Version ID", "Scheduled", "reset-123", "version-123", "true"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output = %q, want %q", output, want)
+		}
+	}
+}
+
+func TestPrintMarkdown_AppStoreVersionRatingResetDeleteResult(t *testing.T) {
+	result := &AppStoreVersionRatingResetDeleteResult{
+		RatingResetRequestID: "reset-123",
+		Cancelled:            true,
+	}
+
+	output := captureStdout(t, func() error {
+		return PrintMarkdown(result)
+	})
+	for _, want := range []string{"Rating Reset Request ID", "Cancelled", "reset-123", "true"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output = %q, want %q", output, want)
+		}
+	}
+}

--- a/internal/cli/capabilities/capabilities.go
+++ b/internal/cli/capabilities/capabilities.go
@@ -244,6 +244,14 @@ func capabilityRows() []Capability {
 			Notes:      []string{"Aggregates common blocking App Review and version readiness signals."},
 		},
 		{
+			Area:         "release",
+			Capability:   "App overview-rating reset",
+			Status:       statusPartial,
+			Commands:     []string{"asc versions rating-reset"},
+			APIResources: []string{"resetRatingsRequests"},
+			Notes:        []string{"Uses an authenticated web-session endpoint absent from Apple's published OpenAPI specification, so this command is experimental."},
+		},
+		{
 			Area:       "builds",
 			Capability: "Build upload and processing tracking",
 			Status:     statusCLISupported,

--- a/internal/cli/capabilities/capabilities.go
+++ b/internal/cli/capabilities/capabilities.go
@@ -246,7 +246,7 @@ func capabilityRows() []Capability {
 		{
 			Area:         "release",
 			Capability:   "App overview-rating reset",
-			Status:       statusPartial,
+			Status:       statusWebSession,
 			Commands:     []string{"asc versions rating-reset"},
 			APIResources: []string{"resetRatingsRequests"},
 			Notes:        []string{"Uses an authenticated web-session endpoint absent from Apple's published OpenAPI specification, so this command is experimental."},

--- a/internal/cli/capabilities/rating_reset_test.go
+++ b/internal/cli/capabilities/rating_reset_test.go
@@ -11,8 +11,8 @@ func TestRatingResetCapabilityDocumentsExperimentalWebSessionSurface(t *testing.
 		if capability.Capability != "App overview-rating reset" {
 			continue
 		}
-		if capability.Status != statusPartial {
-			t.Fatalf("status = %q, want %q", capability.Status, statusPartial)
+		if capability.Status != statusWebSession {
+			t.Fatalf("status = %q, want %q", capability.Status, statusWebSession)
 		}
 		if !slices.Contains(capability.Commands, "asc versions rating-reset") {
 			t.Fatalf("commands = %v, want rating-reset", capability.Commands)

--- a/internal/cli/capabilities/rating_reset_test.go
+++ b/internal/cli/capabilities/rating_reset_test.go
@@ -1,0 +1,29 @@
+package capabilities
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestRatingResetCapabilityDocumentsExperimentalWebSessionSurface(t *testing.T) {
+	for _, capability := range capabilityRows() {
+		if capability.Capability != "App overview-rating reset" {
+			continue
+		}
+		if capability.Status != statusPartial {
+			t.Fatalf("status = %q, want %q", capability.Status, statusPartial)
+		}
+		if !slices.Contains(capability.Commands, "asc versions rating-reset") {
+			t.Fatalf("commands = %v, want rating-reset", capability.Commands)
+		}
+		if !slices.Contains(capability.APIResources, "resetRatingsRequests") {
+			t.Fatalf("resources = %v, want resetRatingsRequests", capability.APIResources)
+		}
+		if len(capability.Notes) == 0 || !strings.Contains(capability.Notes[0], "published OpenAPI specification") {
+			t.Fatalf("notes = %v, want undocumented endpoint warning", capability.Notes)
+		}
+		return
+	}
+	t.Fatal("App overview-rating reset capability entry not found")
+}

--- a/internal/cli/cmdtest/versions_group_help_test.go
+++ b/internal/cli/cmdtest/versions_group_help_test.go
@@ -41,6 +41,7 @@ func TestVersionsGroupHelpDocumentsCoreWorkflows(t *testing.T) {
 		"asc versions attach-build ",
 		"asc versions release ",
 		"asc versions phased-release ",
+		"asc versions rating-reset ",
 	}
 	for _, want := range wantSubcommands {
 		if !strings.Contains(help, want) {
@@ -105,6 +106,7 @@ func TestVersionsGroupHelpListsEverySubcommand(t *testing.T) {
 		"attach-build",
 		"release",
 		"phased-release",
+		"rating-reset",
 		"promotions",
 	}
 

--- a/internal/cli/cmdtest/versions_rating_reset_test.go
+++ b/internal/cli/cmdtest/versions_rating_reset_test.go
@@ -1,0 +1,225 @@
+package cmdtest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+	webcmd "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/web"
+	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
+)
+
+func stubRatingResetWebSession(t *testing.T, transport roundTripFunc) {
+	t.Helper()
+	restore := webcmd.SetResolveWebSession(func(context.Context, string, string, string, string) (*webcore.AuthSession, string, error) {
+		return &webcore.AuthSession{Client: &http.Client{Transport: transport}}, "cache", nil
+	})
+	t.Cleanup(restore)
+}
+
+func TestVersionsRatingResetCreateRootIntegration(t *testing.T) {
+	stubRatingResetWebSession(t, func(request *http.Request) (*http.Response, error) {
+		if request.Method != http.MethodPost || request.URL.Path != "/iris/v1/resetRatingsRequests" {
+			t.Fatalf("request = %s %s, want POST /iris/v1/resetRatingsRequests", request.Method, request.URL.Path)
+		}
+		if got := request.Header.Get("X-CSRF-ITC"); got != "[asc-ui]" {
+			t.Fatalf("X-CSRF-ITC = %q, want [asc-ui]", got)
+		}
+
+		var payload struct {
+			Data struct {
+				Type          string `json:"type"`
+				Relationships struct {
+					AppStoreVersion struct {
+						Data struct {
+							Type string `json:"type"`
+							ID   string `json:"id"`
+						} `json:"data"`
+					} `json:"appStoreVersion"`
+				} `json:"relationships"`
+			} `json:"data"`
+		}
+		if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		version := payload.Data.Relationships.AppStoreVersion.Data
+		if payload.Data.Type != "resetRatingsRequests" || version.Type != "appStoreVersions" || version.ID != "version-1" {
+			t.Fatalf("payload = %#v, want resetRatingsRequests for version-1", payload)
+		}
+		return jsonResponse(http.StatusCreated, `{
+			"data": {"type": "resetRatingsRequests", "id": "reset-1", "attributes": {"resetDate": null}}
+		}`)
+	})
+
+	stdout, stderr := captureOutput(t, func() {
+		code := rootcmd.Run([]string{
+			"versions", "rating-reset", "create",
+			"--output", "json",
+			"--version-id", "version-1",
+			"--confirm",
+		}, "test")
+		if code != rootcmd.ExitSuccess {
+			t.Fatalf("exit code = %d, want %d", code, rootcmd.ExitSuccess)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+
+	var result struct {
+		RatingResetRequestID string `json:"ratingResetRequestId"`
+		VersionID            string `json:"versionId"`
+		Scheduled            bool   `json:"scheduled"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("unmarshal stdout: %v; stdout=%q", err, stdout)
+	}
+	if result.RatingResetRequestID != "reset-1" || result.VersionID != "version-1" || !result.Scheduled {
+		t.Fatalf("result = %#v, want scheduled reset receipt", result)
+	}
+}
+
+func TestVersionsRatingResetViewRootIntegration(t *testing.T) {
+	stubRatingResetWebSession(t, func(request *http.Request) (*http.Response, error) {
+		if request.Method != http.MethodGet || request.URL.Path != "/iris/v1/appStoreVersions/version-1/resetRatingsRequest" {
+			t.Fatalf("request = %s %s, want version rating reset GET", request.Method, request.URL.Path)
+		}
+		return jsonResponse(http.StatusOK, `{
+			"data": {
+				"type": "resetRatingsRequests",
+				"id": "reset-1",
+				"attributes": {"resetDate": "2026-09-01T08:00:00Z"}
+			}
+		}`)
+	})
+
+	stdout, stderr := captureOutput(t, func() {
+		code := rootcmd.Run([]string{
+			"versions", "rating-reset", "view",
+			"--version-id", "version-1",
+			"--output", "table",
+		}, "test")
+		if code != rootcmd.ExitSuccess {
+			t.Fatalf("exit code = %d, want %d", code, rootcmd.ExitSuccess)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	for _, want := range []string{"Rating Reset Request ID", "Reset Date", "reset-1", "2026-09-01T08:00:00Z"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("stdout = %q, want %q", stdout, want)
+		}
+	}
+}
+
+func TestVersionsRatingResetDeleteRootIntegration(t *testing.T) {
+	stubRatingResetWebSession(t, func(request *http.Request) (*http.Response, error) {
+		if request.Method != http.MethodDelete || request.URL.Path != "/iris/v1/resetRatingsRequests/reset-1" {
+			t.Fatalf("request = %s %s, want DELETE rating reset", request.Method, request.URL.Path)
+		}
+		return &http.Response{
+			StatusCode: http.StatusNoContent,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	})
+
+	stdout, stderr := captureOutput(t, func() {
+		code := rootcmd.Run([]string{
+			"versions", "rating-reset", "delete",
+			"--confirm",
+			"--id", "reset-1",
+			"--output", "json",
+		}, "test")
+		if code != rootcmd.ExitSuccess {
+			t.Fatalf("exit code = %d, want %d", code, rootcmd.ExitSuccess)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+
+	var result struct {
+		RatingResetRequestID string `json:"ratingResetRequestId"`
+		Cancelled            bool   `json:"cancelled"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("unmarshal stdout: %v; stdout=%q", err, stdout)
+	}
+	if result.RatingResetRequestID != "reset-1" || !result.Cancelled {
+		t.Fatalf("result = %#v, want cancelled reset receipt", result)
+	}
+}
+
+func TestVersionsRatingResetValidationBeforeSessionResolution(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{name: "view missing version", args: []string{"versions", "rating-reset", "view"}, wantStderr: "--version-id is required"},
+		{name: "create missing version", args: []string{"versions", "rating-reset", "create", "--confirm"}, wantStderr: "--version-id is required"},
+		{name: "create missing confirmation", args: []string{"versions", "rating-reset", "create", "--version-id", "version-1"}, wantStderr: "--confirm is required"},
+		{name: "delete missing id", args: []string{"versions", "rating-reset", "delete", "--confirm"}, wantStderr: "--id is required"},
+		{name: "delete missing confirmation", args: []string{"versions", "rating-reset", "delete", "--id", "reset-1"}, wantStderr: "--confirm is required"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resolverCalls := 0
+			restore := webcmd.SetResolveWebSession(func(context.Context, string, string, string, string) (*webcore.AuthSession, string, error) {
+				resolverCalls++
+				return nil, "", fmt.Errorf("session should not be resolved")
+			})
+			t.Cleanup(restore)
+
+			stdout, stderr := captureOutput(t, func() {
+				if code := rootcmd.Run(test.args, "test"); code != rootcmd.ExitUsage {
+					t.Fatalf("exit code = %d, want %d", code, rootcmd.ExitUsage)
+				}
+			})
+			if stdout != "" {
+				t.Fatalf("stdout = %q, want empty", stdout)
+			}
+			if !strings.Contains(stderr, "Error: "+test.wantStderr) {
+				t.Fatalf("stderr = %q, want %q", stderr, test.wantStderr)
+			}
+			if resolverCalls != 0 {
+				t.Fatalf("session resolver calls = %d, want 0", resolverCalls)
+			}
+		})
+	}
+}
+
+func TestVersionsRatingResetCommandIsExperimentalAndDocumentsRisk(t *testing.T) {
+	command := findSubcommand(RootCommand("test"), "versions", "rating-reset")
+	if command == nil {
+		t.Fatal("versions rating-reset command not found")
+	}
+	if !strings.HasPrefix(command.ShortHelp, "[experimental] ") {
+		t.Fatalf("ShortHelp = %q, want experimental lifecycle marker", command.ShortHelp)
+	}
+	help := strings.Join(strings.Fields(command.LongHelp), " ")
+	for _, want := range []string{
+		"does not include this resource in its published OpenAPI specification",
+		"authenticated Apple Account web session",
+		"you cannot restore the previous overview rating",
+	} {
+		if !strings.Contains(help, want) {
+			t.Fatalf("LongHelp = %q, want %q", command.LongHelp, want)
+		}
+	}
+
+	for _, name := range []string{"create", "delete"} {
+		subcommand := findSubcommand(command, name)
+		if subcommand == nil || subcommand.FlagSet.Lookup("confirm") == nil {
+			t.Fatalf("rating-reset %s must require --confirm", name)
+		}
+	}
+}

--- a/internal/cli/versions/versions.go
+++ b/internal/cli/versions/versions.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	webcli "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/web"
 )
 
 func VersionsCommand() *ffcli.Command {
@@ -34,7 +35,8 @@ Examples:
   asc versions update --version-id "VERSION_ID" --release-type MANUAL
   asc versions attach-build --version-id "VERSION_ID" --build-id "BUILD_ID"
   asc versions release --version-id "VERSION_ID" --confirm
-  asc versions phased-release view --version-id "VERSION_ID"`,
+  asc versions phased-release view --version-id "VERSION_ID"
+  asc versions rating-reset view --version-id "VERSION_ID"`,
 		UsageFunc: shared.VisibleUsageFunc,
 		Subcommands: []*ffcli.Command{
 			VersionsListCommand(),
@@ -49,6 +51,7 @@ Examples:
 			VersionsAttachBuildCommand(),
 			VersionsReleaseCommand(),
 			PhasedReleaseCommand(),
+			webcli.VersionRatingResetCommand(),
 			VersionsPromotionsCommand(),
 		},
 		Exec: func(ctx context.Context, args []string) error {

--- a/internal/cli/web/version_rating_reset.go
+++ b/internal/cli/web/version_rating_reset.go
@@ -93,12 +93,12 @@ Examples:
 				return shared.MissingRequiredUsageError("--version-id")
 			}
 
-			session, err := resolveWebSessionForCommand(ctx, authFlags)
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
+			session, err := resolveWebSessionForCommand(requestCtx, authFlags)
 			if err != nil {
 				return err
 			}
-			requestCtx, cancel := shared.ContextWithTimeout(ctx)
-			defer cancel()
 
 			var response *webcore.RatingResetRequestResponse
 			err = withWebSpinner("Loading rating reset request", func() error {
@@ -109,7 +109,10 @@ Examples:
 			if err != nil {
 				return withWebAuthHint(err, "rating-reset view")
 			}
-			if response == nil || strings.TrimSpace(response.Data.ID) == "" {
+			if response == nil {
+				return fmt.Errorf("rating-reset view failed: response missing")
+			}
+			if response.Data != nil && strings.TrimSpace(response.Data.ID) == "" {
 				return fmt.Errorf("rating-reset view failed: rating reset request ID missing from response")
 			}
 
@@ -164,12 +167,12 @@ Examples:
 				return shared.MissingRequiredUsageError("--confirm")
 			}
 
-			session, err := resolveWebSessionForCommand(ctx, authFlags)
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
+			session, err := resolveWebSessionForCommand(requestCtx, authFlags)
 			if err != nil {
 				return err
 			}
-			requestCtx, cancel := shared.ContextWithTimeout(ctx)
-			defer cancel()
 
 			var response *webcore.RatingResetRequestResponse
 			err = withWebSpinner("Scheduling rating reset", func() error {
@@ -180,7 +183,7 @@ Examples:
 			if err != nil {
 				return withWebAuthHint(err, "rating-reset create")
 			}
-			if response == nil || strings.TrimSpace(response.Data.ID) == "" {
+			if response == nil || response.Data == nil || strings.TrimSpace(response.Data.ID) == "" {
 				return fmt.Errorf("rating-reset create failed: rating reset request ID missing from response")
 			}
 
@@ -231,12 +234,12 @@ Examples:
 				return shared.MissingRequiredUsageError("--confirm")
 			}
 
-			session, err := resolveWebSessionForCommand(ctx, authFlags)
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
+			session, err := resolveWebSessionForCommand(requestCtx, authFlags)
 			if err != nil {
 				return err
 			}
-			requestCtx, cancel := shared.ContextWithTimeout(ctx)
-			defer cancel()
 
 			err = withWebSpinner("Cancelling rating reset", func() error {
 				return deleteVersionRatingResetFn(requestCtx, newWebClientFn(session), id)
@@ -255,11 +258,15 @@ Examples:
 }
 
 func versionRatingResetRows(response *webcore.RatingResetRequestResponse) ([]string, [][]string) {
+	headers := []string{"Rating Reset Request ID", "Reset Date", "Scheduled"}
+	if response.Data == nil {
+		return headers, [][]string{{"", "", "false"}}
+	}
 	resetDate := ""
 	if response.Data.Attributes.ResetDate != nil {
 		resetDate = *response.Data.Attributes.ResetDate
 	}
-	return []string{"Rating Reset Request ID", "Reset Date"}, [][]string{{response.Data.ID, resetDate}}
+	return headers, [][]string{{response.Data.ID, resetDate, "true"}}
 }
 
 func renderVersionRatingResetTable(response *webcore.RatingResetRequestResponse) error {

--- a/internal/cli/web/version_rating_reset.go
+++ b/internal/cli/web/version_rating_reset.go
@@ -26,17 +26,6 @@ var (
 	}
 )
 
-type versionRatingResetCreateResult struct {
-	RatingResetRequestID string `json:"ratingResetRequestId"`
-	VersionID            string `json:"versionId"`
-	Scheduled            bool   `json:"scheduled"`
-}
-
-type versionRatingResetDeleteResult struct {
-	RatingResetRequestID string `json:"ratingResetRequestId"`
-	Cancelled            bool   `json:"cancelled"`
-}
-
 // VersionRatingResetCommand returns the version overview-rating reset command group.
 // It lives in the web command package so it can share the existing web-session
 // authentication and provider-selection implementation while remaining mounted
@@ -195,18 +184,12 @@ Examples:
 				return fmt.Errorf("rating-reset create failed: rating reset request ID missing from response")
 			}
 
-			result := &versionRatingResetCreateResult{
+			result := &asc.AppStoreVersionRatingResetCreateResult{
 				RatingResetRequestID: strings.TrimSpace(response.Data.ID),
 				VersionID:            version,
 				Scheduled:            true,
 			}
-			return shared.PrintOutputWithRenderers(
-				result,
-				*output.Output,
-				*output.Pretty,
-				func() error { return renderVersionRatingResetCreateTable(result) },
-				func() error { return renderVersionRatingResetCreateMarkdown(result) },
-			)
+			return shared.PrintOutput(result, *output.Output, *output.Pretty)
 		},
 	}
 }
@@ -262,17 +245,11 @@ Examples:
 				return withWebAuthHint(err, "rating-reset delete")
 			}
 
-			result := &versionRatingResetDeleteResult{
+			result := &asc.AppStoreVersionRatingResetDeleteResult{
 				RatingResetRequestID: id,
 				Cancelled:            true,
 			}
-			return shared.PrintOutputWithRenderers(
-				result,
-				*output.Output,
-				*output.Pretty,
-				func() error { return renderVersionRatingResetDeleteTable(result) },
-				func() error { return renderVersionRatingResetDeleteMarkdown(result) },
-			)
+			return shared.PrintOutput(result, *output.Output, *output.Pretty)
 		},
 	}
 }
@@ -293,45 +270,6 @@ func renderVersionRatingResetTable(response *webcore.RatingResetRequestResponse)
 
 func renderVersionRatingResetMarkdown(response *webcore.RatingResetRequestResponse) error {
 	headers, rows := versionRatingResetRows(response)
-	asc.RenderMarkdown(headers, rows)
-	return nil
-}
-
-func versionRatingResetCreateRows(result *versionRatingResetCreateResult) ([]string, [][]string) {
-	return []string{"Rating Reset Request ID", "Version ID", "Scheduled"}, [][]string{{
-		result.RatingResetRequestID,
-		result.VersionID,
-		fmt.Sprintf("%t", result.Scheduled),
-	}}
-}
-
-func renderVersionRatingResetCreateTable(result *versionRatingResetCreateResult) error {
-	headers, rows := versionRatingResetCreateRows(result)
-	asc.RenderTable(headers, rows)
-	return nil
-}
-
-func renderVersionRatingResetCreateMarkdown(result *versionRatingResetCreateResult) error {
-	headers, rows := versionRatingResetCreateRows(result)
-	asc.RenderMarkdown(headers, rows)
-	return nil
-}
-
-func versionRatingResetDeleteRows(result *versionRatingResetDeleteResult) ([]string, [][]string) {
-	return []string{"Rating Reset Request ID", "Cancelled"}, [][]string{{
-		result.RatingResetRequestID,
-		fmt.Sprintf("%t", result.Cancelled),
-	}}
-}
-
-func renderVersionRatingResetDeleteTable(result *versionRatingResetDeleteResult) error {
-	headers, rows := versionRatingResetDeleteRows(result)
-	asc.RenderTable(headers, rows)
-	return nil
-}
-
-func renderVersionRatingResetDeleteMarkdown(result *versionRatingResetDeleteResult) error {
-	headers, rows := versionRatingResetDeleteRows(result)
 	asc.RenderMarkdown(headers, rows)
 	return nil
 }

--- a/internal/cli/web/version_rating_reset.go
+++ b/internal/cli/web/version_rating_reset.go
@@ -1,0 +1,337 @@
+package web
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
+)
+
+var (
+	getVersionRatingResetFn = func(ctx context.Context, client *webcore.Client, versionID string) (*webcore.RatingResetRequestResponse, error) {
+		return client.GetAppStoreVersionRatingResetRequest(ctx, versionID)
+	}
+	createVersionRatingResetFn = func(ctx context.Context, client *webcore.Client, versionID string) (*webcore.RatingResetRequestResponse, error) {
+		return client.CreateAppStoreVersionRatingResetRequest(ctx, versionID)
+	}
+	deleteVersionRatingResetFn = func(ctx context.Context, client *webcore.Client, requestID string) error {
+		return client.DeleteAppStoreVersionRatingResetRequest(ctx, requestID)
+	}
+)
+
+type versionRatingResetCreateResult struct {
+	RatingResetRequestID string `json:"ratingResetRequestId"`
+	VersionID            string `json:"versionId"`
+	Scheduled            bool   `json:"scheduled"`
+}
+
+type versionRatingResetDeleteResult struct {
+	RatingResetRequestID string `json:"ratingResetRequestId"`
+	Cancelled            bool   `json:"cancelled"`
+}
+
+// VersionRatingResetCommand returns the version overview-rating reset command group.
+// It lives in the web command package so it can share the existing web-session
+// authentication and provider-selection implementation while remaining mounted
+// at "asc versions rating-reset".
+func VersionRatingResetCommand() *ffcli.Command {
+	return &ffcli.Command{
+		Name:       "rating-reset",
+		ShortUsage: "asc versions rating-reset <subcommand> [flags]",
+		ShortHelp:  "[experimental] Manage the overview-rating reset for an App Store version.",
+		LongHelp: `[experimental] Manage the overview-rating reset for an App Store version.
+
+Apple does not include this resource in its published OpenAPI specification.
+These commands use an authenticated Apple Account web session and may stop
+working if Apple changes its App Store Connect web service. Run
+"asc web auth login" first when no valid cached session is available.
+
+Scheduling a reset affects every country or region for the selected platform.
+Written reviews remain visible. After the version is released, you cannot
+restore the previous overview rating.
+
+Examples:
+  asc versions rating-reset view --version-id "VERSION_ID"
+  asc versions rating-reset create --version-id "VERSION_ID" --confirm
+  asc versions rating-reset delete --id "RESET_REQUEST_ID" --confirm`,
+		UsageFunc: shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			VersionRatingResetViewCommand(),
+			VersionRatingResetCreateCommand(),
+			VersionRatingResetDeleteCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+// VersionRatingResetViewCommand returns the rating-reset view subcommand.
+func VersionRatingResetViewCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("rating-reset view", flag.ExitOnError)
+	versionID := fs.String("version-id", "", "App Store version ID (required)")
+	authFlags := bindWebSessionFlags(fs)
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "view",
+		ShortUsage: "asc versions rating-reset view --version-id \"VERSION_ID\" [flags]",
+		ShortHelp:  "View the overview-rating reset scheduled for an App Store version.",
+		LongHelp: `View the overview-rating reset scheduled for an App Store version.
+
+This command requires a valid Apple Account web session.
+
+Examples:
+  asc versions rating-reset view --version-id "VERSION_ID"
+  asc versions rating-reset view --version-id "VERSION_ID" --apple-id "user@example.com"`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageErrorf("unexpected arguments: %s", strings.Join(args, " "))
+			}
+
+			version := strings.TrimSpace(*versionID)
+			if version == "" {
+				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
+				return shared.MissingRequiredUsageError("--version-id")
+			}
+
+			session, err := resolveWebSessionForCommand(ctx, authFlags)
+			if err != nil {
+				return err
+			}
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
+
+			var response *webcore.RatingResetRequestResponse
+			err = withWebSpinner("Loading rating reset request", func() error {
+				var requestErr error
+				response, requestErr = getVersionRatingResetFn(requestCtx, newWebClientFn(session), version)
+				return requestErr
+			})
+			if err != nil {
+				return withWebAuthHint(err, "rating-reset view")
+			}
+			if response == nil || strings.TrimSpace(response.Data.ID) == "" {
+				return fmt.Errorf("rating-reset view failed: rating reset request ID missing from response")
+			}
+
+			return shared.PrintOutputWithRenderers(
+				response,
+				*output.Output,
+				*output.Pretty,
+				func() error { return renderVersionRatingResetTable(response) },
+				func() error { return renderVersionRatingResetMarkdown(response) },
+			)
+		},
+	}
+}
+
+// VersionRatingResetCreateCommand returns the rating-reset create subcommand.
+func VersionRatingResetCreateCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("rating-reset create", flag.ExitOnError)
+	versionID := fs.String("version-id", "", "App Store version ID (required)")
+	confirm := fs.Bool("confirm", false, "Confirm scheduling the rating reset (required)")
+	authFlags := bindWebSessionFlags(fs)
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "create",
+		ShortUsage: "asc versions rating-reset create --version-id \"VERSION_ID\" --confirm [flags]",
+		ShortHelp:  "Schedule an overview-rating reset when an App Store version is released.",
+		LongHelp: `Schedule an overview-rating reset when an App Store version is released.
+
+The reset applies to every country or region for the selected platform. Written
+reviews remain visible. You can cancel the request before release, but after the
+version is released, the previous overview rating cannot be restored.
+
+This command requires a valid Apple Account web session.
+
+Examples:
+  asc versions rating-reset create --version-id "VERSION_ID" --confirm
+  asc versions rating-reset create --version-id "VERSION_ID" --confirm --apple-id "user@example.com"`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageErrorf("unexpected arguments: %s", strings.Join(args, " "))
+			}
+
+			version := strings.TrimSpace(*versionID)
+			if version == "" {
+				fmt.Fprintln(os.Stderr, "Error: --version-id is required")
+				return shared.MissingRequiredUsageError("--version-id")
+			}
+			if !*confirm {
+				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
+				return shared.MissingRequiredUsageError("--confirm")
+			}
+
+			session, err := resolveWebSessionForCommand(ctx, authFlags)
+			if err != nil {
+				return err
+			}
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
+
+			var response *webcore.RatingResetRequestResponse
+			err = withWebSpinner("Scheduling rating reset", func() error {
+				var requestErr error
+				response, requestErr = createVersionRatingResetFn(requestCtx, newWebClientFn(session), version)
+				return requestErr
+			})
+			if err != nil {
+				return withWebAuthHint(err, "rating-reset create")
+			}
+			if response == nil || strings.TrimSpace(response.Data.ID) == "" {
+				return fmt.Errorf("rating-reset create failed: rating reset request ID missing from response")
+			}
+
+			result := &versionRatingResetCreateResult{
+				RatingResetRequestID: strings.TrimSpace(response.Data.ID),
+				VersionID:            version,
+				Scheduled:            true,
+			}
+			return shared.PrintOutputWithRenderers(
+				result,
+				*output.Output,
+				*output.Pretty,
+				func() error { return renderVersionRatingResetCreateTable(result) },
+				func() error { return renderVersionRatingResetCreateMarkdown(result) },
+			)
+		},
+	}
+}
+
+// VersionRatingResetDeleteCommand returns the rating-reset delete subcommand.
+func VersionRatingResetDeleteCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("rating-reset delete", flag.ExitOnError)
+	requestID := fs.String("id", "", "Rating reset request ID (required)")
+	confirm := fs.Bool("confirm", false, "Confirm cancellation (required)")
+	authFlags := bindWebSessionFlags(fs)
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "delete",
+		ShortUsage: "asc versions rating-reset delete --id \"RESET_REQUEST_ID\" --confirm [flags]",
+		ShortHelp:  "Cancel a scheduled overview-rating reset before release.",
+		LongHelp: `Cancel a scheduled overview-rating reset before release.
+
+Use the request ID returned by rating-reset view or rating-reset create. This
+command requires a valid Apple Account web session.
+
+Examples:
+  asc versions rating-reset delete --id "RESET_REQUEST_ID" --confirm
+  asc versions rating-reset delete --id "RESET_REQUEST_ID" --confirm --apple-id "user@example.com"`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageErrorf("unexpected arguments: %s", strings.Join(args, " "))
+			}
+
+			id := strings.TrimSpace(*requestID)
+			if id == "" {
+				fmt.Fprintln(os.Stderr, "Error: --id is required")
+				return shared.MissingRequiredUsageError("--id")
+			}
+			if !*confirm {
+				fmt.Fprintln(os.Stderr, "Error: --confirm is required")
+				return shared.MissingRequiredUsageError("--confirm")
+			}
+
+			session, err := resolveWebSessionForCommand(ctx, authFlags)
+			if err != nil {
+				return err
+			}
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
+
+			err = withWebSpinner("Cancelling rating reset", func() error {
+				return deleteVersionRatingResetFn(requestCtx, newWebClientFn(session), id)
+			})
+			if err != nil {
+				return withWebAuthHint(err, "rating-reset delete")
+			}
+
+			result := &versionRatingResetDeleteResult{
+				RatingResetRequestID: id,
+				Cancelled:            true,
+			}
+			return shared.PrintOutputWithRenderers(
+				result,
+				*output.Output,
+				*output.Pretty,
+				func() error { return renderVersionRatingResetDeleteTable(result) },
+				func() error { return renderVersionRatingResetDeleteMarkdown(result) },
+			)
+		},
+	}
+}
+
+func versionRatingResetRows(response *webcore.RatingResetRequestResponse) ([]string, [][]string) {
+	resetDate := ""
+	if response.Data.Attributes.ResetDate != nil {
+		resetDate = *response.Data.Attributes.ResetDate
+	}
+	return []string{"Rating Reset Request ID", "Reset Date"}, [][]string{{response.Data.ID, resetDate}}
+}
+
+func renderVersionRatingResetTable(response *webcore.RatingResetRequestResponse) error {
+	headers, rows := versionRatingResetRows(response)
+	asc.RenderTable(headers, rows)
+	return nil
+}
+
+func renderVersionRatingResetMarkdown(response *webcore.RatingResetRequestResponse) error {
+	headers, rows := versionRatingResetRows(response)
+	asc.RenderMarkdown(headers, rows)
+	return nil
+}
+
+func versionRatingResetCreateRows(result *versionRatingResetCreateResult) ([]string, [][]string) {
+	return []string{"Rating Reset Request ID", "Version ID", "Scheduled"}, [][]string{{
+		result.RatingResetRequestID,
+		result.VersionID,
+		fmt.Sprintf("%t", result.Scheduled),
+	}}
+}
+
+func renderVersionRatingResetCreateTable(result *versionRatingResetCreateResult) error {
+	headers, rows := versionRatingResetCreateRows(result)
+	asc.RenderTable(headers, rows)
+	return nil
+}
+
+func renderVersionRatingResetCreateMarkdown(result *versionRatingResetCreateResult) error {
+	headers, rows := versionRatingResetCreateRows(result)
+	asc.RenderMarkdown(headers, rows)
+	return nil
+}
+
+func versionRatingResetDeleteRows(result *versionRatingResetDeleteResult) ([]string, [][]string) {
+	return []string{"Rating Reset Request ID", "Cancelled"}, [][]string{{
+		result.RatingResetRequestID,
+		fmt.Sprintf("%t", result.Cancelled),
+	}}
+}
+
+func renderVersionRatingResetDeleteTable(result *versionRatingResetDeleteResult) error {
+	headers, rows := versionRatingResetDeleteRows(result)
+	asc.RenderTable(headers, rows)
+	return nil
+}
+
+func renderVersionRatingResetDeleteMarkdown(result *versionRatingResetDeleteResult) error {
+	headers, rows := versionRatingResetDeleteRows(result)
+	asc.RenderMarkdown(headers, rows)
+	return nil
+}

--- a/internal/cli/web/version_rating_reset_test.go
+++ b/internal/cli/web/version_rating_reset_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
 )
 
@@ -59,7 +60,7 @@ func TestVersionRatingResetCreate(t *testing.T) {
 		t.Fatalf("version = %q, want trimmed version-1", receivedVersion)
 	}
 
-	var result versionRatingResetCreateResult
+	var result asc.AppStoreVersionRatingResetCreateResult
 	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
 		t.Fatalf("unmarshal output: %v; output=%q", err, stdout)
 	}

--- a/internal/cli/web/version_rating_reset_test.go
+++ b/internal/cli/web/version_rating_reset_test.go
@@ -1,0 +1,251 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"strings"
+	"testing"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
+)
+
+func stubVersionRatingResetSession(t *testing.T) {
+	t.Helper()
+	originalResolver := resolveSessionFn
+	originalClient := newWebClientFn
+	t.Cleanup(func() {
+		resolveSessionFn = originalResolver
+		newWebClientFn = originalClient
+	})
+	resolveSessionFn = func(context.Context, string, string, string, string) (*webcore.AuthSession, string, error) {
+		return &webcore.AuthSession{}, "cache", nil
+	}
+	newWebClientFn = func(*webcore.AuthSession) *webcore.Client {
+		return &webcore.Client{}
+	}
+}
+
+func TestVersionRatingResetCreate(t *testing.T) {
+	stubVersionRatingResetSession(t)
+	originalCreate := createVersionRatingResetFn
+	t.Cleanup(func() { createVersionRatingResetFn = originalCreate })
+
+	var receivedVersion string
+	createVersionRatingResetFn = func(_ context.Context, _ *webcore.Client, versionID string) (*webcore.RatingResetRequestResponse, error) {
+		receivedVersion = versionID
+		return &webcore.RatingResetRequestResponse{
+			Data: webcore.RatingResetRequest{Type: "resetRatingsRequests", ID: "reset-1"},
+		}, nil
+	}
+
+	command := VersionRatingResetCreateCommand()
+	if err := command.FlagSet.Parse([]string{"--version-id", " version-1 ", "--confirm", "--output", "json"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	stdout, stderr := captureWebCommandOutput(t, func() {
+		if err := command.Exec(context.Background(), nil); err != nil {
+			t.Fatalf("Exec() error = %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	if receivedVersion != "version-1" {
+		t.Fatalf("version = %q, want trimmed version-1", receivedVersion)
+	}
+
+	var result versionRatingResetCreateResult
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("unmarshal output: %v; output=%q", err, stdout)
+	}
+	if result.RatingResetRequestID != "reset-1" || result.VersionID != "version-1" || !result.Scheduled {
+		t.Fatalf("result = %#v, want scheduled reset receipt", result)
+	}
+}
+
+func TestVersionRatingResetViewTable(t *testing.T) {
+	stubVersionRatingResetSession(t)
+	originalGet := getVersionRatingResetFn
+	t.Cleanup(func() { getVersionRatingResetFn = originalGet })
+
+	resetDate := "2026-09-01T08:00:00Z"
+	getVersionRatingResetFn = func(_ context.Context, _ *webcore.Client, versionID string) (*webcore.RatingResetRequestResponse, error) {
+		if versionID != "version-1" {
+			t.Fatalf("version = %q, want version-1", versionID)
+		}
+		return &webcore.RatingResetRequestResponse{
+			Data: webcore.RatingResetRequest{
+				Type:       "resetRatingsRequests",
+				ID:         "reset-1",
+				Attributes: webcore.RatingResetRequestAttributes{ResetDate: &resetDate},
+			},
+		}, nil
+	}
+
+	command := VersionRatingResetViewCommand()
+	if err := command.FlagSet.Parse([]string{"--version-id", "version-1", "--output", "table"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	stdout, stderr := captureWebCommandOutput(t, func() {
+		if err := command.Exec(context.Background(), nil); err != nil {
+			t.Fatalf("Exec() error = %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	for _, want := range []string{"Rating Reset Request ID", "Reset Date", "reset-1", resetDate} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("stdout = %q, want %q", stdout, want)
+		}
+	}
+}
+
+func TestVersionRatingResetDelete(t *testing.T) {
+	stubVersionRatingResetSession(t)
+	originalDelete := deleteVersionRatingResetFn
+	t.Cleanup(func() { deleteVersionRatingResetFn = originalDelete })
+
+	var receivedID string
+	deleteVersionRatingResetFn = func(_ context.Context, _ *webcore.Client, requestID string) error {
+		receivedID = requestID
+		return nil
+	}
+
+	command := VersionRatingResetDeleteCommand()
+	if err := command.FlagSet.Parse([]string{"--id", " reset-1 ", "--confirm", "--output", "markdown"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	stdout, stderr := captureWebCommandOutput(t, func() {
+		if err := command.Exec(context.Background(), nil); err != nil {
+			t.Fatalf("Exec() error = %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	if receivedID != "reset-1" {
+		t.Fatalf("id = %q, want trimmed reset-1", receivedID)
+	}
+	for _, want := range []string{"| Rating Reset Request ID | Cancelled |", "reset-1", "true"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("stdout = %q, want %q", stdout, want)
+		}
+	}
+}
+
+func TestVersionRatingResetValidationRunsBeforeSessionResolution(t *testing.T) {
+	originalResolver := resolveSessionFn
+	t.Cleanup(func() { resolveSessionFn = originalResolver })
+	resolverCalls := 0
+	resolveSessionFn = func(context.Context, string, string, string, string) (*webcore.AuthSession, string, error) {
+		resolverCalls++
+		return nil, "", errors.New("session should not be resolved")
+	}
+
+	cases := []struct {
+		name    string
+		command func() *ffcli.Command
+		args    []string
+		want    string
+	}{
+		{name: "view missing version", command: VersionRatingResetViewCommand, want: "--version-id is required"},
+		{name: "create missing version", command: VersionRatingResetCreateCommand, args: []string{"--confirm"}, want: "--version-id is required"},
+		{name: "create missing confirmation", command: VersionRatingResetCreateCommand, args: []string{"--version-id", "version-1"}, want: "--confirm is required"},
+		{name: "delete missing id", command: VersionRatingResetDeleteCommand, args: []string{"--confirm"}, want: "--id is required"},
+		{name: "delete missing confirmation", command: VersionRatingResetDeleteCommand, args: []string{"--id", "reset-1"}, want: "--confirm is required"},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			command := test.command()
+			if err := command.FlagSet.Parse(test.args); err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			stdout, stderr := captureWebCommandOutput(t, func() {
+				if err := command.Exec(context.Background(), nil); !errors.Is(err, flag.ErrHelp) {
+					t.Fatalf("error = %v, want flag.ErrHelp", err)
+				}
+			})
+			if stdout != "" {
+				t.Fatalf("stdout = %q, want empty", stdout)
+			}
+			if !strings.Contains(stderr, "Error: "+test.want) {
+				t.Fatalf("stderr = %q, want %q", stderr, test.want)
+			}
+		})
+	}
+	if resolverCalls != 0 {
+		t.Fatalf("session resolver calls = %d, want 0", resolverCalls)
+	}
+}
+
+func TestVersionRatingResetWrapsUnauthorizedSessionError(t *testing.T) {
+	stubVersionRatingResetSession(t)
+	originalGet := getVersionRatingResetFn
+	t.Cleanup(func() { getVersionRatingResetFn = originalGet })
+	getVersionRatingResetFn = func(context.Context, *webcore.Client, string) (*webcore.RatingResetRequestResponse, error) {
+		return nil, &webcore.APIError{Status: 401}
+	}
+
+	command := VersionRatingResetViewCommand()
+	if err := command.FlagSet.Parse([]string{"--version-id", "version-1"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	err := command.Exec(context.Background(), nil)
+	if err == nil || !strings.Contains(err.Error(), "web session is unauthorized or expired") || !strings.Contains(err.Error(), "asc web auth login") {
+		t.Fatalf("error = %v, want web auth recovery hint", err)
+	}
+}
+
+func TestVersionRatingResetRejectsSuccessfulResponseWithoutID(t *testing.T) {
+	stubVersionRatingResetSession(t)
+	originalCreate := createVersionRatingResetFn
+	t.Cleanup(func() { createVersionRatingResetFn = originalCreate })
+	createVersionRatingResetFn = func(context.Context, *webcore.Client, string) (*webcore.RatingResetRequestResponse, error) {
+		return &webcore.RatingResetRequestResponse{}, nil
+	}
+
+	command := VersionRatingResetCreateCommand()
+	if err := command.FlagSet.Parse([]string{"--version-id", "version-1", "--confirm"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	err := command.Exec(context.Background(), nil)
+	if err == nil || !strings.Contains(err.Error(), "rating reset request ID missing from response") {
+		t.Fatalf("error = %v, want missing response ID", err)
+	}
+}
+
+func TestVersionRatingResetCommandDocumentsExperimentalWebSessionContract(t *testing.T) {
+	command := VersionRatingResetCommand()
+	if !strings.HasPrefix(command.ShortHelp, "[experimental] ") {
+		t.Fatalf("ShortHelp = %q, want experimental marker", command.ShortHelp)
+	}
+	help := strings.Join(strings.Fields(command.LongHelp), " ")
+	for _, want := range []string{
+		"does not include this resource in its published OpenAPI specification",
+		"authenticated Apple Account web session",
+		"you cannot restore the previous overview rating",
+	} {
+		if !strings.Contains(help, want) {
+			t.Fatalf("LongHelp = %q, want %q", command.LongHelp, want)
+		}
+	}
+
+	for _, subcommand := range []*ffcli.Command{
+		VersionRatingResetViewCommand(),
+		VersionRatingResetCreateCommand(),
+		VersionRatingResetDeleteCommand(),
+	} {
+		for _, flagName := range []string{"apple-id", "provider-id", "public-provider-id", "two-factor-code-command"} {
+			if subcommand.FlagSet.Lookup(flagName) == nil {
+				t.Fatalf("%s missing --%s", subcommand.Name, flagName)
+			}
+		}
+	}
+}

--- a/internal/cli/web/version_rating_reset_test.go
+++ b/internal/cli/web/version_rating_reset_test.go
@@ -30,16 +30,24 @@ func stubVersionRatingResetSession(t *testing.T) {
 	}
 }
 
+func requireVersionRatingResetDeadline(t *testing.T, ctx context.Context) {
+	t.Helper()
+	if _, ok := ctx.Deadline(); !ok {
+		t.Fatal("expected operation to receive the command timeout context")
+	}
+}
+
 func TestVersionRatingResetCreate(t *testing.T) {
 	stubVersionRatingResetSession(t)
 	originalCreate := createVersionRatingResetFn
 	t.Cleanup(func() { createVersionRatingResetFn = originalCreate })
 
 	var receivedVersion string
-	createVersionRatingResetFn = func(_ context.Context, _ *webcore.Client, versionID string) (*webcore.RatingResetRequestResponse, error) {
+	createVersionRatingResetFn = func(ctx context.Context, _ *webcore.Client, versionID string) (*webcore.RatingResetRequestResponse, error) {
+		requireVersionRatingResetDeadline(t, ctx)
 		receivedVersion = versionID
 		return &webcore.RatingResetRequestResponse{
-			Data: webcore.RatingResetRequest{Type: "resetRatingsRequests", ID: "reset-1"},
+			Data: &webcore.RatingResetRequest{Type: "resetRatingsRequests", ID: "reset-1"},
 		}, nil
 	}
 
@@ -75,12 +83,13 @@ func TestVersionRatingResetViewTable(t *testing.T) {
 	t.Cleanup(func() { getVersionRatingResetFn = originalGet })
 
 	resetDate := "2026-09-01T08:00:00Z"
-	getVersionRatingResetFn = func(_ context.Context, _ *webcore.Client, versionID string) (*webcore.RatingResetRequestResponse, error) {
+	getVersionRatingResetFn = func(ctx context.Context, _ *webcore.Client, versionID string) (*webcore.RatingResetRequestResponse, error) {
+		requireVersionRatingResetDeadline(t, ctx)
 		if versionID != "version-1" {
 			t.Fatalf("version = %q, want version-1", versionID)
 		}
 		return &webcore.RatingResetRequestResponse{
-			Data: webcore.RatingResetRequest{
+			Data: &webcore.RatingResetRequest{
 				Type:       "resetRatingsRequests",
 				ID:         "reset-1",
 				Attributes: webcore.RatingResetRequestAttributes{ResetDate: &resetDate},
@@ -107,13 +116,63 @@ func TestVersionRatingResetViewTable(t *testing.T) {
 	}
 }
 
+func TestVersionRatingResetViewReportsUnscheduledRelationship(t *testing.T) {
+	stubVersionRatingResetSession(t)
+	originalGet := getVersionRatingResetFn
+	t.Cleanup(func() { getVersionRatingResetFn = originalGet })
+	getVersionRatingResetFn = func(context.Context, *webcore.Client, string) (*webcore.RatingResetRequestResponse, error) {
+		return &webcore.RatingResetRequestResponse{Data: nil}, nil
+	}
+
+	t.Run("json preserves null data", func(t *testing.T) {
+		command := VersionRatingResetViewCommand()
+		if err := command.FlagSet.Parse([]string{"--version-id", "version-1", "--output", "json"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		stdout, stderr := captureWebCommandOutput(t, func() {
+			if err := command.Exec(context.Background(), nil); err != nil {
+				t.Fatalf("Exec() error = %v", err)
+			}
+		})
+		if stderr != "" {
+			t.Fatalf("stderr = %q, want empty", stderr)
+		}
+		if strings.TrimSpace(stdout) != `{"data":null}` {
+			t.Fatalf("stdout = %q, want null JSON:API relationship", stdout)
+		}
+	})
+
+	for _, format := range []string{"table", "markdown"} {
+		t.Run(format+" reports unscheduled", func(t *testing.T) {
+			command := VersionRatingResetViewCommand()
+			if err := command.FlagSet.Parse([]string{"--version-id", "version-1", "--output", format}); err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			stdout, stderr := captureWebCommandOutput(t, func() {
+				if err := command.Exec(context.Background(), nil); err != nil {
+					t.Fatalf("Exec() error = %v", err)
+				}
+			})
+			if stderr != "" {
+				t.Fatalf("stderr = %q, want empty", stderr)
+			}
+			for _, want := range []string{"Scheduled", "false"} {
+				if !strings.Contains(stdout, want) {
+					t.Fatalf("stdout = %q, want %q", stdout, want)
+				}
+			}
+		})
+	}
+}
+
 func TestVersionRatingResetDelete(t *testing.T) {
 	stubVersionRatingResetSession(t)
 	originalDelete := deleteVersionRatingResetFn
 	t.Cleanup(func() { deleteVersionRatingResetFn = originalDelete })
 
 	var receivedID string
-	deleteVersionRatingResetFn = func(_ context.Context, _ *webcore.Client, requestID string) error {
+	deleteVersionRatingResetFn = func(ctx context.Context, _ *webcore.Client, requestID string) error {
+		requireVersionRatingResetDeadline(t, ctx)
 		receivedID = requestID
 		return nil
 	}
@@ -183,6 +242,43 @@ func TestVersionRatingResetValidationRunsBeforeSessionResolution(t *testing.T) {
 	}
 	if resolverCalls != 0 {
 		t.Fatalf("session resolver calls = %d, want 0", resolverCalls)
+	}
+}
+
+func TestVersionRatingResetSessionResolutionUsesCommandTimeout(t *testing.T) {
+	originalResolver := resolveSessionFn
+	t.Cleanup(func() { resolveSessionFn = originalResolver })
+	resolveErr := errors.New("stop after context inspection")
+
+	cases := []struct {
+		name    string
+		command func() *ffcli.Command
+		args    []string
+	}{
+		{name: "view", command: VersionRatingResetViewCommand, args: []string{"--version-id", "version-1"}},
+		{name: "create", command: VersionRatingResetCreateCommand, args: []string{"--version-id", "version-1", "--confirm"}},
+		{name: "delete", command: VersionRatingResetDeleteCommand, args: []string{"--id", "reset-1", "--confirm"}},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			hadDeadline := false
+			resolveSessionFn = func(ctx context.Context, _, _, _, _ string) (*webcore.AuthSession, string, error) {
+				_, hadDeadline = ctx.Deadline()
+				return nil, "", resolveErr
+			}
+
+			command := test.command()
+			if err := command.FlagSet.Parse(test.args); err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			if err := command.Exec(context.Background(), nil); !errors.Is(err, resolveErr) {
+				t.Fatalf("error = %v, want resolve error", err)
+			}
+			if !hadDeadline {
+				t.Fatal("expected session resolution to receive the command timeout context")
+			}
+		})
 	}
 }
 

--- a/internal/web/rating_reset.go
+++ b/internal/web/rating_reset.go
@@ -1,0 +1,108 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const ratingResetRequestResourceType = "resetRatingsRequests"
+
+// RatingResetRequestAttributes describes an App Store overview-rating reset request.
+type RatingResetRequestAttributes struct {
+	ResetDate *string `json:"resetDate"`
+}
+
+// RatingResetRequest is the JSON:API resource returned for an overview-rating reset request.
+type RatingResetRequest struct {
+	Type       string                       `json:"type"`
+	ID         string                       `json:"id"`
+	Attributes RatingResetRequestAttributes `json:"attributes"`
+}
+
+// RatingResetRequestResponse is the JSON:API response for an overview-rating reset request.
+type RatingResetRequestResponse struct {
+	Data  RatingResetRequest `json:"data"`
+	Links json.RawMessage    `json:"links,omitempty"`
+}
+
+func ratingResetRequestHeaders() http.Header {
+	headers := make(http.Header)
+	headers.Set("Accept", "application/json")
+	headers.Set("Content-Type", "application/json")
+	headers.Set("Origin", appStoreBaseURL)
+	headers.Set("Referer", appStoreBaseURL+"/")
+	headers.Set("X-Requested-With", "XMLHttpRequest")
+	headers.Set("X-CSRF-ITC", "[asc-ui]")
+	return headers
+}
+
+func (c *Client) doRatingResetRequest(ctx context.Context, method, path string, body any) ([]byte, error) {
+	return c.doRequestBase(ctx, c.baseURL, method, path, body, ratingResetRequestHeaders())
+}
+
+func parseRatingResetResponse(data []byte) (*RatingResetRequestResponse, error) {
+	var response RatingResetRequestResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse rating reset response: %w", err)
+	}
+	return &response, nil
+}
+
+// GetAppStoreVersionRatingResetRequest returns the overview-rating reset scheduled for a version.
+func (c *Client) GetAppStoreVersionRatingResetRequest(ctx context.Context, versionID string) (*RatingResetRequestResponse, error) {
+	versionID = strings.TrimSpace(versionID)
+	if versionID == "" {
+		return nil, fmt.Errorf("version id is required")
+	}
+
+	path := "/appStoreVersions/" + url.PathEscape(versionID) + "/resetRatingsRequest"
+	data, err := c.doRatingResetRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	return parseRatingResetResponse(data)
+}
+
+// CreateAppStoreVersionRatingResetRequest schedules an overview-rating reset when a version is released.
+func (c *Client) CreateAppStoreVersionRatingResetRequest(ctx context.Context, versionID string) (*RatingResetRequestResponse, error) {
+	versionID = strings.TrimSpace(versionID)
+	if versionID == "" {
+		return nil, fmt.Errorf("version id is required")
+	}
+
+	payload := map[string]any{
+		"data": map[string]any{
+			"type": ratingResetRequestResourceType,
+			"relationships": map[string]any{
+				"appStoreVersion": map[string]any{
+					"data": map[string]string{
+						"type": "appStoreVersions",
+						"id":   versionID,
+					},
+				},
+			},
+		},
+	}
+
+	data, err := c.doRatingResetRequest(ctx, http.MethodPost, "/resetRatingsRequests", payload)
+	if err != nil {
+		return nil, err
+	}
+	return parseRatingResetResponse(data)
+}
+
+// DeleteAppStoreVersionRatingResetRequest cancels a scheduled overview-rating reset.
+func (c *Client) DeleteAppStoreVersionRatingResetRequest(ctx context.Context, requestID string) error {
+	requestID = strings.TrimSpace(requestID)
+	if requestID == "" {
+		return fmt.Errorf("rating reset request id is required")
+	}
+
+	path := "/resetRatingsRequests/" + url.PathEscape(requestID)
+	_, err := c.doRatingResetRequest(ctx, http.MethodDelete, path, nil)
+	return err
+}

--- a/internal/web/rating_reset.go
+++ b/internal/web/rating_reset.go
@@ -27,6 +27,17 @@ type RatingResetRequest struct {
 type RatingResetRequestResponse struct {
 	Data  RatingResetRequest `json:"data"`
 	Links json.RawMessage    `json:"links,omitempty"`
+	raw   json.RawMessage
+}
+
+// MarshalJSON preserves Apple's complete JSON:API response for JSON output,
+// including fields that this experimental endpoint may add without notice.
+func (response RatingResetRequestResponse) MarshalJSON() ([]byte, error) {
+	if len(response.raw) > 0 {
+		return append([]byte(nil), response.raw...), nil
+	}
+	type responseAlias RatingResetRequestResponse
+	return json.Marshal(responseAlias(response))
 }
 
 func ratingResetRequestHeaders() http.Header {
@@ -49,6 +60,7 @@ func parseRatingResetResponse(data []byte) (*RatingResetRequestResponse, error) 
 	if err := json.Unmarshal(data, &response); err != nil {
 		return nil, fmt.Errorf("failed to parse rating reset response: %w", err)
 	}
+	response.raw = append(json.RawMessage(nil), data...)
 	return &response, nil
 }
 

--- a/internal/web/rating_reset.go
+++ b/internal/web/rating_reset.go
@@ -25,8 +25,8 @@ type RatingResetRequest struct {
 
 // RatingResetRequestResponse is the JSON:API response for an overview-rating reset request.
 type RatingResetRequestResponse struct {
-	Data  RatingResetRequest `json:"data"`
-	Links json.RawMessage    `json:"links,omitempty"`
+	Data  *RatingResetRequest `json:"data"`
+	Links json.RawMessage     `json:"links,omitempty"`
 	raw   json.RawMessage
 }
 

--- a/internal/web/rating_reset_test.go
+++ b/internal/web/rating_reset_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -117,6 +118,47 @@ func TestCreateAppStoreVersionRatingResetRequest(t *testing.T) {
 	}
 	if strings.Contains(string(encoded), `"links"`) {
 		t.Fatalf("response = %s, want absent links to stay absent", encoded)
+	}
+}
+
+func TestRatingResetResponsePreservesCompleteEnvelopeForJSONOutput(t *testing.T) {
+	payload := []byte(`{
+		"data": {
+			"type": "resetRatingsRequests",
+			"id": "reset-123",
+			"attributes": {
+				"resetDate": null,
+				"futureAttribute": "preserve-me"
+			},
+			"relationships": {
+				"appStoreVersion": {
+					"data": {"type": "appStoreVersions", "id": "version-123"}
+				}
+			}
+		},
+		"links": {"self": "/resetRatingsRequests/reset-123"},
+		"meta": {"futureTopLevel": true},
+		"included": [{"type": "appStoreVersions", "id": "version-123"}]
+	}`)
+
+	response, err := parseRatingResetResponse(payload)
+	if err != nil {
+		t.Fatalf("parseRatingResetResponse() error = %v", err)
+	}
+	encoded, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+
+	var got, want map[string]any
+	if err := json.Unmarshal(encoded, &got); err != nil {
+		t.Fatalf("decode marshaled response: %v", err)
+	}
+	if err := json.Unmarshal(payload, &want); err != nil {
+		t.Fatalf("decode source response: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("marshaled response = %#v, want complete envelope %#v", got, want)
 	}
 }
 

--- a/internal/web/rating_reset_test.go
+++ b/internal/web/rating_reset_test.go
@@ -51,6 +51,9 @@ func TestGetAppStoreVersionRatingResetRequest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetAppStoreVersionRatingResetRequest() error = %v", err)
 	}
+	if result.Data == nil {
+		t.Fatal("data = nil, want rating reset request")
+	}
 	if result.Data.ID != "reset-123" {
 		t.Fatalf("id = %q, want reset-123", result.Data.ID)
 	}
@@ -106,6 +109,9 @@ func TestCreateAppStoreVersionRatingResetRequest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateAppStoreVersionRatingResetRequest() error = %v", err)
 	}
+	if result.Data == nil {
+		t.Fatal("data = nil, want rating reset request")
+	}
 	if result.Data.ID != "reset-new" {
 		t.Fatalf("id = %q, want reset-new", result.Data.ID)
 	}
@@ -159,6 +165,25 @@ func TestRatingResetResponsePreservesCompleteEnvelopeForJSONOutput(t *testing.T)
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("marshaled response = %#v, want complete envelope %#v", got, want)
+	}
+}
+
+func TestRatingResetResponsePreservesNullRelationship(t *testing.T) {
+	payload := []byte(`{"data":null,"meta":{"state":"unscheduled"}}`)
+
+	response, err := parseRatingResetResponse(payload)
+	if err != nil {
+		t.Fatalf("parseRatingResetResponse() error = %v", err)
+	}
+	if response.Data != nil {
+		t.Fatalf("data = %#v, want nil", response.Data)
+	}
+	encoded, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+	if string(encoded) != string(payload) {
+		t.Fatalf("marshaled response = %s, want %s", encoded, payload)
 	}
 }
 

--- a/internal/web/rating_reset_test.go
+++ b/internal/web/rating_reset_test.go
@@ -1,0 +1,188 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func assertRatingResetWebHeaders(t *testing.T, request *http.Request) {
+	t.Helper()
+	for name, want := range map[string]string{
+		"Accept":           "application/json",
+		"Content-Type":     "application/json",
+		"Origin":           appStoreBaseURL,
+		"Referer":          appStoreBaseURL + "/",
+		"X-Requested-With": "XMLHttpRequest",
+		"X-CSRF-ITC":       "[asc-ui]",
+	} {
+		if got := request.Header.Get(name); got != want {
+			t.Fatalf("%s = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestGetAppStoreVersionRatingResetRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", request.Method)
+		}
+		if request.URL.EscapedPath() != "/appStoreVersions/version%2F123/resetRatingsRequest" {
+			t.Fatalf("path = %q, want escaped version relationship path", request.URL.EscapedPath())
+		}
+		assertRatingResetWebHeaders(t, request)
+		response.Header().Set("Content-Type", "application/json")
+		_, _ = response.Write([]byte(`{
+			"data": {
+				"type": "resetRatingsRequests",
+				"id": "reset-123",
+				"attributes": {"resetDate": "2026-09-01T08:00:00Z"}
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	result, err := testWebClient(server).GetAppStoreVersionRatingResetRequest(context.Background(), " version/123 ")
+	if err != nil {
+		t.Fatalf("GetAppStoreVersionRatingResetRequest() error = %v", err)
+	}
+	if result.Data.ID != "reset-123" {
+		t.Fatalf("id = %q, want reset-123", result.Data.ID)
+	}
+	if result.Data.Attributes.ResetDate == nil || *result.Data.Attributes.ResetDate != "2026-09-01T08:00:00Z" {
+		t.Fatalf("resetDate = %v, want decoded date", result.Data.Attributes.ResetDate)
+	}
+}
+
+func TestCreateAppStoreVersionRatingResetRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodPost || request.URL.Path != "/resetRatingsRequests" {
+			t.Fatalf("request = %s %s, want POST /resetRatingsRequests", request.Method, request.URL.Path)
+		}
+		assertRatingResetWebHeaders(t, request)
+
+		var payload struct {
+			Data struct {
+				Type          string `json:"type"`
+				Relationships struct {
+					AppStoreVersion struct {
+						Data struct {
+							Type string `json:"type"`
+							ID   string `json:"id"`
+						} `json:"data"`
+					} `json:"appStoreVersion"`
+				} `json:"relationships"`
+			} `json:"data"`
+		}
+		if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if payload.Data.Type != ratingResetRequestResourceType {
+			t.Fatalf("type = %q, want %q", payload.Data.Type, ratingResetRequestResourceType)
+		}
+		version := payload.Data.Relationships.AppStoreVersion.Data
+		if version.Type != "appStoreVersions" || version.ID != "version-123" {
+			t.Fatalf("version relationship = %#v", version)
+		}
+
+		response.Header().Set("Content-Type", "application/json")
+		response.WriteHeader(http.StatusCreated)
+		_, _ = response.Write([]byte(`{
+			"data": {
+				"type": "resetRatingsRequests",
+				"id": "reset-new",
+				"attributes": {"resetDate": null}
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	result, err := testWebClient(server).CreateAppStoreVersionRatingResetRequest(context.Background(), " version-123 ")
+	if err != nil {
+		t.Fatalf("CreateAppStoreVersionRatingResetRequest() error = %v", err)
+	}
+	if result.Data.ID != "reset-new" {
+		t.Fatalf("id = %q, want reset-new", result.Data.ID)
+	}
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"resetDate":null`) {
+		t.Fatalf("response = %s, want resetDate null preserved", encoded)
+	}
+	if strings.Contains(string(encoded), `"links"`) {
+		t.Fatalf("response = %s, want absent links to stay absent", encoded)
+	}
+}
+
+func TestDeleteAppStoreVersionRatingResetRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodDelete {
+			t.Fatalf("method = %s, want DELETE", request.Method)
+		}
+		if request.URL.EscapedPath() != "/resetRatingsRequests/reset%2F123" {
+			t.Fatalf("path = %q, want escaped request path", request.URL.EscapedPath())
+		}
+		assertRatingResetWebHeaders(t, request)
+		response.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	if err := testWebClient(server).DeleteAppStoreVersionRatingResetRequest(context.Background(), " reset/123 "); err != nil {
+		t.Fatalf("DeleteAppStoreVersionRatingResetRequest() error = %v", err)
+	}
+}
+
+func TestRatingResetRequestValidationPreventsNetworkCalls(t *testing.T) {
+	client := &Client{}
+	if _, err := client.GetAppStoreVersionRatingResetRequest(context.Background(), " "); err == nil || !strings.Contains(err.Error(), "version id is required") {
+		t.Fatalf("get error = %v, want version validation", err)
+	}
+	if _, err := client.CreateAppStoreVersionRatingResetRequest(context.Background(), " "); err == nil || !strings.Contains(err.Error(), "version id is required") {
+		t.Fatalf("create error = %v, want version validation", err)
+	}
+	if err := client.DeleteAppStoreVersionRatingResetRequest(context.Background(), " "); err == nil || !strings.Contains(err.Error(), "rating reset request id is required") {
+		t.Fatalf("delete error = %v, want request validation", err)
+	}
+}
+
+func TestRatingResetRequestPropagatesSanitizedAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		response.Header().Set("X-Apple-Request-UUID", "request-123")
+		response.WriteHeader(http.StatusConflict)
+		_, _ = response.Write([]byte(`{"errors":[{"code":"STATE_ERROR","detail":"sensitive detail"}]}`))
+	}))
+	defer server.Close()
+
+	_, err := testWebClient(server).CreateAppStoreVersionRatingResetRequest(context.Background(), "version-123")
+	if err == nil {
+		t.Fatal("expected API error")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || apiErr.Status != http.StatusConflict {
+		t.Fatalf("error = %v, want 409 APIError", err)
+	}
+	if strings.Contains(err.Error(), "sensitive detail") {
+		t.Fatalf("error leaked response detail: %v", err)
+	}
+	if !strings.Contains(err.Error(), "request_id=request-123") || !strings.Contains(err.Error(), "STATE_ERROR") {
+		t.Fatalf("error = %v, want request id and service code", err)
+	}
+}
+
+func TestRatingResetRequestRejectsMalformedResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		_, _ = response.Write([]byte(`{"data":`))
+	}))
+	defer server.Close()
+
+	_, err := testWebClient(server).GetAppStoreVersionRatingResetRequest(context.Background(), "version-123")
+	if err == nil || !strings.Contains(err.Error(), "failed to parse rating reset response") {
+		t.Fatalf("error = %v, want parse context", err)
+	}
+}


### PR DESCRIPTION
## Summary

- add experimental `asc versions rating-reset view`, `create`, and `delete` commands
- use the existing authenticated Apple Account web-session stack for the App Store Connect `/iris/v1` resource
- require `--confirm` for scheduling and cancellation, with JSON, table, and Markdown output
- document endpoint instability, authentication, provider selection, reset scope, and irreversibility after release

## Verification

- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- focused client, command, versions, root integration, search/help, and capability tests
- built-binary help, confirmation, invalid-output, search, and capability checks
- clean `git diff --check` and conflict-free merge tree against `origin/main`

## Live verification

The App Store Connect public API rejected the equivalent resource and relationship paths as nonexistent, confirming this is not an API-key surface. The command therefore uses the existing web-session transport and is marked experimental. A live create/view/delete cycle was not run because the local cached web session and connected browser sessions were unauthenticated; no App Store Connect state was changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added experimental `asc versions rating-reset` commands.
  - View, schedule, and cancel App Store version rating resets.
  - Supports table, Markdown, and JSON output formats.
  - Displays scheduled, cancelled, and unscheduled request statuses.
  - Requires an authenticated Apple Account web session and confirmation for actions.

- **Documentation**
  - Added usage guidance, requirements, behavior details, and examples.

- **Bug Fixes**
  - Added input validation and clearer authentication and API error handling.
  - Improved handling of missing or incomplete reset-request responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->