### PR TITLE
Add read-only web api-keys list and view

### DIFF
--- a/commands/web.mdx
+++ b/commands/web.mdx
@@ -11,7 +11,9 @@ The `asc web` command family automates App Store Connect workflows through Apple
 asc web auth login --apple-id "user@example.com"
 asc web auth status
 
-# Create a team API key and save its one-time P8
+# List and inspect API keys, then create a team key and save its one-time P8
+asc web api-keys list --output json
+asc web api-keys view --key-id KEY_ID
 asc web api-keys create --name "Release automation" --output-dir ~/.asc/keys
 
 # Create an app through the web flow
@@ -52,7 +54,7 @@ Use `asc web` when one of these is true:
 
 ## Session model
 
-`asc web` authenticates with a cached Apple Account web session created with `asc web auth login`. The `api-keys create` command uses that session to create an App Store Connect API key; it does not require an existing API key.
+`asc web` authenticates with a cached Apple Account web session created with `asc web auth login`. The `api-keys` commands use that session to list, inspect, or create App Store Connect API keys; they do not require an existing API key.
 
 Common session commands:
 
@@ -105,15 +107,19 @@ asc web agreements accept --agreement-id "AGREEMENT_ID" --confirm
 
 ### `asc web api-keys`
 
-Team API key creation through an Apple Account web session.
+Team and individual API key listing, team-key inspection, and team API key creation through an Apple Account web session.
 
 Available commands:
 
+* `asc web api-keys list` - list team and individual keys visible to the cached web session
+* `asc web api-keys view` - inspect one team API key by `--key-id`
 * `asc web api-keys create` - create an all-apps team key and save its one-time P8 as `AuthKey_<KEY_ID>.p8`
 
 Example:
 
 ```bash  theme={null}
+asc web api-keys list --output json
+asc web api-keys view --key-id KEY_ID --output json
 asc web api-keys create \
   --name "Release automation" \
   --role APP_MANAGER \
@@ -121,7 +127,9 @@ asc web api-keys create \
   --output json
 ```
 
-The role defaults to `ADMIN`. The output file is created with mode `0600`, existing files are not replaced, and key contents are not printed to command output.
+`list` and `view` print key ID, name, roles, and active state. They omit creation date because the existing web-session key readers do not expose it. Key material is never printed. `list` follows every page internally, so it does not accept `--paginate`. `view` uses the iris v1 team-key resource; individual keys appear in `list` but are not loaded by `view`.
+
+The create role defaults to `ADMIN`. The output file is created with mode `0600`, existing files are not replaced, and key contents are not printed to command output.
 
 Role requirement: creating a team API key requires an Account Holder or Admin web session. The `--role` value must be one of Apple's selectable team-key roles.
 

--- a/docs/API_NOTES.md
+++ b/docs/API_NOTES.md
@@ -52,9 +52,9 @@ Finance reports use Apple fiscal months (`YYYY-MM`), not calendar months.
 
 ## Web-session API keys
 
-- `asc web api-keys list` reuses the iris v1 team-key list (`GET /iris/v1/apiKeys?include=createdBy,revokedBy,provider`) and the iris v2 individual-key list (`GET /iris/v2/apiKeys?include=visibleApps,createdByActor,revokedByActor`) already used by `asc web auth capabilities`. Both readers follow `links.next` internally, so the command has no `--paginate` flag.
+- `asc web api-keys list` reuses the iris v1 team-key list (`GET /iris/v1/apiKeys?include=createdBy,revokedBy,provider`) and the iris v2 individual-key list (`GET /iris/v2/apiKeys?include=visibleApps,createdByActor,revokedByActor`) already used by `asc web auth capabilities`. Both readers follow `links.next` internally, so the command has no `--paginate` flag. Individual keys sometimes carry an empty `roles` array on that list payload; list does not issue per-key actor lookups. Use `asc web auth capabilities --key-id` to resolve actor-backed roles for one key.
 - `asc web api-keys view --key-id` uses the existing iris v1 team-key resource (`GET /iris/v1/apiKeys/{id}?include=provider`). Individual keys appear in `list` but are not loaded by `view`. The issue proposed `get`; current CLI taxonomy uses `view` for this leaf.
-- Those payloads expose key ID, nickname, roles, `isActive`, key type, and last-used. They do not include a creation date, so list/get omit that column rather than inventing one. Private key material is never copied into command output.
+- Those payloads expose key ID, nickname, roles, `isActive`, key type, and last-used. They do not include a creation date, so list/view omit that column rather than inventing one. Private key material is never copied into command output.
 - Revoke and `--individual` create still need a live web-session endpoint capture.
 
 ## TestFlight Distribution

--- a/docs/API_NOTES.md
+++ b/docs/API_NOTES.md
@@ -50,6 +50,13 @@ Finance reports use Apple fiscal months (`YYYY-MM`), not calendar months.
 - List, view, update, and clear-history use the v2 API through `asc sandbox`
 - Public `asc sandbox` does not expose create or delete. Create testers with `asc web sandbox create`, which posts to `/sandbox/v2/account/create`
 
+## Web-session API keys
+
+- `asc web api-keys list` reuses the iris v1 team-key list (`GET /iris/v1/apiKeys?include=createdBy,revokedBy,provider`) and the iris v2 individual-key list (`GET /iris/v2/apiKeys?include=visibleApps,createdByActor,revokedByActor`) already used by `asc web auth capabilities`. Both readers follow `links.next` internally, so the command has no `--paginate` flag.
+- `asc web api-keys view --key-id` uses the existing iris v1 team-key resource (`GET /iris/v1/apiKeys/{id}?include=provider`). Individual keys appear in `list` but are not loaded by `view`. The issue proposed `get`; current CLI taxonomy uses `view` for this leaf.
+- Those payloads expose key ID, nickname, roles, `isActive`, key type, and last-used. They do not include a creation date, so list/get omit that column rather than inventing one. Private key material is never copied into command output.
+- Revoke and `--individual` create still need a live web-session endpoint capture.
+
 ## TestFlight Distribution
 
 - `asc testflight distribution edit --external-testing` shipped in 0.35.3 but App Store Connect does not allow `externalBuildState` in the build beta detail PATCH request. The flag remains parseable during its deprecation window and fails before HTTP instead of sending an unsupported update.

--- a/internal/asc/output_registry_init.go
+++ b/internal/asc/output_registry_init.go
@@ -19,6 +19,8 @@ func registerAllOutputRenderers() {
 	registerRows(webAppDeleteRows)
 	registerRows(webSubscriptionMonthlyCommitmentBootstrapRows)
 	registerRows(webXcodeCloudWorkflowsListRows)
+	registerRows(webAPIKeysListRows)
+	registerRows(webAPIKeyGetRows)
 	registerDirect(func(v *KeywordRankReport, render func([]string, [][]string)) error {
 		h, r := keywordRankSummaryRows(v)
 		render(h, r)

--- a/internal/asc/output_web_api_keys.go
+++ b/internal/asc/output_web_api_keys.go
@@ -1,0 +1,75 @@
+package asc
+
+import (
+	"fmt"
+	"strings"
+)
+
+// WebAPIKeyActor is a non-secret user or actor reference on an API key.
+type WebAPIKeyActor struct {
+	ID   string `json:"id"`
+	Name string `json:"name,omitempty"`
+}
+
+// WebAPIKeyListItem is one team or individual API key from a web-session list.
+type WebAPIKeyListItem struct {
+	KeyID       string          `json:"keyId"`
+	Name        string          `json:"name,omitempty"`
+	Kind        string          `json:"kind"`
+	Roles       []string        `json:"roles,omitempty"`
+	Active      bool            `json:"active"`
+	KeyType     string          `json:"keyType,omitempty"`
+	LastUsed    string          `json:"lastUsed,omitempty"`
+	GeneratedBy *WebAPIKeyActor `json:"generatedBy,omitempty"`
+	RevokedBy   *WebAPIKeyActor `json:"revokedBy,omitempty"`
+}
+
+// WebAPIKeysListResult is the computed list of API keys visible to a web session.
+type WebAPIKeysListResult struct {
+	Keys []WebAPIKeyListItem `json:"keys"`
+}
+
+// WebAPIKeyGetResult is non-secret metadata for one team API key.
+type WebAPIKeyGetResult struct {
+	KeyID          string   `json:"keyId"`
+	Name           string   `json:"name,omitempty"`
+	IssuerID       string   `json:"issuerId,omitempty"`
+	Roles          []string `json:"roles,omitempty"`
+	Active         bool     `json:"active"`
+	AllAppsVisible bool     `json:"allAppsVisible"`
+	CanDownload    bool     `json:"canDownload"`
+	KeyType        string   `json:"keyType,omitempty"`
+	LastUsed       string   `json:"lastUsed,omitempty"`
+	RevokingDate   string   `json:"revokingDate,omitempty"`
+}
+
+func webAPIKeysListRows(result *WebAPIKeysListResult) ([]string, [][]string) {
+	headers := []string{"Key ID", "Name", "Kind", "Roles", "Active"}
+	if result == nil {
+		return headers, nil
+	}
+	rows := make([][]string, 0, len(result.Keys))
+	for _, item := range result.Keys {
+		rows = append(rows, []string{
+			item.KeyID,
+			item.Name,
+			item.Kind,
+			strings.Join(item.Roles, ", "),
+			fmt.Sprintf("%t", item.Active),
+		})
+	}
+	return headers, rows
+}
+
+func webAPIKeyGetRows(result *WebAPIKeyGetResult) ([]string, [][]string) {
+	if result == nil {
+		result = &WebAPIKeyGetResult{}
+	}
+	return []string{"Key ID", "Name", "Issuer ID", "Roles", "Active"}, [][]string{{
+		result.KeyID,
+		result.Name,
+		result.IssuerID,
+		strings.Join(result.Roles, ", "),
+		fmt.Sprintf("%t", result.Active),
+	}}
+}

--- a/internal/asc/output_web_api_keys_test.go
+++ b/internal/asc/output_web_api_keys_test.go
@@ -1,0 +1,54 @@
+package asc
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPrintTableWebAPIKeysListUsesRegistry(t *testing.T) {
+	result := &WebAPIKeysListResult{
+		Keys: []WebAPIKeyListItem{
+			{KeyID: "ABC123XYZ", Name: "Release automation", Kind: "team", Roles: []string{"ADMIN"}, Active: true},
+			{KeyID: "IND456ABC", Name: "Personal", Kind: "individual", Roles: []string{"APP_MANAGER"}, Active: false},
+		},
+	}
+
+	output := captureStdout(t, func() error { return PrintTable(result) })
+	for _, want := range []string{
+		"Key ID", "Name", "Kind", "Roles", "Active",
+		"ABC123XYZ", "Release automation", "team", "ADMIN", "true",
+		"IND456ABC", "Personal", "individual", "APP_MANAGER", "false",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("table output missing %q: %q", want, output)
+		}
+	}
+	if strings.Contains(output, "Created") || strings.Contains(output, "Creation") {
+		t.Fatalf("did not expect a creation-date column: %q", output)
+	}
+}
+
+func TestPrintMarkdownWebAPIKeyGetUsesRegistry(t *testing.T) {
+	result := &WebAPIKeyGetResult{
+		KeyID:          "ABC123XYZ",
+		Name:           "Release automation",
+		IssuerID:       "69a6de00-aaaa-bbbb-cccc-123456789abc",
+		Roles:          []string{"ADMIN"},
+		Active:         true,
+		AllAppsVisible: true,
+		KeyType:        "PUBLIC_API",
+	}
+
+	output := captureStdout(t, func() error { return PrintMarkdown(result) })
+	for _, want := range []string{
+		"Key ID", "Name", "Issuer ID", "Roles", "Active",
+		"ABC123XYZ", "Release automation", "69a6de00-aaaa-bbbb-cccc-123456789abc", "ADMIN", "true",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("markdown output missing %q: %q", want, output)
+		}
+	}
+	if strings.Contains(output, "Created") || strings.Contains(output, "Creation") {
+		t.Fatalf("did not expect a creation-date column: %q", output)
+	}
+}

--- a/internal/cli/cmdtest/web_api_keys_commands_test.go
+++ b/internal/cli/cmdtest/web_api_keys_commands_test.go
@@ -1,6 +1,80 @@
 package cmdtest
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"flag"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestWebAPIKeysListCommandRegistration(t *testing.T) {
+	root := RootCommand("1.2.3")
+	cmd := findSubcommand(root, "web", "api-keys", "list")
+	if cmd == nil {
+		t.Fatal("expected web api-keys list command")
+	}
+	for _, flagName := range []string{
+		"apple-id",
+		"two-factor-code-command",
+		"provider-id",
+		"public-provider-id",
+		"output",
+		"pretty",
+	} {
+		if cmd.FlagSet.Lookup(flagName) == nil {
+			t.Fatalf("expected --%s flag", flagName)
+		}
+	}
+	if cmd.FlagSet.Lookup("paginate") != nil {
+		t.Fatal("did not expect --paginate on web api-keys list; the team and individual key readers already follow every page")
+	}
+}
+
+func TestWebAPIKeysViewCommandRegistration(t *testing.T) {
+	root := RootCommand("1.2.3")
+	if findSubcommand(root, "web", "api-keys", "get") != nil {
+		t.Fatal("did not expect legacy web api-keys get; canonical leaf is view")
+	}
+	cmd := findSubcommand(root, "web", "api-keys", "view")
+	if cmd == nil {
+		t.Fatal("expected web api-keys view command")
+	}
+	for _, flagName := range []string{
+		"key-id",
+		"apple-id",
+		"two-factor-code-command",
+		"provider-id",
+		"public-provider-id",
+		"output",
+		"pretty",
+	} {
+		if cmd.FlagSet.Lookup(flagName) == nil {
+			t.Fatalf("expected --%s flag", flagName)
+		}
+	}
+}
+
+func TestWebAPIKeysViewMissingKeyIDFailsBeforeHTTP(t *testing.T) {
+	root := RootCommand("1.2.3")
+	root.FlagSet.SetOutput(io.Discard)
+
+	var runErr error
+	_, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"web", "api-keys", "view"}); err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected ErrHelp, got %v", runErr)
+	}
+	if !strings.Contains(stderr, "Error: --key-id is required") {
+		t.Fatalf("expected missing --key-id error, got %q", stderr)
+	}
+}
 
 func TestWebAPIKeysCreateCommandRegistration(t *testing.T) {
 	root := RootCommand("1.2.3")

--- a/internal/cli/web/web.go
+++ b/internal/cli/web/web.go
@@ -28,6 +28,8 @@ Use ` + "`asc web apps create`" + ` as the canonical app-creation command in thi
 Examples:
   asc web auth status
   asc web agreements status
+  asc web api-keys list --output json
+  asc web api-keys view --key-id KEY_ID
   asc web api-keys create --name "Release automation"
   asc web sandbox create --first-name "Jane" --last-name "Tester" --email "jane+sandbox@example.com" --password "Passwordtest1" --territory "USA"
   asc web auth login --apple-id "user@example.com"

--- a/internal/cli/web/web_api_keys.go
+++ b/internal/cli/web/web_api_keys.go
@@ -97,7 +97,9 @@ func WebAPIKeysListCommand() *ffcli.Command {
 List team and individual App Store Connect API keys visible to the cached Apple
 Account web session. Output includes key ID, name, kind, roles, and active
 state. Creation date is omitted because the existing key-list readers do not
-expose it. Key material is never printed.
+expose it. Key material is never printed. Individual keys may have empty roles
+on this list; use "asc web auth capabilities --key-id" to resolve actor-backed
+roles for one key.
 
 The underlying readers already follow every pagination link, so this command
 always returns the complete visible set and does not accept --paginate.

--- a/internal/cli/web/web_api_keys.go
+++ b/internal/cli/web/web_api_keys.go
@@ -32,6 +32,9 @@ var (
 	getWebAPIKeyFn = func(ctx context.Context, client *webcore.Client, keyID string) (*webcore.APIKey, error) {
 		return client.GetAPIKey(ctx, keyID)
 	}
+	listWebAPIKeysFn = func(ctx context.Context, client *webcore.Client) ([]webcore.APIKeyListItem, error) {
+		return client.ListAPIKeys(ctx)
+	}
 	waitWebAPIKeyRetryFn = waitForWebAPIKeyRetry
 )
 
@@ -59,15 +62,193 @@ func WebAPIKeysCommand() *ffcli.Command {
 
 Manage App Store Connect API keys using a cached Apple Account web session.
 
+Examples:
+  asc web api-keys list --output json
+  asc web api-keys view --key-id KEY_ID
+  asc web api-keys create --name "Release automation"
+
 `,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
+			WebAPIKeysListCommand(),
+			WebAPIKeysViewCommand(),
 			WebAPIKeysCreateCommand(),
 		},
 		Exec: func(ctx context.Context, args []string) error {
 			return flag.ErrHelp
 		},
+	}
+}
+
+// WebAPIKeysListCommand lists team and individual API keys visible to the web session.
+func WebAPIKeysListCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("web api-keys list", flag.ExitOnError)
+
+	authFlags := bindWebSessionFlags(fs)
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "list",
+		ShortUsage: "asc web api-keys list [flags]",
+		ShortHelp:  "List App Store Connect API keys via a web session.",
+		LongHelp: `WEB SESSION WORKFLOWS
+
+List team and individual App Store Connect API keys visible to the cached Apple
+Account web session. Output includes key ID, name, kind, roles, and active
+state. Creation date is omitted because the existing key-list readers do not
+expose it. Key material is never printed.
+
+The underlying readers already follow every pagination link, so this command
+always returns the complete visible set and does not accept --paginate.
+
+Examples:
+  asc web api-keys list
+  asc web api-keys list --output json
+
+`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageError("web api-keys list does not accept positional arguments")
+			}
+			if _, err := shared.ValidateOutputFormat(*output.Output, *output.Pretty); err != nil {
+				return shared.UsageError(err.Error())
+			}
+
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
+			session, err := resolveWebSessionForCommand(requestCtx, authFlags)
+			if err != nil {
+				return err
+			}
+			client := newWebAPIKeyClientFn(session)
+
+			var keys []webcore.APIKeyListItem
+			err = withWebSpinner("Loading App Store Connect API keys", func() error {
+				var listErr error
+				keys, listErr = listWebAPIKeysFn(requestCtx, client)
+				return listErr
+			})
+			if err != nil {
+				return withWebAuthHint(err, "web api-keys list")
+			}
+			if keys == nil {
+				keys = []webcore.APIKeyListItem{}
+			}
+
+			result := &asc.WebAPIKeysListResult{Keys: make([]asc.WebAPIKeyListItem, 0, len(keys))}
+			for _, key := range keys {
+				result.Keys = append(result.Keys, webAPIKeyListItemFromClient(key))
+			}
+			return shared.PrintOutput(result, *output.Output, *output.Pretty)
+		},
+	}
+}
+
+// WebAPIKeysViewCommand inspects one team API key by ID.
+func WebAPIKeysViewCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("web api-keys view", flag.ExitOnError)
+
+	keyID := fs.String("key-id", "", "API key ID")
+	authFlags := bindWebSessionFlags(fs)
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "view",
+		ShortUsage: "asc web api-keys view --key-id KEY_ID [flags]",
+		ShortHelp:  "View one App Store Connect API key via a web session.",
+		LongHelp: `WEB SESSION WORKFLOWS
+
+Inspect one team API key by ID using the iris v1 key resource. Output includes
+key ID, name, issuer ID, roles, and active state. Creation date is omitted
+because the existing GetAPIKey reader does not expose it. Key material is never
+printed.
+
+Individual keys appear in "asc web api-keys list" but are not loaded by this
+command.
+
+Examples:
+  asc web api-keys view --key-id KEY_ID
+  asc web api-keys view --key-id KEY_ID --output json
+
+`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageError("web api-keys view does not accept positional arguments")
+			}
+			if _, err := shared.ValidateOutputFormat(*output.Output, *output.Pretty); err != nil {
+				return shared.UsageError(err.Error())
+			}
+			keyIDValue := strings.TrimSpace(*keyID)
+			if keyIDValue == "" {
+				return shared.UsageError("--key-id is required")
+			}
+
+			requestCtx, cancel := shared.ContextWithTimeout(ctx)
+			defer cancel()
+			session, err := resolveWebSessionForCommand(requestCtx, authFlags)
+			if err != nil {
+				return err
+			}
+			client := newWebAPIKeyClientFn(session)
+
+			var details *webcore.APIKey
+			err = withWebSpinner("Loading App Store Connect API key", func() error {
+				var getErr error
+				details, getErr = getWebAPIKeyFn(requestCtx, client, keyIDValue)
+				return getErr
+			})
+			if err != nil {
+				return withWebAuthHint(err, "web api-keys view")
+			}
+			if details == nil {
+				return fmt.Errorf("web api-keys view failed: response did not include a key")
+			}
+
+			result := webAPIKeyGetResultFromClient(details)
+			return shared.PrintOutput(result, *output.Output, *output.Pretty)
+		},
+	}
+}
+
+func webAPIKeyListItemFromClient(key webcore.APIKeyListItem) asc.WebAPIKeyListItem {
+	item := asc.WebAPIKeyListItem{
+		KeyID:    key.KeyID,
+		Name:     key.Name,
+		Kind:     key.Kind,
+		Roles:    append([]string(nil), key.Roles...),
+		Active:   key.Active,
+		KeyType:  key.KeyType,
+		LastUsed: key.LastUsed,
+	}
+	if key.GeneratedBy != nil {
+		item.GeneratedBy = &asc.WebAPIKeyActor{ID: key.GeneratedBy.ID, Name: key.GeneratedBy.Name}
+	}
+	if key.RevokedBy != nil {
+		item.RevokedBy = &asc.WebAPIKeyActor{ID: key.RevokedBy.ID, Name: key.RevokedBy.Name}
+	}
+	return item
+}
+
+func webAPIKeyGetResultFromClient(key *webcore.APIKey) *asc.WebAPIKeyGetResult {
+	if key == nil {
+		return &asc.WebAPIKeyGetResult{}
+	}
+	return &asc.WebAPIKeyGetResult{
+		KeyID:          key.KeyID,
+		Name:           key.Name,
+		IssuerID:       key.IssuerID,
+		Roles:          append([]string(nil), key.Roles...),
+		Active:         key.Active,
+		AllAppsVisible: key.AllAppsVisible,
+		CanDownload:    key.CanDownload,
+		KeyType:        key.KeyType,
+		LastUsed:       key.LastUsed,
+		RevokingDate:   key.RevokingDate,
 	}
 }
 

--- a/internal/cli/web/web_api_keys_read_test.go
+++ b/internal/cli/web/web_api_keys_read_test.go
@@ -1,0 +1,331 @@
+package web
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"flag"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
+)
+
+func TestWebAPIKeysListPrintsMetadataWithoutKeyMaterial(t *testing.T) {
+	restore := installWebAPIKeyReadFakes(t)
+	t.Cleanup(restore)
+
+	cmd := WebAPIKeysListCommand()
+	if err := cmd.FlagSet.Parse([]string{"--output", "json"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	var execErr error
+	stdout, stderr := captureOutput(t, func() {
+		execErr = cmd.Exec(context.Background(), nil)
+	})
+	if execErr != nil {
+		t.Fatalf("expected success, got %v", execErr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var result asc.WebAPIKeysListResult
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("decode JSON: %v\nstdout: %s", err, stdout)
+	}
+	if len(result.Keys) != 2 {
+		t.Fatalf("expected 2 keys, got %#v", result.Keys)
+	}
+	if result.Keys[0].KeyID != "ABC123XYZ" || result.Keys[0].Name != "Release automation" || result.Keys[0].Kind != "team" {
+		t.Fatalf("unexpected first key: %#v", result.Keys[0])
+	}
+	if len(result.Keys[0].Roles) != 1 || result.Keys[0].Roles[0] != "ADMIN" || !result.Keys[0].Active {
+		t.Fatalf("unexpected first key roles/state: %#v", result.Keys[0])
+	}
+	if result.Keys[1].KeyID != "IND456ABC" || result.Keys[1].Kind != "individual" || result.Keys[1].Active {
+		t.Fatalf("unexpected second key: %#v", result.Keys[1])
+	}
+	assertNoKeyMaterial(t, apiKeyTestP8(t), stdout, stderr)
+}
+
+func TestWebAPIKeysListRejectsPositionalArgumentsBeforeSession(t *testing.T) {
+	resolveCalled := false
+	restoreSession := SetResolveWebSession(func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
+		resolveCalled = true
+		return &webcore.AuthSession{}, "cache", nil
+	})
+	t.Cleanup(restoreSession)
+
+	cmd := WebAPIKeysListCommand()
+	if err := cmd.FlagSet.Parse([]string{"extra"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	var execErr error
+	_, stderr := captureOutput(t, func() {
+		execErr = cmd.Exec(context.Background(), cmd.FlagSet.Args())
+	})
+	if !errors.Is(execErr, flag.ErrHelp) {
+		t.Fatalf("expected usage error, got %v", execErr)
+	}
+	if !strings.Contains(stderr, "web api-keys list does not accept positional arguments") {
+		t.Fatalf("expected positional-args stderr, got %q", stderr)
+	}
+	if resolveCalled {
+		t.Fatal("did not expect session resolution for positional arguments")
+	}
+}
+
+func TestWebAPIKeysListRejectsInvalidOutputBeforeSession(t *testing.T) {
+	resolveCalled := false
+	restoreSession := SetResolveWebSession(func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
+		resolveCalled = true
+		return &webcore.AuthSession{}, "cache", nil
+	})
+	t.Cleanup(restoreSession)
+
+	cmd := WebAPIKeysListCommand()
+	if err := cmd.FlagSet.Parse([]string{"--output", "xml"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	var execErr error
+	_, stderr := captureOutput(t, func() {
+		execErr = cmd.Exec(context.Background(), nil)
+	})
+	if !errors.Is(execErr, flag.ErrHelp) {
+		t.Fatalf("expected usage error, got %v", execErr)
+	}
+	if !strings.Contains(stderr, `--output must be one of`) && !strings.Contains(execErr.Error(), `--output must be one of`) {
+		t.Fatalf("expected invalid-output stderr, got %q / %v", stderr, execErr)
+	}
+	if resolveCalled {
+		t.Fatal("did not expect session resolution for invalid --output")
+	}
+}
+
+func TestWebAPIKeysViewRequiresKeyIDBeforeSession(t *testing.T) {
+	resolveCalled := false
+	restoreSession := SetResolveWebSession(func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
+		resolveCalled = true
+		return &webcore.AuthSession{}, "cache", nil
+	})
+	t.Cleanup(restoreSession)
+
+	cmd := WebAPIKeysViewCommand()
+	if err := cmd.FlagSet.Parse([]string{}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	var execErr error
+	_, stderr := captureOutput(t, func() {
+		execErr = cmd.Exec(context.Background(), nil)
+	})
+	if !errors.Is(execErr, flag.ErrHelp) {
+		t.Fatalf("expected usage error, got %v", execErr)
+	}
+	if !strings.Contains(stderr, "Error: --key-id is required") {
+		t.Fatalf("expected missing --key-id stderr, got %q", stderr)
+	}
+	if resolveCalled {
+		t.Fatal("did not expect session resolution before --key-id validation")
+	}
+}
+
+func TestWebAPIKeysViewRejectsBlankKeyIDBeforeSession(t *testing.T) {
+	resolveCalled := false
+	restoreSession := SetResolveWebSession(func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
+		resolveCalled = true
+		return &webcore.AuthSession{}, "cache", nil
+	})
+	t.Cleanup(restoreSession)
+
+	cmd := WebAPIKeysViewCommand()
+	if err := cmd.FlagSet.Parse([]string{"--key-id", "   "}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	var execErr error
+	_, stderr := captureOutput(t, func() {
+		execErr = cmd.Exec(context.Background(), nil)
+	})
+	if !errors.Is(execErr, flag.ErrHelp) {
+		t.Fatalf("expected usage error, got %v", execErr)
+	}
+	if !strings.Contains(stderr, "Error: --key-id is required") {
+		t.Fatalf("expected blank --key-id stderr, got %q", stderr)
+	}
+	if resolveCalled {
+		t.Fatal("did not expect session resolution for a blank --key-id")
+	}
+}
+
+func TestWebAPIKeysViewPrintsMetadataWithoutKeyMaterial(t *testing.T) {
+	restore := installWebAPIKeyReadFakes(t)
+	t.Cleanup(restore)
+
+	cmd := WebAPIKeysViewCommand()
+	if err := cmd.FlagSet.Parse([]string{"--key-id", "ABC123XYZ", "--output", "json"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	var execErr error
+	stdout, stderr := captureOutput(t, func() {
+		execErr = cmd.Exec(context.Background(), nil)
+	})
+	if execErr != nil {
+		t.Fatalf("expected success, got %v", execErr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var result asc.WebAPIKeyGetResult
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("decode JSON: %v\nstdout: %s", err, stdout)
+	}
+	if result.KeyID != "ABC123XYZ" || result.Name != "Release automation" || result.IssuerID != "69a6de00-aaaa-bbbb-cccc-123456789abc" {
+		t.Fatalf("unexpected key: %#v", result)
+	}
+	if len(result.Roles) != 1 || result.Roles[0] != "ADMIN" || !result.Active {
+		t.Fatalf("unexpected roles/state: %#v", result)
+	}
+	assertNoKeyMaterial(t, apiKeyTestP8(t), stdout, stderr)
+}
+
+func TestWebAPIKeysListHTTPFixtureNeverPrintsPrivateKey(t *testing.T) {
+	t.Setenv("ASC_WEB_MIN_REQUEST_INTERVAL", "0")
+	p8 := apiKeyTestP8(t)
+	restoreSession := SetResolveWebSession(func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
+		return &webcore.AuthSession{TeamID: "TEAM123"}, "cache", nil
+	})
+	t.Cleanup(restoreSession)
+	originalClient := newWebAPIKeyClientFn
+	t.Cleanup(func() { newWebAPIKeyClientFn = originalClient })
+
+	newWebAPIKeyClientFn = func(session *webcore.AuthSession) *webcore.Client {
+		return newCLIAPIKeyHTTPTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/iris/v1/apiKeys":
+				_, _ = w.Write([]byte(`{"data":[{"id":"ABC123XYZ","attributes":{"nickname":"Release automation","roles":["ADMIN"],"isActive":true,"keyType":"PUBLIC_API","privateKey":"` + encodeAPIKeyP8(p8) + `"}}],"included":[]}`))
+			case r.Method == http.MethodGet && r.URL.Path == "/iris/v2/apiKeys":
+				_, _ = w.Write([]byte(`{"data":[]}`))
+			default:
+				http.Error(w, "unexpected "+r.Method+" "+r.URL.Path, http.StatusInternalServerError)
+			}
+		}))
+	}
+
+	cmd := WebAPIKeysListCommand()
+	if err := cmd.FlagSet.Parse([]string{"--output", "json"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	var execErr error
+	stdout, stderr := captureOutput(t, func() {
+		execErr = cmd.Exec(context.Background(), nil)
+	})
+	if execErr != nil {
+		t.Fatalf("expected success, got %v", execErr)
+	}
+	assertNoKeyMaterial(t, p8, stdout, stderr, execErrString(execErr))
+}
+
+func TestWebAPIKeysViewHTTPFixtureNeverPrintsPrivateKey(t *testing.T) {
+	t.Setenv("ASC_WEB_MIN_REQUEST_INTERVAL", "0")
+	p8 := apiKeyTestP8(t)
+	restoreSession := SetResolveWebSession(func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
+		return &webcore.AuthSession{TeamID: "TEAM123"}, "cache", nil
+	})
+	t.Cleanup(restoreSession)
+	originalClient := newWebAPIKeyClientFn
+	t.Cleanup(func() { newWebAPIKeyClientFn = originalClient })
+
+	newWebAPIKeyClientFn = func(session *webcore.AuthSession) *webcore.Client {
+		return newCLIAPIKeyHTTPTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			if r.Method != http.MethodGet || r.URL.Path != "/iris/v1/apiKeys/ABC123XYZ" {
+				http.Error(w, "unexpected "+r.Method+" "+r.URL.Path, http.StatusInternalServerError)
+				return
+			}
+			_, _ = w.Write([]byte(`{"data":{"type":"apiKeys","id":"ABC123XYZ","attributes":{"nickname":"Release automation","roles":["ADMIN"],"isActive":true,"allAppsVisible":true,"keyType":"PUBLIC_API","privateKey":"` + encodeAPIKeyP8(p8) + `"},"relationships":{"provider":{"data":{"type":"contentProviders","id":"69a6de00-aaaa-bbbb-cccc-123456789abc"}}}}}`))
+		}))
+	}
+
+	cmd := WebAPIKeysViewCommand()
+	if err := cmd.FlagSet.Parse([]string{"--key-id", "ABC123XYZ", "--output", "json"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	var execErr error
+	stdout, stderr := captureOutput(t, func() {
+		execErr = cmd.Exec(context.Background(), nil)
+	})
+	if execErr != nil {
+		t.Fatalf("expected success, got %v", execErr)
+	}
+	assertNoKeyMaterial(t, p8, stdout, stderr, execErrString(execErr))
+}
+
+func installWebAPIKeyReadFakes(t *testing.T) func() {
+	t.Helper()
+	restoreSession := SetResolveWebSession(func(ctx context.Context, appleID, password, twoFactorCode string) (*webcore.AuthSession, string, error) {
+		return &webcore.AuthSession{TeamID: "TEAM123"}, "cache", nil
+	})
+	originalNewClient := newWebAPIKeyClientFn
+	originalList := listWebAPIKeysFn
+	originalGet := getWebAPIKeyFn
+
+	newWebAPIKeyClientFn = func(session *webcore.AuthSession) *webcore.Client {
+		return &webcore.Client{}
+	}
+	listWebAPIKeysFn = func(ctx context.Context, client *webcore.Client) ([]webcore.APIKeyListItem, error) {
+		return []webcore.APIKeyListItem{
+			{
+				KeyID:  "ABC123XYZ",
+				Name:   "Release automation",
+				Kind:   webcore.APIKeyKindTeam,
+				Roles:  []string{"ADMIN"},
+				Active: true,
+			},
+			{
+				KeyID:  "IND456ABC",
+				Name:   "Personal",
+				Kind:   webcore.APIKeyKindIndividual,
+				Roles:  []string{"APP_MANAGER"},
+				Active: false,
+			},
+		}, nil
+	}
+	getWebAPIKeyFn = func(ctx context.Context, client *webcore.Client, keyID string) (*webcore.APIKey, error) {
+		if keyID != "ABC123XYZ" {
+			t.Fatalf("unexpected key id %q", keyID)
+		}
+		return &webcore.APIKey{
+			KeyID:          keyID,
+			Name:           "Release automation",
+			IssuerID:       "69a6de00-aaaa-bbbb-cccc-123456789abc",
+			Roles:          []string{"ADMIN"},
+			Active:         true,
+			AllAppsVisible: true,
+			KeyType:        "PUBLIC_API",
+		}, nil
+	}
+
+	return func() {
+		restoreSession()
+		newWebAPIKeyClientFn = originalNewClient
+		listWebAPIKeysFn = originalList
+		getWebAPIKeyFn = originalGet
+	}
+}
+
+func encodeAPIKeyP8(p8 []byte) string {
+	return base64.StdEncoding.EncodeToString(p8)
+}

--- a/internal/web/api_keys.go
+++ b/internal/web/api_keys.go
@@ -18,6 +18,11 @@ import (
 
 const apiKeyTypePublic = "PUBLIC_API"
 
+const (
+	APIKeyKindTeam       = "team"
+	APIKeyKindIndividual = "individual"
+)
+
 // ErrAPIKeyResponseInvalid reports a malformed or incomplete one-time P8 response.
 var ErrAPIKeyResponseInvalid = errors.New("invalid api key download response")
 
@@ -39,6 +44,19 @@ type APIKey struct {
 	KeyType        string   `json:"keyType,omitempty"`
 	LastUsed       string   `json:"lastUsed,omitempty"`
 	RevokingDate   string   `json:"revokingDate,omitempty"`
+}
+
+// APIKeyListItem is non-secret metadata for one listed App Store Connect API key.
+type APIKeyListItem struct {
+	KeyID       string    `json:"keyId"`
+	Name        string    `json:"name,omitempty"`
+	Kind        string    `json:"kind"`
+	Roles       []string  `json:"roles,omitempty"`
+	Active      bool      `json:"active"`
+	KeyType     string    `json:"keyType,omitempty"`
+	LastUsed    string    `json:"lastUsed,omitempty"`
+	GeneratedBy *KeyActor `json:"generatedBy,omitempty"`
+	RevokedBy   *KeyActor `json:"revokedBy,omitempty"`
 }
 
 type apiKeyResource struct {
@@ -113,6 +131,73 @@ func (c *Client) GetAPIKey(ctx context.Context, keyID string) (*APIKey, error) {
 		return nil, err
 	}
 	return parseAPIKeyResponse(body, "get api key")
+}
+
+// ListAPIKeys returns team and individual API keys visible to the web session.
+// Team keys come from the iris v1 integrations list; individual keys come from
+// iris v2. Both readers already follow pagination links, so this method returns
+// the complete visible set. Creation date is not present on either payload.
+func (c *Client) ListAPIKeys(ctx context.Context) ([]APIKeyListItem, error) {
+	teamKeys, teamErr := c.listTeamKeys(ctx)
+	if teamErr != nil && !shouldFallbackToIndividualKeys(teamErr) {
+		return nil, teamErr
+	}
+
+	individualKeys, individualErr := c.listIndividualKeys(ctx)
+	if individualErr != nil && !shouldFallbackToIndividualKeys(individualErr) {
+		if teamErr == nil {
+			return nil, individualErr
+		}
+		return nil, teamErr
+	}
+	if teamErr != nil && individualErr != nil {
+		return nil, teamErr
+	}
+
+	nTeam, nIndividual := 0, 0
+	if teamErr == nil {
+		nTeam = len(teamKeys)
+	}
+	if individualErr == nil {
+		nIndividual = len(individualKeys)
+	}
+	items := make([]APIKeyListItem, 0, nTeam+nIndividual)
+	if teamErr == nil {
+		for _, key := range teamKeys {
+			items = append(items, APIKeyListItem{
+				KeyID:       key.KeyID,
+				Name:        key.Name,
+				Kind:        APIKeyKindTeam,
+				Roles:       append([]string(nil), key.Roles...),
+				Active:      key.Active,
+				KeyType:     key.KeyType,
+				LastUsed:    key.LastUsed,
+				GeneratedBy: cloneKeyActor(key.GeneratedBy),
+				RevokedBy:   cloneKeyActor(key.RevokedBy),
+			})
+		}
+	}
+	if individualErr == nil {
+		for _, key := range individualKeys {
+			item := APIKeyListItem{
+				KeyID:    key.KeyID,
+				Name:     key.Name,
+				Kind:     APIKeyKindIndividual,
+				Roles:    append([]string(nil), key.Roles...),
+				Active:   key.Active,
+				KeyType:  key.KeyType,
+				LastUsed: key.LastUsed,
+			}
+			if key.CreatedByActorID != "" {
+				item.GeneratedBy = &KeyActor{ID: key.CreatedByActorID}
+			}
+			if key.RevokedByActorID != "" {
+				item.RevokedBy = &KeyActor{ID: key.RevokedByActorID}
+			}
+			items = append(items, item)
+		}
+	}
+	return items, nil
 }
 
 // DownloadAPIKey downloads and decodes the one-time P8 for an API key.
@@ -231,4 +316,12 @@ func parseAPIKeyResponse(body []byte, operation string) (*APIKey, error) {
 		LastUsed:       strings.TrimSpace(payload.Data.Attributes.LastUsed),
 		RevokingDate:   strings.TrimSpace(payload.Data.Attributes.RevokingDate),
 	}, nil
+}
+
+func cloneKeyActor(actor *KeyActor) *KeyActor {
+	if actor == nil {
+		return nil
+	}
+	cloned := *actor
+	return &cloned
 }

--- a/internal/web/api_keys.go
+++ b/internal/web/api_keys.go
@@ -145,10 +145,7 @@ func (c *Client) ListAPIKeys(ctx context.Context) ([]APIKeyListItem, error) {
 
 	individualKeys, individualErr := c.listIndividualKeys(ctx)
 	if individualErr != nil && !shouldFallbackToIndividualKeys(individualErr) {
-		if teamErr == nil {
-			return nil, individualErr
-		}
-		return nil, teamErr
+		return nil, individualErr
 	}
 	if teamErr != nil && individualErr != nil {
 		return nil, teamErr

--- a/internal/web/api_keys_test.go
+++ b/internal/web/api_keys_test.go
@@ -310,6 +310,32 @@ func TestClientListAPIKeysFallsBackWhenTeamKeysForbidden(t *testing.T) {
 	}
 }
 
+func TestClientListAPIKeysReturnsIndividualErrorAfterTeamFallback(t *testing.T) {
+	fixture := handlertest.New(t)
+	client := newAPIKeyHTTPTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/iris/v1/apiKeys":
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"errors":[{"status":"403","title":"Forbidden"}]}`))
+		case "/iris/v2/apiKeys":
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"errors":[{"status":"500","title":"Internal Server Error"}]}`))
+		default:
+			fixture.Respond(w, "unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+
+	keys, err := client.ListAPIKeys(context.Background())
+	if keys != nil {
+		t.Fatalf("expected no keys on error, got %#v", keys)
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || apiErr.Status != http.StatusInternalServerError {
+		t.Fatalf("expected individual-list 500 after team fallback, got %v", err)
+	}
+}
+
 func TestClientListAPIKeysErrorsWhenBothListsForbidden(t *testing.T) {
 	client := newAPIKeyHTTPTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/web/api_keys_test.go
+++ b/internal/web/api_keys_test.go
@@ -310,6 +310,72 @@ func TestClientListAPIKeysFallsBackWhenTeamKeysForbidden(t *testing.T) {
 	}
 }
 
+func TestClientListAPIKeysPropagatesIndividualPaginationForbidden(t *testing.T) {
+	fixture := handlertest.New(t)
+	client := newAPIKeyHTTPTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/iris/v1/apiKeys":
+			_, _ = w.Write([]byte(`{"data":[{"id":"ABC123XYZ","attributes":{"nickname":"Release automation","roles":["ADMIN"],"isActive":true,"keyType":"PUBLIC_API"}}]}`))
+		case r.URL.Path == "/iris/v2/apiKeys" && r.URL.Query().Get("cursor") == "page-2":
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"errors":[{"status":"403","title":"Forbidden"}]}`))
+		case r.URL.Path == "/iris/v2/apiKeys":
+			_, _ = w.Write([]byte(`{
+				"data":[{"id":"IND456ABC","attributes":{"nickname":"Personal","roles":["ADMIN"],"isActive":true,"keyType":"PUBLIC_API"}}],
+				"links":{"next":"https://appstoreconnect.apple.com/iris/v2/apiKeys?cursor=page-2"}
+			}`))
+		default:
+			fixture.Respond(w, "unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+
+	keys, err := client.ListAPIKeys(context.Background())
+	if keys != nil {
+		t.Fatalf("expected no keys when individual pagination fails, got %#v", keys)
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || apiErr.Status != http.StatusForbidden {
+		t.Fatalf("expected individual pagination 403, got %v", err)
+	}
+	if !errors.Is(err, errAPIKeyListPagination) {
+		t.Fatalf("expected pagination sentinel, got %v", err)
+	}
+}
+
+func TestClientListAPIKeysPropagatesTeamPaginationNotFound(t *testing.T) {
+	fixture := handlertest.New(t)
+	client := newAPIKeyHTTPTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/iris/v1/apiKeys" && r.URL.Query().Get("cursor") == "page-2":
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"errors":[{"status":"404","title":"Not Found"}]}`))
+		case r.URL.Path == "/iris/v1/apiKeys":
+			_, _ = w.Write([]byte(`{
+				"data":[{"id":"ABC123XYZ","attributes":{"nickname":"Release automation","roles":["ADMIN"],"isActive":true,"keyType":"PUBLIC_API"}}],
+				"links":{"next":"https://appstoreconnect.apple.com/iris/v1/apiKeys?cursor=page-2"}
+			}`))
+		case r.URL.Path == "/iris/v2/apiKeys":
+			_, _ = w.Write([]byte(`{"data":[{"id":"IND456ABC","attributes":{"nickname":"Personal","roles":["ADMIN"],"isActive":true,"keyType":"PUBLIC_API"}}]}`))
+		default:
+			fixture.Respond(w, "unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+
+	keys, err := client.ListAPIKeys(context.Background())
+	if keys != nil {
+		t.Fatalf("expected no keys when team pagination fails, got %#v", keys)
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || apiErr.Status != http.StatusNotFound {
+		t.Fatalf("expected team pagination 404, got %v", err)
+	}
+	if !errors.Is(err, errAPIKeyListPagination) {
+		t.Fatalf("expected pagination sentinel, got %v", err)
+	}
+}
+
 func TestClientListAPIKeysReturnsIndividualErrorAfterTeamFallback(t *testing.T) {
 	fixture := handlertest.New(t)
 	client := newAPIKeyHTTPTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/api_keys_test.go
+++ b/internal/web/api_keys_test.go
@@ -18,6 +18,8 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/handlertest"
 )
 
 func TestClientCreateAPIKeySendsTeamKeyPayload(t *testing.T) {
@@ -206,6 +208,145 @@ func TestClientGetAPIKeyParsesIssuerID(t *testing.T) {
 	}
 }
 
+func TestClientListAPIKeysCombinesTeamAndIndividualKeys(t *testing.T) {
+	fixture := handlertest.New(t)
+	var teamPath, individualPath string
+	var teamInclude, individualInclude string
+	p8 := generateP256PKCS8PEM(t)
+	client := newAPIKeyHTTPTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/iris/v1/apiKeys":
+			teamPath = r.URL.Path
+			teamInclude = r.URL.Query().Get("include")
+			_, _ = w.Write([]byte(`{
+				"data":[{
+					"id":"ABC123XYZ",
+					"attributes":{
+						"nickname":"Release automation",
+						"roles":["ADMIN"],
+						"isActive":true,
+						"keyType":"PUBLIC_API",
+						"lastUsed":"2026-03-15T11:48:57.844-07:00",
+						"privateKey":"` + base64.StdEncoding.EncodeToString(p8) + `"
+					},
+					"relationships":{"createdBy":{"data":{"id":"user-1"}}}
+				}],
+				"included":[{"type":"users","id":"user-1","attributes":{"firstName":"Ada","lastName":"Lovelace"}}]
+			}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/iris/v2/apiKeys":
+			individualPath = r.URL.Path
+			individualInclude = r.URL.Query().Get("include")
+			_, _ = w.Write([]byte(`{
+				"data":[{
+					"id":"IND456ABC",
+					"attributes":{"nickname":"Personal","roles":["APP_MANAGER"],"isActive":false,"keyType":"PUBLIC_API"},
+					"relationships":{"createdByActor":{"data":{"id":"actor-1"}}}
+				}]
+			}`))
+		default:
+			fixture.Respond(w, "unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+
+	keys, err := client.ListAPIKeys(context.Background())
+	if err != nil {
+		t.Fatalf("ListAPIKeys() error: %v", err)
+	}
+	if teamPath != "/iris/v1/apiKeys" {
+		t.Fatalf("expected team list path /iris/v1/apiKeys, got %q", teamPath)
+	}
+	if individualPath != "/iris/v2/apiKeys" {
+		t.Fatalf("expected individual list path /iris/v2/apiKeys, got %q", individualPath)
+	}
+	if teamInclude != "createdBy,revokedBy,provider" {
+		t.Fatalf("unexpected team include %q", teamInclude)
+	}
+	if individualInclude != "visibleApps,createdByActor,revokedByActor" {
+		t.Fatalf("unexpected individual include %q", individualInclude)
+	}
+	if len(keys) != 2 {
+		t.Fatalf("expected 2 keys, got %#v", keys)
+	}
+	if keys[0].KeyID != "ABC123XYZ" || keys[0].Kind != APIKeyKindTeam || keys[0].Name != "Release automation" {
+		t.Fatalf("unexpected team key: %#v", keys[0])
+	}
+	if !keys[0].Active || len(keys[0].Roles) != 1 || keys[0].Roles[0] != "ADMIN" {
+		t.Fatalf("unexpected team key state: %#v", keys[0])
+	}
+	if keys[0].GeneratedBy == nil || keys[0].GeneratedBy.Name != "Ada Lovelace" {
+		t.Fatalf("unexpected generatedBy: %#v", keys[0].GeneratedBy)
+	}
+	if keys[1].KeyID != "IND456ABC" || keys[1].Kind != APIKeyKindIndividual || keys[1].Active {
+		t.Fatalf("unexpected individual key: %#v", keys[1])
+	}
+	if keys[1].GeneratedBy == nil || keys[1].GeneratedBy.ID != "actor-1" {
+		t.Fatalf("unexpected individual generatedBy: %#v", keys[1].GeneratedBy)
+	}
+	assertNoKeyMaterialInAPIKeys(t, p8, keys)
+}
+
+func TestClientListAPIKeysFallsBackWhenTeamKeysForbidden(t *testing.T) {
+	fixture := handlertest.New(t)
+	client := newAPIKeyHTTPTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/iris/v1/apiKeys":
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"errors":[{"status":"403","title":"Forbidden"}]}`))
+		case "/iris/v2/apiKeys":
+			_, _ = w.Write([]byte(`{"data":[{"id":"IND456ABC","attributes":{"nickname":"Personal","roles":["ADMIN"],"isActive":true,"keyType":"PUBLIC_API"}}]}`))
+		default:
+			fixture.Respond(w, "unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+
+	keys, err := client.ListAPIKeys(context.Background())
+	if err != nil {
+		t.Fatalf("ListAPIKeys() error: %v", err)
+	}
+	if len(keys) != 1 || keys[0].KeyID != "IND456ABC" || keys[0].Kind != APIKeyKindIndividual {
+		t.Fatalf("expected individual-only fallback, got %#v", keys)
+	}
+}
+
+func TestClientListAPIKeysErrorsWhenBothListsForbidden(t *testing.T) {
+	client := newAPIKeyHTTPTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"errors":[{"status":"403","title":"Forbidden"}]}`))
+	}))
+
+	keys, err := client.ListAPIKeys(context.Background())
+	if err == nil {
+		t.Fatal("expected error when both key lists are forbidden")
+	}
+	if keys != nil {
+		t.Fatalf("expected no keys on error, got %#v", keys)
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || apiErr.Status != http.StatusForbidden {
+		t.Fatalf("expected forbidden API error, got %v", err)
+	}
+}
+
+func TestClientGetAPIKeyRequiresKeyID(t *testing.T) {
+	called := false
+	client := newAPIKeyHTTPTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"id":"x"}}`))
+	}))
+
+	_, err := client.GetAPIKey(context.Background(), "   ")
+	if err == nil {
+		t.Fatal("expected error for empty key id")
+	}
+	if called {
+		t.Fatal("did not expect HTTP for an empty key id")
+	}
+}
+
 func TestIsAPIKeyDownloadRetryable(t *testing.T) {
 	if IsAPIKeyDownloadRetryable(nil) {
 		t.Fatal("expected nil error not to be retryable")
@@ -345,6 +486,15 @@ func assertNoKeyMaterial(t *testing.T, p8 []byte, outputs ...string) {
 			}
 		}
 	}
+}
+
+func assertNoKeyMaterialInAPIKeys(t *testing.T, p8 []byte, keys []APIKeyListItem) {
+	t.Helper()
+	encoded, err := json.Marshal(keys)
+	if err != nil {
+		t.Fatalf("marshal listed keys: %v", err)
+	}
+	assertNoKeyMaterial(t, p8, string(encoded))
 }
 
 func newAPIKeyHTTPTestClient(t *testing.T, handler http.Handler) *Client {

--- a/internal/web/auth_capabilities.go
+++ b/internal/web/auth_capabilities.go
@@ -18,6 +18,7 @@ var (
 	ErrAPIKeyNotFound        = errors.New("api key not found")
 	ErrAPIKeyNotVisible      = errors.New("api key not visible in accessible key lists")
 	ErrAPIKeyRolesUnresolved = errors.New("api key roles could not be resolved")
+	errAPIKeyListPagination  = errors.New("api key list pagination failed")
 )
 
 func integrationsHeaders(referer string) http.Header {
@@ -169,7 +170,7 @@ func (c *Client) listTeamKeys(ctx context.Context) ([]teamAPIKey, error) {
 
 		body, err := c.doIrisV1Request(ctx, http.MethodGet, nextPath, nil)
 		if err != nil {
-			return nil, err
+			return nil, wrapAPIKeyListPageError(err, len(payloads))
 		}
 
 		var payload teamKeyPayload
@@ -266,7 +267,7 @@ func (c *Client) listIndividualKeys(ctx context.Context) ([]individualAPIKey, er
 
 		body, err := c.doIrisV2Request(ctx, http.MethodGet, nextPath, nil)
 		if err != nil {
-			return nil, err
+			return nil, wrapAPIKeyListPageError(err, len(payloads))
 		}
 
 		var payload individualKeyPayload
@@ -571,7 +572,17 @@ func (c *Client) LookupAPIKeyRoles(ctx context.Context, keyID string) (*APIKeyRo
 	return nil, fmt.Errorf("%w: %s", ErrAPIKeyNotFound, keyID)
 }
 
+func wrapAPIKeyListPageError(err error, pagesFetched int) error {
+	if err == nil || pagesFetched == 0 {
+		return err
+	}
+	return fmt.Errorf("%w: %w", errAPIKeyListPagination, err)
+}
+
 func shouldFallbackToIndividualKeys(err error) bool {
+	if errors.Is(err, errAPIKeyListPagination) {
+		return false
+	}
 	var apiErr *APIError
 	if !errors.As(err, &apiErr) {
 		return false

--- a/internal/web/auth_capabilities_test.go
+++ b/internal/web/auth_capabilities_test.go
@@ -3,6 +3,7 @@ package web
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -1124,6 +1125,8 @@ func TestShouldFallbackToIndividualKeys(t *testing.T) {
 		{name: "not found", err: &APIError{Status: http.StatusNotFound}, want: true},
 		{name: "bad request", err: &APIError{Status: http.StatusBadRequest}, want: false},
 		{name: "non api error", err: errors.New("boom"), want: false},
+		{name: "pagination forbidden", err: fmt.Errorf("%w: %w", errAPIKeyListPagination, &APIError{Status: http.StatusForbidden}), want: false},
+		{name: "pagination not found", err: fmt.Errorf("%w: %w", errAPIKeyListPagination, &APIError{Status: http.StatusNotFound}), want: false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Add `asc web api-keys list` and `asc web api-keys view --key-id` so a cached web session can inventory team and individual keys and inspect one team key without printing key material.
- Reuse the existing iris v1/v2 key-list readers (`listTeamKeys` / `listIndividualKeys`) and `GetAPIKey`. Creation date is omitted because those payloads do not expose it. `--paginate` is omitted because the readers already follow every page internally (accepting the flag would silently ignore a first-page-only mode that does not exist).
- The issue proposed `get`; current CLI taxonomy bans `get` leaf verbs, so this ships `view`. httptest fixtures that include P8 material never appear on stdout/stderr.

Part of #2283

Remaining: `revoke` and `create --individual` (need live web-session endpoint capture).

## Test plan
- [x] Focused httptest/cmdtest coverage for list/view flags, JSON fields, required `--key-id` before HTTP, and P8 never leaking
- [x] Canonical-verb tests (`view` not `get`)
- [x] `make generate-command-docs` (COMMANDS.md unchanged), `make format`, `make build`, `make check-docs`, `make lint`, `ASC_BYPASS_KEYCHAIN=1 make test`
- [ ] Live `list`/`view` against a web session — `ASC_BYPASS_KEYCHAIN=1 /tmp/asc-2283 web auth status` returned `authenticated:false`; did not run `web auth login` (2FA). Relied on httptest + cmdtest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `web api-keys list` for visible team and individual keys.
  - Added `web api-keys view` for team-key metadata by key ID.
  - Added table, Markdown, and JSON output with pagination.
  - API-key details include status, roles, type, usage, and actor information; private key material is never displayed.
  - Improved handling when individual-key data or roles are unavailable.

- **Documentation**
  - Expanded help and API-key documentation with examples, cached-session authentication, pagination, output behavior, endpoint limitations, and sparse-fieldset guidance.
  - Updated documentation to use `view` instead of `get`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->