### PR TITLE
fix(web privacy): keep DATA_NOT_COLLECTED as a representable remote declaration

### DIFF
--- a/internal/cli/web/web_privacy.go
+++ b/internal/cli/web/web_privacy.go
@@ -400,12 +400,8 @@ func declarationFromRemoteDataUsages(usages []webcore.AppDataUsage) privacyDecla
 }
 
 func isUnrepresentableDataProtection(protection string) bool {
-	switch normalizeToken(protection) {
-	case dataProtectionLinked, dataProtectionNotLinked, dataProtectionTracking:
-		return false
-	default:
-		return true
-	}
+	_, known := knownDataProtections[normalizeToken(protection)]
+	return !known
 }
 
 func countUnrepresentableRemoteUsages(usages []webcore.AppDataUsage) int {

--- a/internal/cli/web/web_privacy_test.go
+++ b/internal/cli/web/web_privacy_test.go
@@ -230,6 +230,41 @@ func TestDeclarationFromRemoteDataUsagesEmptyDefaultsNotCollected(t *testing.T) 
 	}
 }
 
+func TestDeclarationFromRemoteDataUsagesKeepsNotCollectedProtection(t *testing.T) {
+	usages := []webcore.AppDataUsage{
+		{
+			ID:             "u1",
+			DataProtection: dataProtectionNotCollected,
+		},
+	}
+
+	declaration := declarationFromRemoteDataUsages(usages)
+	if declaration.SchemaVersion != privacySchemaVersion {
+		t.Fatalf("expected schemaVersion=%d, got %d", privacySchemaVersion, declaration.SchemaVersion)
+	}
+	if len(declaration.DataUsages) != 1 {
+		t.Fatalf("expected one data usage, got %#v", declaration.DataUsages)
+	}
+	got := declaration.DataUsages[0]
+	if !reflect.DeepEqual(got.DataProtections, []string{dataProtectionNotCollected}) {
+		t.Fatalf("expected DATA_NOT_COLLECTED to remain representable, got %#v", got)
+	}
+	if got.Category != "" || len(got.Purposes) != 0 {
+		t.Fatalf("expected DATA_NOT_COLLECTED declaration with empty category/purposes, got %#v", got)
+	}
+	if count := countUnrepresentableRemoteUsages(usages); count != 0 {
+		t.Fatalf("expected unrepresentableCount=0 for DATA_NOT_COLLECTED, got %d", count)
+	}
+
+	raw, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal usage: %v", err)
+	}
+	if string(raw) != `{"dataProtections":["DATA_NOT_COLLECTED"]}` {
+		t.Fatalf("expected canonical not-collected JSON without empty category/purposes, got %s", raw)
+	}
+}
+
 func TestDeclarationFromRemoteDataUsagesMalformedOnlyPreservesUnrepresentable(t *testing.T) {
 	declaration := declarationFromRemoteDataUsages([]webcore.AppDataUsage{
 		{
@@ -1444,6 +1479,100 @@ func TestWebPrivacyPullPreservesMalformedUsagesAlongsideValidOnes(t *testing.T) 
 	}
 	if !containsPrivacyProtection(got.DataProtections, dataProtectionLinked) || !containsPrivacyProtection(got.DataProtections, dataProtectionUnknown) {
 		t.Fatalf("expected valid and opaque protections, got %#v", got.DataProtections)
+	}
+}
+
+func TestWebPrivacyPullNotCollectedRoundTripsThroughPlan(t *testing.T) {
+	fixture := handlertest.New(t)
+	outPath := filepath.Join(t.TempDir(), "privacy.json")
+	notCollectedUsages := `{
+		"data": [{
+			"id": "u1",
+			"type": "appDataUsages",
+			"relationships": {
+				"dataProtection": {"data": {"type":"appDataUsageDataProtections","id":"DATA_NOT_COLLECTED"}}
+			}
+		}]
+	}`
+	stubPrivacyWebSession(t, func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/iris/v1/apps/"+privacyTestAppID+"/dataUsages":
+			return privacyJSONResponse(req, notCollectedUsages), nil
+		case req.Method == http.MethodGet && req.URL.Path == "/iris/v1/apps/"+privacyTestAppID+"/dataUsagePublishState":
+			return privacyJSONResponse(req, `{
+				"data": {
+					"id": "publish-state-1",
+					"type": "appDataUsagesPublishState",
+					"attributes": {"published": true}
+				}
+			}`), nil
+		default:
+			return fixture.Response("unexpected request: %s %s", req.Method, req.URL.Path), nil
+		}
+	})
+
+	pullCmd := WebPrivacyPullCommand()
+	if err := pullCmd.FlagSet.Parse([]string{"--app", privacyTestAppID, "--out", outPath, "--output", "json"}); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	stdout, stderr := captureWebCommandOutput(t, func() {
+		if err := pullCmd.Exec(context.Background(), nil); err != nil {
+			t.Fatalf("pull exec error: %v", err)
+		}
+	})
+	assertNoPrivacySecrets(t, stdout, stderr)
+
+	var payload struct {
+		UnrepresentableCount int `json:"unrepresentableCount"`
+		Declaration          privacyDeclarationFile
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("failed to parse pull stdout JSON: %v\nstdout=%s", err, stdout)
+	}
+	if payload.UnrepresentableCount != 0 {
+		t.Fatalf("expected unrepresentableCount=0 for DATA_NOT_COLLECTED, got %d", payload.UnrepresentableCount)
+	}
+	if len(payload.Declaration.DataUsages) != 1 {
+		t.Fatalf("expected one pulled usage, got %#v", payload.Declaration.DataUsages)
+	}
+	if !reflect.DeepEqual(payload.Declaration.DataUsages[0].DataProtections, []string{dataProtectionNotCollected}) {
+		t.Fatalf("expected pulled DATA_NOT_COLLECTED, got %#v", payload.Declaration.DataUsages[0])
+	}
+
+	fileData, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read --out file: %v", err)
+	}
+	var written privacyDeclarationFile
+	if err := json.Unmarshal(fileData, &written); err != nil {
+		t.Fatalf("parse --out file: %v\n%s", err, fileData)
+	}
+	if _, err := declarationToTupleSet(written); err != nil {
+		t.Fatalf("pulled file failed plan validator: %v\n%s", err, fileData)
+	}
+	if strings.Contains(string(fileData), `"category"`) || strings.Contains(string(fileData), `"purposes"`) {
+		t.Fatalf("expected canonical not-collected file without empty category/purposes keys:\n%s", fileData)
+	}
+
+	planCmd := WebPrivacyPlanCommand()
+	if err := planCmd.FlagSet.Parse([]string{"--app", privacyTestAppID, "--file", outPath, "--output", "json"}); err != nil {
+		t.Fatalf("plan parse error: %v", err)
+	}
+
+	planStdout, planStderr := captureWebCommandOutput(t, func() {
+		if err := planCmd.Exec(context.Background(), nil); err != nil {
+			t.Fatalf("plan exec error: %v", err)
+		}
+	})
+	assertNoPrivacySecrets(t, planStdout, planStderr)
+
+	var plan privacyPlanOutput
+	if err := json.Unmarshal([]byte(planStdout), &plan); err != nil {
+		t.Fatalf("failed to parse plan stdout JSON: %v\nstdout=%s", err, planStdout)
+	}
+	if len(plan.Adds) != 0 || len(plan.Deletes) != 0 || len(plan.Updates) != 0 {
+		t.Fatalf("expected empty pull->plan diff, got adds=%#v deletes=%#v updates=%#v", plan.Adds, plan.Deletes, plan.Updates)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Follow-up to #2317; fixes the pull -> plan round trip for Data Not Collected apps.
- `isUnrepresentableDataProtection` now uses `knownDataProtections` as the single source of truth, so Apple's legitimate `DATA_NOT_COLLECTED` token is no longer rewritten as `UNKNOWN_OR_MISSING`.
- Empty/unknown protections still fail closed. Canonical pull JSON for a not-collected app remains `{"dataProtections":["DATA_NOT_COLLECTED"]}` with no empty `category`/`purposes` keys, matching 4.9.2.

PR #2317 (`fix(web privacy): fail closed on unrepresentable remote usages`, issue #2269) introduced a switch that treated only `DATA_LINKED_TO_YOU`, `DATA_NOT_LINKED_TO_YOU`, and `DATA_USED_TO_TRACK_YOU` as representable. That omitted `DATA_NOT_COLLECTED`, which is a catalog token, is in `knownDataProtections`, and is the canonical "Data Not Collected" declaration. The most common privacy state therefore could not round-trip: pull wrote `UNKNOWN_OR_MISSING` with `unrepresentableCount: 1`, and plan then exited 2.

## Test plan
- [x] RED: `declarationFromRemoteDataUsages` / `countUnrepresentableRemoteUsages` with `{ID:"u1", DataProtection:"DATA_NOT_COLLECTED"}` failed with `expected DATA_NOT_COLLECTED to remain representable, got ... UNKNOWN_OR_MISSING` and `expected unrepresentableCount=0 ... got 1`
- [x] GREEN: same tests pass; existing malformed/unknown fail-closed tests still pass
- [x] CLI httptest: pull of a remote `DATA_NOT_COLLECTED` usage writes that token, `unrepresentableCount=0`, and plan of the pulled file is `adds:[]` `deletes:[]`
- [x] `make format`, `make build`, `make check-docs`, `make lint`, `ASC_BYPASS_KEYCHAIN=1 make test`

## Live verification
Disposable app `6759231657` (read-only). Auth: `ASC_BYPASS_KEYCHAIN=1 ./asc web auth status` → `authenticated:true`.

```text
$ ASC_BYPASS_KEYCHAIN=1 ASC_TIMEOUT=90s ./asc web privacy pull --app 6759231657 --out /tmp/privacy-dnc.json --pretty
{
  "appId": "6759231657",
  "declaration": {
    "schemaVersion": 1,
    "dataUsages": [
      {
        "dataProtections": [
          "DATA_NOT_COLLECTED"
        ]
      }
    ]
  },
  "publishState": {
    "id": "6759231657",
    "published": true,
    "publishedKnown": true
  },
  "unrepresentableCount": 0,
  "out": "/tmp/privacy-dnc.json"
}

$ ASC_BYPASS_KEYCHAIN=1 ASC_TIMEOUT=90s ./asc web privacy plan --app 6759231657 --file /tmp/privacy-dnc.json --pretty
{
  "appId": "6759231657",
  "file": "/tmp/privacy-dnc.json",
  "adds": [],
  "deletes": []
}
```

Did not run `web privacy apply` or `publish`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved `DATA_NOT_COLLECTED` privacy declarations when pulling remote usage data.
  * Ensured these declarations retain canonical formatting without empty category or purpose fields.
  * Improved consistency across validation, saved declarations, and planning so unchanged declarations remain unchanged through the full workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->