### PR TITLE
test(profiles,certificates): verify sparse fieldsets combined with includes

### DIFF
--- a/docs/API_NOTES.md
+++ b/docs/API_NOTES.md
@@ -132,6 +132,13 @@ Finance reports use Apple fiscal months (`YYYY-MM`), not calendar months.
 - Live API rejects `include=passTypeId` and `fields[passTypeIds]` on `/v1/passTypeIds/{id}/certificates` despite the OpenAPI spec allowing them.
 - The CLI does not expose those parameters for `pass-type-ids certificates list` to avoid API errors.
 
+## Sparse Fieldsets Combined with Includes
+
+Observed 2026-09-02 against a live App Store Connect team. The CLI does not add included relationship names to the primary fieldset for these list commands.
+
+- `GET /v1/profiles` with `fields[profiles]=name&include=devices` returns HTTP 200 and still puts related devices in `included`. Apple omits `relationships` on each profile unless `devices` is also listed in `fields[profiles]`. `fields[devices]=name,udid` still sparse-filters those included devices.
+- `GET /v1/certificates` with `fields[certificates]=displayName&include=passTypeId` returns HTTP 200. This team has no `PASS_TYPE_ID` certificates, so `included` was absent both with that sparse fieldset and with `include=passTypeId` alone. Non-pass certificates expose `relationships.passTypeId.data=null` only when the relationship is in the fieldset (or when no certificate fieldset is sent).
+
 ## App Store Connect API 4.4.1
 
 - Apple added discrete versions for in-app purchases, subscriptions, and subscription groups. Their v2 localizations and images are version-scoped; pass a version ID rather than the legacy product, subscription, or group ID.

--- a/internal/cli/cmdtest/certificates_list_query_surface_test.go
+++ b/internal/cli/cmdtest/certificates_list_query_surface_test.go
@@ -24,6 +24,11 @@ type certificatesListQuerySurfaceRequest struct {
 
 func certificatesListQuerySurfaceStub(t *testing.T) *certificatesListQuerySurfaceRequest {
 	t.Helper()
+	return certificatesListQuerySurfaceStubBody(t, `{"data":[{"type":"certificates","id":"cert-1","attributes":{"name":"Certificate","certificateType":"IOS_DISTRIBUTION"}}]}`)
+}
+
+func certificatesListQuerySurfaceStubBody(t *testing.T, body string) *certificatesListQuerySurfaceRequest {
+	t.Helper()
 	setupAuth(t)
 
 	captured := &certificatesListQuerySurfaceRequest{}
@@ -32,7 +37,7 @@ func certificatesListQuerySurfaceStub(t *testing.T) *certificatesListQuerySurfac
 		captured.path = req.URL.Path
 		captured.query = req.URL.Query()
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = io.WriteString(w, `{"data":[{"type":"certificates","id":"cert-1","attributes":{"name":"Certificate","certificateType":"IOS_DISTRIBUTION"}}]}`)
+		_, _ = io.WriteString(w, body)
 	}))
 	t.Cleanup(server.Close)
 
@@ -119,6 +124,63 @@ func TestCertificatesListQuerySurfaceEmitsDocumentedParameters(t *testing.T) {
 	}
 	if !strings.Contains(stdout, `"id":"cert-1"`) {
 		t.Fatalf("stdout = %q, want certificate response", stdout)
+	}
+}
+
+func TestCertificatesListSparseFieldsPreserveIncludedPassTypeID(t *testing.T) {
+	const includedPassTypeIDs = `[{"type":"passTypeIds","id":"ptid-1","attributes":{"name":"Pass Type"}}]`
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "relationships and included",
+			body: `{"data":[{"type":"certificates","id":"cert-1","attributes":{"displayName":"Pass Cert"},"relationships":{"passTypeId":{"data":{"type":"passTypeIds","id":"ptid-1"}}}}],"links":{},"included":` + includedPassTypeIDs + `}`,
+		},
+		{
+			name: "included without relationships",
+			body: `{"data":[{"type":"certificates","id":"cert-1","attributes":{"displayName":"Pass Cert"}}],"links":{},"included":` + includedPassTypeIDs + `}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			captured := certificatesListQuerySurfaceStubBody(t, test.body)
+
+			stdout, stderr, err := runCertificatesListQuerySurface(
+				t,
+				"certificates", "list",
+				"--fields", "displayName",
+				"--include", "passTypeId",
+				"--pass-type-id-fields", "name",
+				"--output", "json",
+			)
+			if err != nil {
+				t.Fatalf("run error: %v (stderr=%q)", err, stderr)
+			}
+			if strings.TrimSpace(stderr) != "" {
+				t.Fatalf("stderr = %q, want empty", stderr)
+			}
+			if captured.path != "/v1/certificates" {
+				t.Fatalf("path = %q, want /v1/certificates", captured.path)
+			}
+			wantQuery := map[string]string{
+				"fields[certificates]": "displayName",
+				"fields[passTypeIds]":  "name",
+				"include":              "passTypeId",
+			}
+			for key, want := range wantQuery {
+				if got := captured.query.Get(key); got != want {
+					t.Fatalf("query %s = %q, want %q (full query %s)", key, got, want, captured.query.Encode())
+				}
+			}
+			if len(captured.query) != len(wantQuery) {
+				t.Fatalf("query = %s, want exactly %d parameters", captured.query.Encode(), len(wantQuery))
+			}
+			if stdout != test.body+"\n" {
+				t.Fatalf("stdout = %q, want byte-identical envelope %q", stdout, test.body+"\n")
+			}
+		})
 	}
 }
 

--- a/internal/cli/cmdtest/profiles_query_surface_test.go
+++ b/internal/cli/cmdtest/profiles_query_surface_test.go
@@ -251,6 +251,81 @@ func TestProfilesListRelationshipOnlySparseResponsePreservesAttributeAbsence(t *
 	}
 }
 
+func TestProfilesListSparseFieldsPreserveIncludedDevices(t *testing.T) {
+	const includedDevices = `[{"type":"devices","id":"device-1","attributes":{"name":"iPhone","udid":"00000000-0000-0000-0000-000000000001"}}]`
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "relationships and included",
+			body: `{"data":[{"type":"profiles","id":"profile-1","attributes":{"name":"Development"},"relationships":{"devices":{"data":[{"type":"devices","id":"device-1"}]}}}],"links":{},"included":` + includedDevices + `}`,
+		},
+		{
+			name: "included without relationships",
+			body: `{"data":[{"type":"profiles","id":"profile-1","attributes":{"name":"Development"}}],"links":{},"included":` + includedDevices + `}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setupAuth(t)
+
+			var query url.Values
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				if req.Method != http.MethodGet || req.URL.Path != "/v1/profiles" {
+					t.Errorf("unexpected request: %s %s", req.Method, req.URL.Path)
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				query = req.URL.Query()
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, test.body)
+			}))
+			t.Cleanup(server.Close)
+			installProfilesQueryTestClient(t, server)
+
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse([]string{
+					"profiles", "list",
+					"--fields", "name",
+					"--include", "devices",
+					"--device-fields", "name,udid",
+					"--output", "json",
+				}); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				if err := root.Run(context.Background()); err != nil {
+					t.Fatalf("run error: %v", err)
+				}
+			})
+
+			wantQuery := map[string]string{
+				"fields[profiles]":     "name",
+				"fields[devices]":      "name,udid",
+				"include":              "devices",
+				"filter[profileState]": "ACTIVE,INVALID",
+			}
+			for key, want := range wantQuery {
+				if got := query.Get(key); got != want {
+					t.Errorf("%s = %q, want %q", key, got, want)
+				}
+			}
+			if len(query) != len(wantQuery) {
+				t.Errorf("query = %s, want exactly %d parameters", query.Encode(), len(wantQuery))
+			}
+			if stdout != test.body+"\n" {
+				t.Fatalf("stdout = %q, want byte-identical envelope %q", stdout, test.body+"\n")
+			}
+			if stderr != "" {
+				t.Fatalf("stderr = %q, want empty", stderr)
+			}
+		})
+	}
+}
+
 func TestProfilesListRejectsInvalidQueryValuesBeforeAuth(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary
- Pin `profiles list --fields name --include devices --device-fields name,udid` and `certificates list --fields displayName --include passTypeId --pass-type-id-fields name` so JSON stdout stays byte-identical to Apple's envelope when `included` is populated, including the shape that omits `relationships`.
- Assert `fields[profiles]=name` and `fields[certificates]=displayName` exactly so a silent fieldset augmentation fails the tests.
- Record 2026-09-02 live read-only behavior in `docs/API_NOTES.md`. Apple does not drop `included` for profiles, so no help-text change.

Closes #2279

## Test plan
- [x] `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run TestProfilesListSparseFieldsPreserveIncludedDevices`
- [x] `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/cmdtest -run TestCertificatesListSparseFieldsPreserveIncludedPassTypeID`
- [x] Confirmed RED: stripping `Included` from `ProfilesResponse.MarshalJSON` fails both profile subtests; restored afterward
- [x] `make format`, `make build`, `make check-docs`, `make lint`, `ASC_BYPASS_KEYCHAIN=1 make test` via the host gate lock

## Live verification (2026-09-02, redacted)
Built `/tmp/asc-2279` from this branch. All calls returned HTTP 200 / exit 0.

**Profiles** (`--fields name --include devices --limit 2 --output json`):
- Top-level `included` present (1 `devices` entry). Primary attributes limited to `name`. `relationships` omitted on both profiles.
- Baseline without `--fields` still returns `included` and includes `relationships.devices`.
- Adding `--device-fields name,udid` sparse-filters included device attributes to `name` and `udid` only.

**Certificates** (`--fields displayName --include passTypeId --limit 2 --output json`):
- Team has 28 certificates (`DISTRIBUTION`, `DEVELOPMENT`, `IOS_*`, `DEVELOPER_ID_APPLICATION*`) and **no** `PASS_TYPE_ID` certificates (`--certificate-type PASS_TYPE_ID` returned an empty collection).
- `included` was absent both with the sparse fieldset and with `--include passTypeId` alone. Non-pass certificates expose `relationships.passTypeId.data=null` only when no certificate fieldset is sent; `--fields displayName` omits `relationships`.
- No 400. Auto-adding the relationship name to the primary fieldset is not implemented here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added API notes describing sparse fieldsets combined with relationship includes for profiles and certificates.

* **Tests**
  * Added coverage confirming included profile devices and certificate pass type IDs remain available with sparse field selections.
  * Verified consistent query parameters and byte-identical JSON responses across relationship scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->