### PR TITLE
docs(signing): document encryption, revocation, and remaining CI failure modes

### DIFF
--- a/commands/signing.mdx
+++ b/commands/signing.mdx
@@ -171,6 +171,8 @@ The command does not overwrite output files. This prevents a failed write from s
 
 Use `--certificate-type` only when the inferred type is not the one you need.
 
+Fetch and sync also accept `IOS_APP_INHOUSE` and `TVOS_APP_INHOUSE`. Those enterprise/in-house profiles install on devices that were never registered, so revoking that distribution certificate stops already-installed apps; revoking an App Store certificate does not pull binaries Apple already re-signed, and development profiles stay limited to registered devices.
+
 ## Create a certificate without losing its private key
 
 If no suitable certificate exists, generate the private key and certificate signing request locally while creating the App Store Connect certificate:
@@ -244,6 +246,16 @@ Do not print the private key or store it in shell history. The certificate finge
 ## Share a usable signing identity
 
 `signing sync push` fetches the chosen certificate and profile, verifies the local private identity against them, encrypts the assets, and publishes one Git commit. It works in a temporary clone and removes that clone after the run.
+
+### What the encrypted store protects
+
+Every `.enc` file uses AES-256-GCM. That authenticated encryption gives confidentiality plus integrity for the ciphertext: a modified file or a wrong password fails decryption. It does not replace a private, least-privilege Git repository or a generated high-entropy password. Anyone who has both can decrypt.
+
+Versioned envelopes (identity PKCS#12 files, identity-context records, and newly written provisioning profiles) derive a 32-byte key with scrypt (`N=32768`, `r=8`, `p=1`). A JSON metadata header is bound as AES-GCM additional authenticated data, so changing the recorded relative path, kind, sensitivity flag, certificate SHA-256, team, bundle ID, profile type, or KDF parameters fails the same way as a modified ciphertext. Identity metadata binds path, kind, sensitivity, certificate fingerprint, and team. Context metadata binds the bundle identifier and profile type. Profile envelopes bind bundle ID, profile type, resource ID, and UUID.
+
+Public certificate files, and older unversioned profile files still present in existing repositories, keep the stable PBKDF2 format: PBKDF2-HMAC-SHA256 with 100,000 iterations, a 16-byte salt, a 32-byte key, and no additional authenticated data. `sync pull` still reads those files. The normalized PKCS#12 payload is separately password-protected with the same sync password using PBKDF2.
+
+The store does not hide Git history, rewrite old commits when you rotate the password, or protect plaintext after a successful pull.
 
 ### Push a PKCS#12 identity
 
@@ -457,7 +469,7 @@ and follow your team's history-retention procedure.
 
 ### Current sync scope
 
-The encrypted store currently uses Git. Push applies one profile configuration and one identity across its selected targets; it does not accept per-target profile types or device sets. Pull selectors similarly use one profile type per invocation. Certificate renewal and stale encrypted-store deletion remain explicit operator work. Dedicated persistent keychain installation is separate from sync, creates a new keychain for one identity per invocation, and leaves provisioning-profile installation as an independent operation.
+The encrypted store currently uses Git. Push applies one profile configuration and one identity across its selected targets; it does not accept per-target profile types or device sets. Pull selectors similarly use one profile type per invocation. Certificate renewal and stale encrypted-store deletion remain explicit operator work; [Rotation and expiry](#rotation-and-expiry) has the ordering. Dedicated persistent keychain installation is separate from sync, creates a new keychain for one identity per invocation, and leaves provisioning-profile installation as an independent operation.
 
 ## CI example
 
@@ -467,11 +479,21 @@ available through identity installation, and one trap removes both password
 files and the persistent job keychain. Do not upload `.asc/signing/pulled` as a
 workflow artifact.
 
+`signing sync` is noninteractive for its own Git subprocesses: it sets
+`GIT_TERMINAL_PROMPT=0`, and when `GIT_SSH_COMMAND`, `GIT_SSH`, and
+`core.sshCommand` are unset it uses `GIT_SSH_COMMAND=ssh -o BatchMode=yes`. A
+custom `GIT_SSH_COMMAND` is preserved verbatim, so include `-o BatchMode=yes`
+(or an equivalent no-prompt wrapper) yourself; an SSH passphrase or unknown-host
+prompt will hang the runner. The job-level values below cover any other Git or
+SSH the step runs:
+
 ```yaml  theme={null}
 - name: Pull signing assets
   shell: bash
   env:
     SIGNING_SYNC_PASSWORD: ${{ secrets.SIGNING_SYNC_PASSWORD }}
+    GIT_TERMINAL_PROMPT: "0"
+    GIT_SSH_COMMAND: ssh -o BatchMode=yes
   run: |
     set +x
     umask 077
@@ -672,12 +694,21 @@ asc profiles local clean --expired --confirm
 
 Profiles cannot be edited. When a device, capability, certificate, or validity requirement changes, create a successor profile and move builds to it. Keep the old profile until every active build path has switched.
 
-For certificate rotation:
+`signing sync` does not renew certificates or delete stale encrypted files. Do that work in this order:
 
 1. Create the new certificate from a locally retained private key or a new generated CSR.
-2. Create or reconcile profiles that use the new certificate.
-3. Push the new identity and verified profiles to the encrypted repository.
-4. Pull and test on a clean worker before deactivating the old certificate.
+2. Create or reconcile successor profiles that use the new certificate.
+3. Push the new identity and verified profiles to the encrypted repository. Push advances the authenticated identity-context record; Git history still contains the previous ciphertext.
+4. Pull and test on a clean worker.
+5. Keep the old certificate until every active build path has switched. Deactivate it (`asc certificates update --id CERT_ID --activated false`) when you only need to stop new profile creation. Revoke it when the private key is compromised or you must invalidate remaining profiles and already-distributed artifacts that still depend on that certificate:
+
+```bash  theme={null}
+asc certificates revoke --id CERT_ID --confirm
+```
+
+`--confirm` is required. Revocation cannot be undone and cannot be reversed with `--activated`. It invalidates provisioning profiles that embed that certificate. Apple still counts a revoked certificate against the per-type limit until it expires, so revocation is not a way to free a slot immediately; see [Certificates](/commands/certificates).
+
+6. If HEAD should no longer carry unused `.enc` files, delete those paths in a later reviewed Git commit. Sync does not remove them. Password rotation re-encrypts the current branch head only; rewriting history is a separate incident-response decision.
 
 Git history retains encrypted prior assets, so repository access and password rotation deserve the same controls as other signing secrets. Do not commit the decrypted pull directory, password files, raw private keys, or PKCS#12 inputs.
 
@@ -715,9 +746,19 @@ Use an iOS ad hoc profile with registered devices and `get-task-allow` disabled.
 
 Read the plan blockers. Common causes include multiple eligible certificates, an entitlement whose capability settings cannot be verified, a team mismatch, an unsupported archive platform, or a mutation count over `--max-mutations`. Planning does not repair those conditions silently.
 
+### Expired or missing WWDR intermediate
+
+Apple issues developer certificates under a Worldwide Developer Relations (WWDR) intermediate. If that intermediate is expired or missing from the System keychain, `codesign` can reject a pulled identity that is otherwise valid. Eligible Xcode versions install current WWDR intermediates automatically; otherwise download them from the [Apple PKI](https://www.apple.com/certificateauthority/) page and install them into `/Library/Keychains/System.keychain`. `asc` does not fetch or install WWDR intermediates.
+
+### Identity is present but `codesign` cannot see it
+
+`codesign` only uses identities in keychains on the current user search list, and only when the private key's partition list includes `apple-tool:` and `apple:`. `asc signing keychain install --add-to-search-list --confirm` does both inside a new dedicated keychain. `asc signing run` prepends its temporary keychain for the child process, then restores the search list.
+
+If you imported the PKCS#12 some other way, run `security list-keychains` and confirm the destination is on that list. Partition-list updates against the login or a shared keychain can affect unrelated private keys; prefer `signing keychain install` or `signing run` so those changes stay in a dedicated keychain. Do not put a keychain password on a `security set-key-partition-list` command line.
+
 ## Related commands
 
-* [Certificates](/commands/certificates) - create, inspect, download, and deactivate public certificates
+* [Certificates](/commands/certificates) - create, inspect, download, deactivate, and revoke public certificates
 * [Profiles](/commands/profiles) - create, download, inspect, install, and clean profiles
 * [Bundle IDs](/commands/bundle-ids) - manage identifiers and capabilities
 * [Devices](/commands/devices) - list and register test devices

--- a/commands/signing.mdx
+++ b/commands/signing.mdx
@@ -700,13 +700,13 @@ Profiles cannot be edited. When a device, capability, certificate, or validity r
 2. Create or reconcile successor profiles that use the new certificate.
 3. Push the new identity and verified profiles to the encrypted repository. Push advances the authenticated identity-context record; Git history still contains the previous ciphertext.
 4. Pull and test on a clean worker.
-5. Keep the old certificate until every active build path has switched. Deactivate it (`asc certificates update --id CERT_ID --activated false`) when you only need to stop new profile creation. Revoke it when the private key is compromised or you must invalidate remaining profiles and already-distributed artifacts that still depend on that certificate:
+5. Keep the old certificate until every active build path has switched. Deactivate it (`asc certificates update --id CERT_ID --activated false`) when you only need to stop new profile creation. Revoke it when the private key is compromised or you must invalidate remaining profiles that still embed that certificate:
 
 ```bash  theme={null}
 asc certificates revoke --id CERT_ID --confirm
 ```
 
-`--confirm` is required. Revocation cannot be undone and cannot be reversed with `--activated`. It invalidates provisioning profiles that embed that certificate. Apple still counts a revoked certificate against the per-type limit until it expires, so revocation is not a way to free a slot immediately; see [Certificates](/commands/certificates).
+`--confirm` is required. Revocation cannot be undone and cannot be reversed with `--activated`. It invalidates provisioning profiles that embed that certificate. It does not pull App Store binaries Apple already re-signed; stopping already-installed apps is the in-house case under [Common profile types](#common-profile-types). Apple still counts a revoked certificate against the per-type limit until it expires, so revocation is not a way to free a slot immediately; see [Certificates](/commands/certificates).
 
 6. If HEAD should no longer carry unused `.enc` files, delete those paths in a later reviewed Git commit. Sync does not remove them. Password rotation re-encrypts the current branch head only; rewriting history is a separate incident-response decision.
 

--- a/guides/code-signing.mdx
+++ b/guides/code-signing.mdx
@@ -4,7 +4,7 @@
 
 A downloaded certificate is not a signing identity. The certificate contains a public key; Xcode also needs the matching private key. App Store Connect can return certificates and provisioning profiles, but it cannot return a private key after the certificate request has been created.
 
-Use the [signing command reference](/commands/signing) for every flag, profile-type table, encrypted repository format, multi-target manifest, CI example, rotation sequence, and troubleshooting case. This guide explains which workflow to choose.
+Use the [signing command reference](/commands/signing) for every flag, profile-type table, encrypted repository format, encryption guarantees, multi-target manifest, CI example, rotation and revocation sequence, and troubleshooting case. This guide explains which workflow to choose.
 
 ## Existing identity on one Mac
 
@@ -147,9 +147,11 @@ asc signing sync push \
 
 The same profile type, certificate filter, identity, and device set apply to every target. A batch can create profiles before the final repository push, so a later failure may leave those immutable App Store Connect profiles in place.
 
+What AES-256-GCM, PBKDF2, scrypt, and authenticated metadata do and do not guarantee is in [What the encrypted store protects](/commands/signing#what-the-encrypted-store-protects).
+
 ## Pull in CI
 
-Write the repository password from the CI secret manager to a runner-private file, then pull the signing assets:
+Write the repository password from the CI secret manager to a runner-private file, then pull the signing assets. `signing sync` already forces noninteractive Git (`GIT_TERMINAL_PROMPT=0` and, unless you overrode SSH, `GIT_SSH_COMMAND=ssh -o BatchMode=yes`); keep any custom SSH wrapper equally noninteractive so a prompt cannot hang the runner. The full CI example lives in the [signing command reference](/commands/signing#ci-example).
 
 ```bash  theme={null}
 set +x
@@ -289,6 +291,6 @@ For an archive with extensions, App Clips, Watch apps, or other embedded targets
 
 ## What the encrypted store does not do
 
-The current store uses Git. It does not renew certificates, delete stale encrypted assets, assign different settings per target, or manage the later lifecycle of installed persistent keychains. Treat those as separate reviewed operations.
+The current store uses Git. It does not renew certificates, delete stale encrypted assets, assign different settings per target, or manage the later lifecycle of installed persistent keychains. Treat those as separate reviewed operations. Renew first, push the successor identity, verify a clean pull, then revoke or deactivate; the ordering is under [Rotation and expiry](/commands/signing#rotation-and-expiry).
 
 Read the [signing command reference](/commands/signing) before the first live push; it includes file-permission rules, exact output fields, failure boundaries, profile maintenance, and recovery behavior.


### PR DESCRIPTION
## Summary

Closes the six remaining signing-docs gaps from #2273. PR #2250 already covered control-plane vs encrypted store, complete artifact set, secret-hygiene, matching rules, and no-secrets-in-argv; none of these six were present on current `main`.

- **Encryption model.** New [What the encrypted store protects](https://github.com/rorkai/App-Store-Connect-CLI/blob/docs/2273-signing-security-docs/commands/signing.mdx) subsection under Share a usable signing identity. AES-256-GCM; scrypt `N=32768,r=8,p=1` for versioned identity/context/profile envelopes with metadata as GCM AAD; PBKDF2-HMAC-SHA256 (100,000 iterations) for legacy certificate files and older unversioned profiles. Integrity is the GCM tag, not a separate checksum. Git ACLs and password entropy remain operator-owned (least-privilege).
- **Revocation lifecycle.** Rotation sequence now names `asc certificates revoke --id CERT_ID --confirm`, distinguishes deactivate vs revoke, and notes profile invalidation. Apple still counts revoked certificates against the per-type limit until they expire, so this does **not** claim that revocation frees a slot immediately (`commands/certificates.mdx` already says that).
- **Renewal / stale artifacts.** Explicit operator order: new cert → successor profiles → push → verify pull → revoke/deactivate → optional HEAD cleanup. Sync does not delete unused `.enc` files; password rotation re-encrypts HEAD only.
- **Noninteractive CI.** Documents that `signing sync` already sets `GIT_TERMINAL_PROMPT=0` and defaults `GIT_SSH_COMMAND=ssh -o BatchMode=yes` unless the operator overrode SSH; custom wrappers must stay noninteractive. Job-level env in the CI example covers other Git/SSH in the step.
- **Troubleshooting.** Expired/missing WWDR intermediate (Apple PKI; `asc` does not install it). Identity present but invisible to `codesign` (search list / `apple-tool:,apple:` partition list; prefer `signing keychain install` / `signing run`).
- **Enterprise/in-house risk.** One paragraph under Common profile types: `IOS_APP_INHOUSE` / `TVOS_APP_INHOUSE` install on unregistered devices, so revocation has a larger blast radius than App Store or development certificates.

`guides/code-signing.mdx` cross-links the encryption, CI, and rotation sections. No claim exceeds `internal/signing/encrypt.go` / `gitstore.go`. No example puts a secret in a command argument. `docs/COMMANDS.md` is unchanged.

## Test plan

- [x] Verified all six greps were empty on `origin/main` before editing
- [x] Cross-checked `internal/signing/encrypt.go` constants (`pbkdf2Iterations = 100_000`, `keySize = 32`, `scryptN/R/P = 32768/8/1`) and AAD behavior
- [x] `go build -o /tmp/asc-2273 .` then `ASC_BYPASS_KEYCHAIN=1 /tmp/asc-2273 certificates revoke --help` and `signing --help` / `signing keychain install --help`
- [x] `/tmp/asc-locks/with-lock.sh gate make check-docs` passed; `docs/COMMANDS.md` up to date
- [x] Re-ran the issue greps (results below)

### Acceptance greps (this head)

```
$ grep -niE "AES|GCM|PBKDF2|authenticated encryption|checksum|integrity|least.privilege" commands/signing.mdx guides/code-signing.mdx README.md
commands/signing.mdx:252:Every `.enc` file uses AES-256-GCM. That authenticated encryption gives confidentiality plus integrity ...
commands/signing.mdx:254:Versioned envelopes ... scrypt (`N=32768`, `r=8`, `p=1`) ... AES-GCM additional authenticated data ...
commands/signing.mdx:256:... keep the stable PBKDF2 format: PBKDF2-HMAC-SHA256 with 100,000 iterations ...
guides/code-signing.mdx:150:What AES-256-GCM, PBKDF2, scrypt, and authenticated metadata do and do not guarantee ...

$ grep -niE "revoke|revocation" commands/signing.mdx guides/code-signing.mdx
commands/signing.mdx:703:... Revoke it when the private key is compromised ...
commands/signing.mdx:706:asc certificates revoke --id CERT_ID --confirm
commands/signing.mdx:709:... Revocation cannot be undone ...
guides/code-signing.mdx:7:... rotation and revocation sequence ...
guides/code-signing.mdx:294:... then revoke or deactivate ...

$ grep -niE "noninteractive|non-interactive|GIT_TERMINAL_PROMPT" commands/signing.mdx guides/code-signing.mdx
commands/signing.mdx:482:`signing sync` is noninteractive for its own Git subprocesses: it sets
commands/signing.mdx:483:`GIT_TERMINAL_PROMPT=0`, and when `GIT_SSH_COMMAND`, `GIT_SSH`, and
commands/signing.mdx:495:    GIT_TERMINAL_PROMPT: "0"
guides/code-signing.mdx:154:... noninteractive Git (`GIT_TERMINAL_PROMPT=0` ...

$ grep -ni "WWDR" commands/signing.mdx guides/code-signing.mdx
commands/signing.mdx:749:### Expired or missing WWDR intermediate
commands/signing.mdx:751:... Worldwide Developer Relations (WWDR) intermediate. ...
```

Closes #2273

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded signing guidance for enterprise profiles, encrypted stores, metadata authentication, and CI configuration.
  - Added troubleshooting information for keychain visibility and WWDR intermediate certificate requirements.
  - Clarified certificate rotation and revocation sequencing, including provisioning-profile invalidation and distribution-specific effects.
  - Documented encrypted-store guarantees and noninteractive Git/SSH behavior during CI operations.
  - Added references connecting certificate rotation, expiry, and revocation guidance with store limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->