### PR TITLE
fix(web review): drop appStoreVersionExperimentV2 from the iris items include

### DIFF
--- a/docs/API_NOTES.md
+++ b/docs/API_NOTES.md
@@ -57,6 +57,10 @@ Finance reports use Apple fiscal months (`YYYY-MM`), not calendar months.
 - Those payloads expose key ID, nickname, roles, `isActive`, key type, and last-used. They do not include a creation date, so list/view omit that column rather than inventing one. Private key material is never copied into command output.
 - Revoke and `--individual` create still need a live web-session endpoint capture.
 
+## Web-session review submissions (iris)
+
+- `GET /iris/v1/reviewSubmissions/{id}/items` rejects `include=appStoreVersionExperimentV2` with HTTP 400 `PARAMETER_ERROR.INVALID` even though the public OpenAPI snapshot lists that relationship. Verified live 2026-09-03. `asc web review show` omits it from the items include and keeps the iris-accepted names, including `inAppPurchaseVersion`, `subscriptionVersion`, and `subscriptionGroupVersion`.
+
 ## TestFlight Distribution
 
 - `asc testflight distribution edit --external-testing` shipped in 0.35.3 but App Store Connect does not allow `externalBuildState` in the build beta detail PATCH request. The flag remains parseable during its deprecation window and fails before HTTP instead of sending an unsupported update.

--- a/internal/web/review.go
+++ b/internal/web/review.go
@@ -18,8 +18,11 @@ import (
 )
 
 const (
-	reviewSubmissionsInclude      = "appStoreVersionForReview,items,lastUpdatedByActor,submittedByActor,createdByActor"
-	reviewSubmissionsItemsInclude = "appStoreVersion,appCustomProductPageVersion,appStoreVersionExperiment,appStoreVersionExperimentV2,appEvent,backgroundAssetVersion,gameCenterAchievementVersion,gameCenterActivityVersion,gameCenterChallengeVersion,gameCenterLeaderboardSetVersion,gameCenterLeaderboardVersion,inAppPurchaseVersion,subscriptionVersion,subscriptionGroupVersion"
+	reviewSubmissionsInclude = "appStoreVersionForReview,items,lastUpdatedByActor,submittedByActor,createdByActor"
+	// iris GET /reviewSubmissions/{id}/items rejects appStoreVersionExperimentV2
+	// with PARAMETER_ERROR.INVALID (verified live 2026-09-03) even though the
+	// public OpenAPI lists it.
+	reviewSubmissionsItemsInclude = "appStoreVersion,appCustomProductPageVersion,appStoreVersionExperiment,appEvent,backgroundAssetVersion,gameCenterAchievementVersion,gameCenterActivityVersion,gameCenterChallengeVersion,gameCenterLeaderboardSetVersion,gameCenterLeaderboardVersion,inAppPurchaseVersion,subscriptionVersion,subscriptionGroupVersion"
 	reviewMessagesInclude         = "fromActor,rejections,resolutionCenterMessageAttachments"
 	reviewRejectionsInclude       = "appCustomProductPageVersion,appEvent,appStoreVersion,appStoreVersionExperiment,backgroundAssetVersions,gameCenterAchievementVersions,gameCenterLeaderboardVersions,gameCenterLeaderboardSetVersions,gameCenterChallengeVersions,gameCenterActivityVersions,build,appBundleVersion,rejectionAttachments"
 	attachmentHostsEnv            = "ASC_WEB_ALLOWED_ATTACHMENT_HOSTS"

--- a/internal/web/review_included_test.go
+++ b/internal/web/review_included_test.go
@@ -106,6 +106,59 @@ func TestListReviewRejectionsRetainsIncludedContext(t *testing.T) {
 	}
 }
 
+func TestListReviewSubmissionItemsOmitsRejectedExperimentV2Include(t *testing.T) {
+	fixture := handlertest.New(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/reviewSubmissions/sub-1/items" {
+			fixture.Respond(w, "unexpected path: %s", r.URL.Path)
+			return
+		}
+		include := r.URL.Query().Get("include")
+		tokens := map[string]bool{}
+		for _, token := range strings.Split(include, ",") {
+			tokens[strings.TrimSpace(token)] = true
+		}
+		// iris GET /reviewSubmissions/{id}/items rejects this name with
+		// PARAMETER_ERROR.INVALID (verified live 2026-09-03) even though the
+		// public OpenAPI lists it.
+		if tokens["appStoreVersionExperimentV2"] {
+			fixture.Respond(w, "include must not contain appStoreVersionExperimentV2 (iris rejects it): %q", include)
+			return
+		}
+		for _, want := range []string{
+			"appStoreVersion",
+			"appCustomProductPageVersion",
+			"appStoreVersionExperiment",
+			"appEvent",
+			"backgroundAssetVersion",
+			"gameCenterAchievementVersion",
+			"gameCenterActivityVersion",
+			"gameCenterChallengeVersion",
+			"gameCenterLeaderboardSetVersion",
+			"gameCenterLeaderboardVersion",
+			"inAppPurchaseVersion",
+			"subscriptionVersion",
+			"subscriptionGroupVersion",
+		} {
+			if !tokens[want] {
+				fixture.Respond(w, "missing include %s in %q", want, include)
+				return
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer server.Close()
+
+	items, err := testWebClient(server).ListReviewSubmissionItems(context.Background(), "sub-1")
+	if err != nil {
+		t.Fatalf("ListReviewSubmissionItems() error = %v", err)
+	}
+	if items == nil {
+		t.Fatal("expected empty items slice, got nil")
+	}
+}
+
 func TestListReviewSubmissionItemsRetainsIncludedContext(t *testing.T) {
 	fixture := handlertest.New(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -115,7 +168,6 @@ func TestListReviewSubmissionItemsRetainsIncludedContext(t *testing.T) {
 		}
 		include := r.URL.Query().Get("include")
 		for _, want := range []string{
-			"appStoreVersionExperimentV2",
 			"inAppPurchaseVersion",
 			"subscriptionVersion",
 			"subscriptionGroupVersion",


### PR DESCRIPTION
Follow-up to #2310 (issues #2272 / #2296).

## Summary

- `asc web review show` has been failing on main with HTTP 400 `PARAMETER_ERROR.INVALID` because PR #2310 added `appStoreVersionExperimentV2` to the iris items `include` list.
- iris `GET /iris/v1/reviewSubmissions/{id}/items?include=...` rejects that name even though the public OpenAPI snapshot lists it.
- This PR removes only `appStoreVersionExperimentV2` from `reviewSubmissionsItemsInclude` and keeps the iris-accepted names from #2310 (`inAppPurchaseVersion`, `subscriptionVersion`, `subscriptionGroupVersion`) plus the original ten.

## Regression

Merge commit `41e6d16cf` on `fix/2272-2296-web-review-readers` changed `reviewSubmissionsItemsInclude` to include `appStoreVersionExperimentV2`. On current main:

```text
ASC_BYPASS_KEYCHAIN=1 asc web review show --app 6759231657
Error: web review show failed: web api error (status 400), request_id=..., codes=[PARAMETER_ERROR.INVALID]
```

`web review list` still works. Released 4.9.2 worked.

## Live bisection

Rebuilding with different include lists and running `web review show --submission 52ada222-0184-42b3-bdec-6310db25648e`:

| Include list | Result |
| --- | --- |
| base list (the pre-#2310 ten includes) | 200 OK |
| base + `appStoreVersionExperimentV2` | 400 `PARAMETER_ERROR.INVALID` |
| base + `inAppPurchaseVersion` | 200 OK |
| base + `subscriptionVersion` | 200 OK |
| base + `subscriptionGroupVersion` | 200 OK |

## Other include constants

`reviewRejectionsInclude` has `appStoreVersionExperiment` but **not** `appStoreVersionExperimentV2`. No other `internal/web/*.go` include constant contains `appStoreVersionExperimentV2`, so nothing else was removed and no extra live probe was needed.

## Test plan

- [x] RED: `TestListReviewSubmissionItemsOmitsRejectedExperimentV2Include` failed on current code with `include must not contain appStoreVersionExperimentV2 (iris rejects it): "...appStoreVersionExperimentV2..."`
- [x] GREEN: same test passes; items include still contains the original ten plus `inAppPurchaseVersion`, `subscriptionVersion`, `subscriptionGroupVersion`
- [x] `ASC_BYPASS_KEYCHAIN=1 go test ./internal/web/... ./internal/cli/web/...`
- [x] `make format`, `make build`, `make check-docs`, `make lint`, `ASC_BYPASS_KEYCHAIN=1 make test`

## Live verification

Disposable app `6759231657` (read-only). Auth: `ASC_BYPASS_KEYCHAIN=1 ./asc web auth status` → `authenticated:true`.

```text
$ ASC_BYPASS_KEYCHAIN=1 ASC_TIMEOUT=90s ./asc web review show --app 6759231657 --out /tmp/asc-review-fix --output json
exit 0
submission.id = 52ada222-0184-42b3-bdec-6310db25648e
submissionItems[0].related[0] = {
  "relationship": "subscriptionVersion",
  "type": "subscriptionVersions",
  "id": "51d81f73-2d9f-4c8d-a91e-03b0fabf6e45",
  "label": "1"
}

$ ASC_BYPASS_KEYCHAIN=1 ASC_TIMEOUT=90s ./asc web review show --app 6759231657 --out /tmp/asc-review-fix --output table
exit 0
Submission ID 52ada222-0184-42b3-bdec-6310db25648e
Items Reviewed Count 1
```

The #2296 included-label feature still populates: this disposable app's item has `related[].label` `"1"` (subscription version string).

Did not run mutating review subcommands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed App Store Connect review submission requests to omit an unsupported relationship.
  * Preserved all supported relationship parameters and existing review submission results.

* **Documentation**
  * Added API notes describing the accepted relationship parameters and the omitted unsupported relationship.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->