### PR TITLE
docs: document individual API keys and missing web command surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,16 @@ asc auth login \
   --network
 ```
 
+Individual API keys have no issuer ID. Omit `--issuer-id` and pass `--key-type individual`:
+
+```bash
+asc auth login \
+  --name "MyIndividualKey" \
+  --key-id "ABC123" \
+  --key-type individual \
+  --private-key /path/to/AuthKey.p8
+```
+
 Generate API keys at:
 https://appstoreconnect.apple.com/access/integrations/api
 

--- a/authentication.mdx
+++ b/authentication.mdx
@@ -479,7 +479,7 @@ Ensure your `.p8` file:
 
 ### JWT generation failed
 
-Verify all three credentials are correct:
+Verify the credentials for your key type are correct. Team keys need a key ID, issuer ID, and private key. Individual keys need a key ID and private key with `--key-type individual`; they do not use an issuer ID.
 
 ```bash  theme={null}
 asc auth doctor
@@ -487,7 +487,9 @@ asc auth doctor
 
 Common issues:
 
-* Key ID and Issuer ID don't match the `.p8` file
+* Key ID doesn't match the `.p8` file
+* Issuer ID is wrong for a team key, or was supplied for an individual key
+* `--key-type individual` was omitted for an individual key (the default is `team`)
 * Private key file is corrupted or incomplete
 
 ## Next steps

--- a/commands/sandbox.mdx
+++ b/commands/sandbox.mdx
@@ -39,6 +39,22 @@ asc sandbox update --email "tester@example.com" --interrupt-purchases true
 asc sandbox clear-history --id "SANDBOX_TESTER_ID" --confirm
 ```
 
+### Create a sandbox tester (web session)
+
+The public App Store Connect API does not expose sandbox tester create. Use the
+web-session workflow:
+
+```bash  theme={null}
+asc web sandbox create \
+  --first-name "Jane" \
+  --last-name "Tester" \
+  --email "jane+sandbox@example.com" \
+  --password "Passwordtest1" \
+  --territory "USA"
+```
+
+See [web sandbox](/commands/web) for session setup.
+
 ## List flags
 
 <ParamField path="--output" type="string">
@@ -105,5 +121,9 @@ asc sandbox clear-history --id "SANDBOX_TESTER_ID" --confirm
 
   <Card title="Subscriptions command" icon="repeat" href="/commands/subscriptions">
     Manage subscriptions
+  </Card>
+
+  <Card title="Web command" icon="globe" href="/commands/web">
+    Create sandbox testers through an Apple web session
   </Card>
 </CardGroup>

--- a/commands/sandbox.mdx
+++ b/commands/sandbox.mdx
@@ -41,7 +41,7 @@ asc sandbox clear-history --id "SANDBOX_TESTER_ID" --confirm
 
 ### Create a sandbox tester (web session)
 
-The public App Store Connect API does not expose sandbox tester create. Use the
+The public App Store Connect API does not expose sandbox tester creation. Use the
 web-session workflow:
 
 ```bash  theme={null}

--- a/commands/web.mdx
+++ b/commands/web.mdx
@@ -77,6 +77,29 @@ trusted-device code once; Apple then delivers the phone verification code by
 its configured method (including SMS) and `asc` prompts again. Automated flows
 rerun the configured `--two-factor-code-command` after phone fallback.
 
+### `asc web agreements`
+
+Check and accept Apple Developer Program agreements through Apple web-session
+endpoints. This command is experimental. The public App Store Connect API has
+no endpoint for these agreements.
+
+Available commands:
+
+* `asc web agreements status` - show the agreement alert banner and program agreement history
+* `asc web agreements accept` - accept a pending agreement as the Account Holder
+
+An agreement is reported as pending when App Store Connect shows an agreement
+alert banner or when the agreement's accepted date is older than its effective
+date. Accepting an agreement is a legal action; Apple only allows the team's
+Account Holder to accept it.
+
+Example:
+
+```bash  theme={null}
+asc web agreements status
+asc web agreements accept --agreement-id "AGREEMENT_ID" --confirm
+```
+
 ### `asc web api-keys`
 
 Team API key creation through an Apple Account web session.
@@ -121,6 +144,51 @@ Sandbox tester creation via the App Store Connect web UI contract.
 Available commands:
 
 * `asc web sandbox create` - create a sandbox tester
+
+### `asc web removed-apps`
+
+Inspect apps shown in App Store Connect's Removed Apps status view.
+
+Available commands:
+
+* `asc web removed-apps list` - list removed apps
+
+Example:
+
+```bash  theme={null}
+asc web removed-apps list
+asc web removed-apps list --paginate --output table
+```
+
+### `asc web bundle-ids`
+
+Bundle ID operations that are only available through Apple web-session
+endpoints, including Developer Portal-only capabilities and App Clip
+capability sync.
+
+Available commands:
+
+* `asc web bundle-ids capabilities enable` - enable a Developer Portal-only Bundle ID capability
+* `asc web bundle-ids capabilities sync-app-clip` - sync an App Clip capability with its parent Bundle ID
+
+Currently supported capability IDs for `enable`: `PRIVATE_CLOUD_COMPUTE`.
+Existing settings and relationships are preserved. If the requested capability
+is already enabled, the command returns an already-enabled result without
+sending a PATCH.
+
+Example:
+
+```bash  theme={null}
+asc web bundle-ids capabilities enable \
+  --bundle-id "BUNDLE_RESOURCE_ID" \
+  --capability "PRIVATE_CLOUD_COMPUTE" \
+  --confirm
+
+asc web bundle-ids capabilities sync-app-clip \
+  --bundle-id "CLIP_BUNDLE_ID" \
+  --parent-bundle-id "PARENT_BUNDLE_ID" \
+  --capability "PUSH_NOTIFICATIONS"
+```
 
 ### `asc web app-groups`
 
@@ -194,10 +262,18 @@ Available commands:
 * `asc web review list` - list review submissions for an app
 * `asc web review show` - inspect one submission and related messages/screenshots
 * `asc web review subscriptions` - inspect and mutate next-version subscription review selection
+* `asc web review iaps` - attach a non-renewing IAP to the next app version review
 
 Subscription JSON includes both `submitWithNextAppStoreVersion` and
 `submitWithNextAppStoreVersionKnown`. When the presence field is `false`, Apple
 omitted the attachment attribute and the boolean value is not authoritative.
+
+`asc web review iaps attach` requires `--app`, `--iap-id`, and `--confirm`.
+`--iap-id` accepts the iris resource ID or the product ID from `asc iap list`.
+
+```bash  theme={null}
+asc web review iaps attach --app "123456789" --iap-id "PRODUCT_ID" --confirm
+```
 
 ### `asc web subscriptions`
 
@@ -308,8 +384,11 @@ Use the CLI help directly to explore the current surface:
 ```bash  theme={null}
 asc web --help
 asc web auth --help
+asc web agreements --help
 asc web api-keys --help
 asc web apps --help
+asc web removed-apps --help
+asc web bundle-ids --help
 asc web privacy --help
 asc web review --help
 asc web analytics --help

--- a/docs/API_NOTES.md
+++ b/docs/API_NOTES.md
@@ -42,8 +42,9 @@ Finance reports use Apple fiscal months (`YYYY-MM`), not calendar months.
 
 ## Sandbox Testers
 
-- Required fields: email, first/last name, password + confirm, secret question/answer, birth date, territory
+- `asc web sandbox create` requires `--first-name`, `--last-name`, `--email`, `--password`, and `--territory`
 - Password must include uppercase, lowercase, and a number (8+ chars)
+- Historical public v1 create also required password confirmation, a secret question/answer, and a birth date; that create endpoint is not exposed by the current CLI
 - Sandbox territory inputs accept alpha-2, alpha-3, and exact English country names, but the CLI sends canonical 3-letter App Store territory codes (for example, `US`, `USA`, and `United States` all resolve to `USA`)
 - This normalization is limited to verified ASC alpha-3 territory surfaces, including customer-review filters; public storefront and finance region flags keep their existing namespaces
 - List, view, update, and clear-history use the v2 API through `asc sandbox`

--- a/docs/API_NOTES.md
+++ b/docs/API_NOTES.md
@@ -46,8 +46,8 @@ Finance reports use Apple fiscal months (`YYYY-MM`), not calendar months.
 - Password must include uppercase, lowercase, and a number (8+ chars)
 - Sandbox territory inputs accept alpha-2, alpha-3, and exact English country names, but the CLI sends canonical 3-letter App Store territory codes (for example, `US`, `USA`, and `United States` all resolve to `USA`)
 - This normalization is limited to verified ASC alpha-3 territory surfaces, including customer-review filters; public storefront and finance region flags keep their existing namespaces
-- List/get use the v2 API; create/delete use v1 endpoints (may be unavailable on some accounts)
-- Update/clear-history use the v2 API
+- List, view, update, and clear-history use the v2 API through `asc sandbox`
+- Public `asc sandbox` does not expose create or delete. Create testers with `asc web sandbox create`, which posts to `/sandbox/v2/account/create`
 
 ## TestFlight Distribution
 

--- a/internal/cli/web/web_bundle_ids.go
+++ b/internal/cli/web/web_bundle_ids.go
@@ -33,7 +33,7 @@ func WebBundleIDsCommand() *ffcli.Command {
 		ShortHelp:  "Manage Bundle IDs via web-session endpoints.",
 		LongHelp: `WEB SESSION WORKFLOWS
 
-Manage Bundle ID operations that are only available through Apple web-session web-session endpoints.
+Manage Bundle ID operations that are only available through Apple web-session endpoints.
 
 `,
 		FlagSet:   fs,

--- a/internal/cli/web/web_bundle_ids_test.go
+++ b/internal/cli/web/web_bundle_ids_test.go
@@ -141,6 +141,16 @@ func TestWebBundleIDCapabilitiesEnableValidationErrors(t *testing.T) {
 	}
 }
 
+func TestWebBundleIDsCommandHelpDoesNotDuplicateWebSession(t *testing.T) {
+	help := WebBundleIDsCommand().LongHelp
+	if strings.Contains(help, "web-session web-session") {
+		t.Fatalf("bundle-ids LongHelp duplicates web-session phrase: %q", help)
+	}
+	if !strings.Contains(help, "Apple web-session endpoints") {
+		t.Fatalf("bundle-ids LongHelp missing web-session endpoints wording: %q", help)
+	}
+}
+
 func TestWebBundleIDCapabilitiesEnableHelpUsesSupportedLoginFlags(t *testing.T) {
 	cmd := WebBundleIDCapabilitiesEnableCommand()
 	if strings.Contains(cmd.LongHelp, "--reauthenticate") {


### PR DESCRIPTION
## Summary
- Document the individual API key login path in the README quickstart and stop the JWT troubleshooting section from telling those users to supply an issuer ID.
- Fill the missing `asc web` docs for agreements, bundle-ids, removed-apps, and `review iaps`; remove the duplicated "web-session web-session" help phrase; replace the stale sandbox v1 create/delete note with the current `asc web sandbox create` (`POST /sandbox/v2/account/create`) path.

`make generate-command-docs` was run. `docs/COMMANDS.md` is unchanged because that generator indexes top-level `asc --help` only; the nested `web bundle-ids` LongHelp fix does not appear there.

## Test plan
- [x] `ASC_BYPASS_KEYCHAIN=1 /tmp/asc-2281 auth login --help` lists `--key-type individual` and matches production 4.9.2
- [x] `ASC_BYPASS_KEYCHAIN=1 /tmp/asc-2281 web agreements|bundle-ids|removed-apps|review iaps|sandbox create --help` matches the new docs (no invented flags)
- [x] Focused test `TestWebBundleIDsCommandHelpDoesNotDuplicateWebSession` went RED then GREEN
- [x] `make generate-command-docs`, `make build`, `make format`, `make check-docs`, `make lint`, `ASC_BYPASS_KEYCHAIN=1 make test`
- [ ] Did not run `asc web auth login` (needs 2FA)

Closes #2267
Closes #2281

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added documentation for managing Apple Developer agreements, removed apps, Bundle ID capabilities, App Clip synchronization, and in-app purchase review attachments.
  - Documented sandbox tester creation through the web workflow.
  - Added guidance for authenticating with individual Apple API keys.

- **Documentation**
  - Expanded JWT troubleshooting and clarified sandbox API usage and command requirements.
  - Updated CLI help examples to include new web command families.

- **Bug Fixes**
  - Corrected duplicated wording in `web bundle-ids` command help.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->