### PR TITLE
apps wall: add AI Sound Effects: Audio Studio

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -40,6 +40,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/60/12/19/60121940-0202-b42d-6c0d-074edb4fff49/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "AI Sound Effects: Audio Studio",
+    "link": "https://apps.apple.com/us/app/ai-sound-effects-audio-studio/id6759847647?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/4b/63/2f/4b632f89-4083-8c06-f708-94270fce6d14/AppIcon-0-0-1x_U007ephone-0-1-0-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Airtist",
     "link": "https://apps.apple.com/app/id6745053878",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/a1/85/81/a185815f-0e82-98b4-ac37-aed44c57d719/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `AI Sound Effects: Audio Studio` to the Wall of Apps

## Entry

- App ID: 6759847647
- App: AI Sound Effects: Audio Studio
- Link: https://apps.apple.com/us/app/ai-sound-effects-audio-studio/id6759847647?uo=4

## Notes

- Submitted via `asc apps wall submit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI Sound Effects: Audio Studio to the app directory, including its App Store link and icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->