### PR TITLE
fix(web privacy): fail closed on unrepresentable remote usages

### DIFF
--- a/internal/cli/web/web_privacy.go
+++ b/internal/cli/web/web_privacy.go
@@ -121,10 +121,11 @@ type privacyPublishState struct {
 }
 
 type privacyPullOutput struct {
-	AppID        string                 `json:"appId"`
-	Declaration  privacyDeclarationFile `json:"declaration"`
-	PublishState privacyPublishState    `json:"publishState"`
-	Out          string                 `json:"out,omitempty"`
+	AppID                string                 `json:"appId"`
+	Declaration          privacyDeclarationFile `json:"declaration"`
+	PublishState         privacyPublishState    `json:"publishState"`
+	UnrepresentableCount int                    `json:"unrepresentableCount"`
+	Out                  string                 `json:"out,omitempty"`
 }
 
 type privacyPublishOutput struct {
@@ -222,6 +223,9 @@ func declarationToTupleSet(declaration privacyDeclarationFile) (map[string]priva
 			return nil, fmt.Errorf("dataUsages[%d].dataProtections is required", index)
 		}
 		for _, protection := range protections {
+			if protection == dataProtectionUnknown {
+				return nil, fmt.Errorf("dataUsages[%d].dataProtections contains unrepresentable remote privacy data %q; resolve those entries before apply", index, protection)
+			}
 			if _, ok := knownDataProtections[protection]; !ok {
 				return nil, fmt.Errorf("dataUsages[%d].dataProtections contains unsupported value %q", index, protection)
 			}
@@ -385,23 +389,33 @@ func declarationFromRemoteDataUsages(usages []webcore.AppDataUsage) privacyDecla
 	}
 
 	tuples := make(map[string]privacyTuple)
-	for key, value := range remoteStateFromDataUsages(usages) {
-		if _, known := knownDataProtections[value.Tuple.DataProtection]; !known {
-			continue
+	for _, value := range remoteStateFromDataUsages(usages) {
+		tuple := value.Tuple
+		if isUnrepresentableDataProtection(tuple.DataProtection) {
+			tuple.DataProtection = dataProtectionUnknown
 		}
-		tuples[key] = value.Tuple
-	}
-	if len(tuples) == 0 {
-		return privacyDeclarationFile{
-			SchemaVersion: privacySchemaVersion,
-			DataUsages: []privacyUsage{
-				{
-					DataProtections: []string{dataProtectionNotCollected},
-				},
-			},
-		}
+		tuples[privacyTupleKey(tuple)] = tuple
 	}
 	return declarationFromTupleSet(tuples)
+}
+
+func isUnrepresentableDataProtection(protection string) bool {
+	switch normalizeToken(protection) {
+	case dataProtectionLinked, dataProtectionNotLinked, dataProtectionTracking:
+		return false
+	default:
+		return true
+	}
+}
+
+func countUnrepresentableRemoteUsages(usages []webcore.AppDataUsage) int {
+	count := 0
+	for _, usage := range usages {
+		if isUnrepresentableDataProtection(usage.DataProtection) {
+			count++
+		}
+	}
+	return count
 }
 
 func pairChangesIntoUpdates(adds []privacyPlanChange, deletes []privacyPlanChange) ([]privacyPlanChange, []privacyPlanChange, []privacyPlanChange) {
@@ -967,6 +981,9 @@ func formatPrivacyPublished(state privacyPublishState) string {
 func renderPrivacyPullTable(payload privacyPullOutput) error {
 	fmt.Printf("App ID: %s\n", payload.AppID)
 	fmt.Printf("Published: %s\n", formatPrivacyPublished(payload.PublishState))
+	if payload.UnrepresentableCount > 0 {
+		fmt.Printf("Unrepresentable: %d\n", payload.UnrepresentableCount)
+	}
 	if strings.TrimSpace(payload.Out) != "" {
 		fmt.Printf("Output File: %s\n", payload.Out)
 	}
@@ -981,6 +998,9 @@ func renderPrivacyPullTable(payload privacyPullOutput) error {
 func renderPrivacyPullMarkdown(payload privacyPullOutput) error {
 	fmt.Printf("**App ID:** %s\n\n", payload.AppID)
 	fmt.Printf("**Published:** %s\n\n", formatPrivacyPublished(payload.PublishState))
+	if payload.UnrepresentableCount > 0 {
+		fmt.Printf("**Unrepresentable:** %d\n\n", payload.UnrepresentableCount)
+	}
 	if strings.TrimSpace(payload.Out) != "" {
 		fmt.Printf("**Output File:** %s\n\n", payload.Out)
 	}
@@ -1279,6 +1299,10 @@ func WebPrivacyPullCommand() *ffcli.Command {
 Fetch current app data usage declarations from web-session endpoints and emit
 canonical JSON that can be used with plan/apply.
 
+Unrepresentable remote data-protection values are preserved as
+UNKNOWN_OR_MISSING and counted in unrepresentableCount. apply refuses those
+files until the entries are resolved.
+
 Examples:
   asc web privacy pull --app "123456789"
   asc web privacy pull --app "123456789" --out "./privacy.json"`,
@@ -1334,10 +1358,11 @@ Examples:
 			}
 
 			payload := privacyPullOutput{
-				AppID:        resolvedAppID,
-				Declaration:  declaration,
-				PublishState: privacyPublishStateFromRemote(publishState),
-				Out:          outPath,
+				AppID:                resolvedAppID,
+				Declaration:          declaration,
+				PublishState:         privacyPublishStateFromRemote(publishState),
+				UnrepresentableCount: countUnrepresentableRemoteUsages(remoteUsages),
+				Out:                  outPath,
 			}
 			return shared.PrintOutputWithRenderers(
 				payload,
@@ -1367,6 +1392,9 @@ func WebPrivacyPlanCommand() *ffcli.Command {
 
 Compute a deterministic diff between local declaration JSON and remote
 app data usage tuples.
+
+Declarations that contain UNKNOWN_OR_MISSING (unrepresentable remote data)
+are rejected before any planning against the live app.
 
 Examples:
   asc web privacy plan --app "123456789" --file "./privacy.json"`,
@@ -1446,6 +1474,9 @@ func WebPrivacyApplyCommand() *ffcli.Command {
 
 Apply local declaration tuples to remote app data usages.
 This command never publishes automatically.
+
+Declarations that contain UNKNOWN_OR_MISSING (unrepresentable remote data)
+are rejected before any create, update, or delete.
 
 Examples:
   asc web privacy apply --app "123456789" --file "./privacy.json"

--- a/internal/cli/web/web_privacy_test.go
+++ b/internal/cli/web/web_privacy_test.go
@@ -230,7 +230,7 @@ func TestDeclarationFromRemoteDataUsagesEmptyDefaultsNotCollected(t *testing.T) 
 	}
 }
 
-func TestDeclarationFromRemoteDataUsagesMalformedOnlyDefaultsNotCollected(t *testing.T) {
+func TestDeclarationFromRemoteDataUsagesMalformedOnlyPreservesUnrepresentable(t *testing.T) {
 	declaration := declarationFromRemoteDataUsages([]webcore.AppDataUsage{
 		{
 			ID:       "usage-malformed-1",
@@ -240,14 +240,21 @@ func TestDeclarationFromRemoteDataUsagesMalformedOnlyDefaultsNotCollected(t *tes
 	})
 
 	if len(declaration.DataUsages) != 1 {
-		t.Fatalf("expected one default data usage, got %#v", declaration.DataUsages)
+		t.Fatalf("expected one unrepresentable usage, got %#v", declaration.DataUsages)
 	}
-	if !reflect.DeepEqual(declaration.DataUsages[0].DataProtections, []string{dataProtectionNotCollected}) {
-		t.Fatalf("unexpected default declaration for malformed-only usages: %#v", declaration.DataUsages[0])
+	got := declaration.DataUsages[0]
+	if containsPrivacyProtection(got.DataProtections, dataProtectionNotCollected) {
+		t.Fatalf("non-empty malformed remote usages must not collapse to DATA_NOT_COLLECTED: %#v", got)
+	}
+	if !reflect.DeepEqual(got.DataProtections, []string{dataProtectionUnknown}) {
+		t.Fatalf("expected opaque %s marker, got %#v", dataProtectionUnknown, got)
+	}
+	if got.Category != "PURCHASE_HISTORY" {
+		t.Fatalf("expected malformed category to be preserved, got %#v", got)
 	}
 }
 
-func TestDeclarationFromRemoteDataUsagesSkipsMalformedWhenValidPresent(t *testing.T) {
+func TestDeclarationFromRemoteDataUsagesPreservesMalformedWhenValidPresent(t *testing.T) {
 	declaration := declarationFromRemoteDataUsages([]webcore.AppDataUsage{
 		{
 			ID:       "usage-malformed-1",
@@ -263,13 +270,17 @@ func TestDeclarationFromRemoteDataUsagesSkipsMalformedWhenValidPresent(t *testin
 	})
 
 	if len(declaration.DataUsages) != 1 {
-		t.Fatalf("expected one valid usage group, got %#v", declaration.DataUsages)
+		t.Fatalf("expected one grouped usage, got %#v", declaration.DataUsages)
 	}
-	if declaration.DataUsages[0].Category != "PURCHASE_HISTORY" {
-		t.Fatalf("unexpected declaration category: %#v", declaration.DataUsages[0])
+	got := declaration.DataUsages[0]
+	if got.Category != "PURCHASE_HISTORY" {
+		t.Fatalf("unexpected declaration category: %#v", got)
 	}
-	if !reflect.DeepEqual(declaration.DataUsages[0].DataProtections, []string{dataProtectionLinked}) {
-		t.Fatalf("unexpected declaration protections: %#v", declaration.DataUsages[0])
+	if containsPrivacyProtection(got.DataProtections, dataProtectionNotCollected) {
+		t.Fatalf("mixed remote usages must not collapse malformed entries to DATA_NOT_COLLECTED: %#v", got)
+	}
+	if !reflect.DeepEqual(got.DataProtections, []string{dataProtectionLinked, dataProtectionUnknown}) {
+		t.Fatalf("expected valid and unrepresentable protections, got %#v", got.DataProtections)
 	}
 }
 
@@ -1281,5 +1292,225 @@ func assertNoPrivacySecrets(t *testing.T, stdout, stderr string) {
 		if strings.Contains(combined, secret) {
 			t.Fatalf("output leaked session secret %q", secret)
 		}
+	}
+}
+
+func containsPrivacyProtection(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestWebPrivacyPullDoesNotWriteNotCollectedForMalformedRemoteUsages(t *testing.T) {
+	fixture := handlertest.New(t)
+	outPath := filepath.Join(t.TempDir(), "privacy.json")
+	stubPrivacyWebSession(t, func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/iris/v1/apps/"+privacyTestAppID+"/dataUsages":
+			return privacyJSONResponse(req, `{
+				"data": [{
+					"id": "usage-malformed-1",
+					"type": "appDataUsages",
+					"relationships": {
+						"category": {"data": {"type":"appDataUsageCategories","id":"PURCHASE_HISTORY"}},
+						"purpose": {"data": {"type":"appDataUsagePurposes","id":"APP_FUNCTIONALITY"}}
+					}
+				}, {
+					"id": "usage-malformed-2",
+					"type": "appDataUsages",
+					"relationships": {
+						"category": {"data": {"type":"appDataUsageCategories","id":"EMAIL_ADDRESS"}}
+					}
+				}]
+			}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/iris/v1/apps/"+privacyTestAppID+"/dataUsagePublishState":
+			return privacyJSONResponse(req, `{
+				"data": {
+					"id": "publish-state-1",
+					"type": "appDataUsagesPublishState",
+					"attributes": {"published": false}
+				}
+			}`), nil
+		default:
+			return fixture.Response("unexpected request: %s %s", req.Method, req.URL.Path), nil
+		}
+	})
+
+	cmd := WebPrivacyPullCommand()
+	if err := cmd.FlagSet.Parse([]string{"--app", privacyTestAppID, "--out", outPath, "--output", "json"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	stdout, stderr := captureWebCommandOutput(t, func() {
+		if err := cmd.Exec(context.Background(), nil); err != nil {
+			t.Fatalf("exec error: %v", err)
+		}
+	})
+	assertNoPrivacySecrets(t, stdout, stderr)
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("failed to parse stdout JSON: %v\nstdout=%s", err, stdout)
+	}
+	count, ok := payload["unrepresentableCount"].(float64)
+	if !ok || count != 2 {
+		t.Fatalf("expected unrepresentableCount=2, got %#v", payload["unrepresentableCount"])
+	}
+	declaration, ok := payload["declaration"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected declaration object, got %#v", payload["declaration"])
+	}
+	assertJSONDeclarationHasNoNotCollected(t, declaration)
+
+	fileData, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read --out file: %v", err)
+	}
+	if strings.Contains(string(fileData), dataProtectionNotCollected) {
+		t.Fatalf("--out wrote DATA_NOT_COLLECTED for non-empty malformed remote usages:\n%s", fileData)
+	}
+	if !strings.Contains(string(fileData), dataProtectionUnknown) {
+		t.Fatalf("--out missing opaque %s marker:\n%s", dataProtectionUnknown, fileData)
+	}
+}
+
+func TestWebPrivacyPullPreservesMalformedUsagesAlongsideValidOnes(t *testing.T) {
+	fixture := handlertest.New(t)
+	stubPrivacyWebSession(t, func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/iris/v1/apps/"+privacyTestAppID+"/dataUsages":
+			return privacyJSONResponse(req, `{
+				"data": [{
+					"id": "usage-malformed-1",
+					"type": "appDataUsages",
+					"relationships": {
+						"category": {"data": {"type":"appDataUsageCategories","id":"PURCHASE_HISTORY"}},
+						"purpose": {"data": {"type":"appDataUsagePurposes","id":"APP_FUNCTIONALITY"}}
+					}
+				}, {
+					"id": "usage-valid-1",
+					"type": "appDataUsages",
+					"relationships": {
+						"category": {"data": {"type":"appDataUsageCategories","id":"PURCHASE_HISTORY"}},
+						"purpose": {"data": {"type":"appDataUsagePurposes","id":"APP_FUNCTIONALITY"}},
+						"dataProtection": {"data": {"type":"appDataUsageDataProtections","id":"DATA_LINKED_TO_YOU"}}
+					}
+				}]
+			}`), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/iris/v1/apps/"+privacyTestAppID+"/dataUsagePublishState":
+			return privacyJSONResponse(req, `{
+				"data": {
+					"id": "publish-state-1",
+					"type": "appDataUsagesPublishState",
+					"attributes": {"published": true}
+				}
+			}`), nil
+		default:
+			return fixture.Response("unexpected request: %s %s", req.Method, req.URL.Path), nil
+		}
+	})
+
+	cmd := WebPrivacyPullCommand()
+	if err := cmd.FlagSet.Parse([]string{"--app", privacyTestAppID, "--output", "json"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	stdout, stderr := captureWebCommandOutput(t, func() {
+		if err := cmd.Exec(context.Background(), nil); err != nil {
+			t.Fatalf("exec error: %v", err)
+		}
+	})
+	assertNoPrivacySecrets(t, stdout, stderr)
+
+	var payload struct {
+		UnrepresentableCount int `json:"unrepresentableCount"`
+		Declaration          privacyDeclarationFile
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("failed to parse stdout JSON: %v\nstdout=%s", err, stdout)
+	}
+	if payload.UnrepresentableCount != 1 {
+		t.Fatalf("expected unrepresentableCount=1, got %d", payload.UnrepresentableCount)
+	}
+	if len(payload.Declaration.DataUsages) != 1 {
+		t.Fatalf("expected one grouped usage, got %#v", payload.Declaration.DataUsages)
+	}
+	got := payload.Declaration.DataUsages[0]
+	if containsPrivacyProtection(got.DataProtections, dataProtectionNotCollected) {
+		t.Fatalf("mixed pull collapsed malformed entries: %#v", got)
+	}
+	if !containsPrivacyProtection(got.DataProtections, dataProtectionLinked) || !containsPrivacyProtection(got.DataProtections, dataProtectionUnknown) {
+		t.Fatalf("expected valid and opaque protections, got %#v", got.DataProtections)
+	}
+}
+
+func TestWebPrivacyApplyRefusesUnrepresentableDeclarationWithoutDeletes(t *testing.T) {
+	fixture := handlertest.New(t)
+	var deleteCount int
+	stubPrivacyWebSession(t, func(req *http.Request) (*http.Response, error) {
+		if req.Method == http.MethodDelete {
+			deleteCount++
+			return fixture.Response("did not expect DELETE %s", req.URL.Path), nil
+		}
+		return fixture.Response("unexpected request: %s %s", req.Method, req.URL.Path), nil
+	})
+
+	path := filepath.Join(t.TempDir(), "privacy.json")
+	if err := os.WriteFile(path, []byte(`{
+		"schemaVersion": 1,
+		"dataUsages": [{
+			"category": "PURCHASE_HISTORY",
+			"purposes": ["APP_FUNCTIONALITY"],
+			"dataProtections": ["UNKNOWN_OR_MISSING"]
+		}]
+	}`), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	cmd := WebPrivacyApplyCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--app", privacyTestAppID,
+		"--file", path,
+		"--allow-deletes",
+		"--confirm",
+		"--output", "json",
+	}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	var execErr error
+	stdout, stderr := captureWebCommandOutput(t, func() {
+		execErr = cmd.Exec(context.Background(), nil)
+	})
+	assertNoPrivacySecrets(t, stdout, stderr)
+	if execErr == nil {
+		t.Fatal("expected apply to fail closed on unrepresentable declaration")
+	}
+	if !strings.Contains(execErr.Error(), "unrepresentable") {
+		t.Fatalf("error = %v, want unrepresentable", execErr)
+	}
+	if !strings.Contains(stderr, "unrepresentable") {
+		t.Fatalf("stderr = %q, want unrepresentable", stderr)
+	}
+	if deleteCount != 0 {
+		t.Fatalf("expected no deletes, got %d", deleteCount)
+	}
+}
+
+func assertJSONDeclarationHasNoNotCollected(t *testing.T, declaration map[string]any) {
+	t.Helper()
+	usages, ok := declaration["dataUsages"].([]any)
+	if !ok {
+		t.Fatalf("expected dataUsages array, got %#v", declaration["dataUsages"])
+	}
+	raw, err := json.Marshal(usages)
+	if err != nil {
+		t.Fatalf("marshal dataUsages: %v", err)
+	}
+	if strings.Contains(string(raw), dataProtectionNotCollected) {
+		t.Fatalf("declaration contained DATA_NOT_COLLECTED: %s", raw)
 	}
 }


### PR DESCRIPTION
## Summary
- `web privacy pull` no longer collapses a non-empty malformed remote usage set to `DATA_NOT_COLLECTED`. Unrepresentable data-protection values are kept as the opaque `UNKNOWN_OR_MISSING` marker, with an additive `unrepresentableCount` field (and `Unrepresentable: N` in table/markdown when the count is greater than zero).
- `web privacy apply` and `web privacy plan` reject declarations that contain `UNKNOWN_OR_MISSING` before any HTTP create/update/delete. No override flag is added; operators must resolve those entries first.
- Empty remote responses still emit `DATA_NOT_COLLECTED`. `internal/web/privacy.go` is unchanged; the planner already preserved malformed remote tuples.

Closes #2269

## Test plan
- [x] RED then GREEN: all-malformed non-empty remote usages do not write `DATA_NOT_COLLECTED` and report `unrepresentableCount`
- [x] Mixed valid + malformed usages preserve both protections in the pulled declaration
- [x] `apply --allow-deletes --confirm` with `UNKNOWN_OR_MISSING` exits non-zero, prints `unrepresentable` on stderr, and issues no DELETE
- [x] Empty remote still maps to `DATA_NOT_COLLECTED`
- [x] No cookies or raw Apple bodies in command output
- [x] `make format`, `make build`, `make check-docs`, `make lint`, `ASC_BYPASS_KEYCHAIN=1 make test`

## Live verification
`ASC_BYPASS_KEYCHAIN=1 /tmp/asc-2269 web auth status` returned `authenticated:false` (`passwordStored:false`). Did not run `web auth login` (2FA) and did not run live `pull`/`apply`/`publish`. Coverage is command-level httptest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Privacy pulls now preserve unrecognized or malformed remote data values as `UNKNOWN_OR_MISSING` instead of discarding them.
  - Pull results display the number of unrepresentable values in table, Markdown, and structured output.

- **Bug Fixes**
  - Privacy plans and applies now stop safely when unresolved values are declared, preventing unintended remote changes.
  - Pulls retain both valid and unrecognized data values for more accurate review and recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->