### PR TITLE
fix(web): serialize keychain session mutations and cache generations

### DIFF
--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -112,7 +112,8 @@ type AuthSession struct {
 	// loaded from, zero for a freshly logged-in session. It lets a caller that
 	// proves the loaded jar unusable delete only that entry, leaving a
 	// replacement another process persisted in the meantime intact.
-	cachedUpdatedAt time.Time
+	cachedUpdatedAt  time.Time
+	cachedGeneration string
 
 	// Prepared 2FA delivery state so callers can request code delivery before prompting.
 	twoFactorMethod        string

--- a/internal/web/session_cache.go
+++ b/internal/web/session_cache.go
@@ -120,6 +120,7 @@ var (
 	// delete in DeleteSessionIfMatches. Tests set it to schedule a concurrent
 	// persist inside that window; it is nil in production.
 	sessionCompareDeleteBarrier func()
+	sessionGenerationReader     = func(b []byte) (int, error) { return rand.Read(b) }
 )
 
 func webSessionCacheEnabled() bool {
@@ -254,11 +255,20 @@ func isExpiredCookie(c pCookie, now time.Time) bool {
 }
 
 func serializeCookieJar(jar http.CookieJar, userEmail string) persistedSession {
+	sess, _ := serializeCookieJarWithError(jar, userEmail)
+	return sess
+}
+
+func serializeCookieJarWithError(jar http.CookieJar, userEmail string) (persistedSession, error) {
 	now := time.Now().UTC()
+	var generation [16]byte
+	if _, err := sessionGenerationReader(generation[:]); err != nil {
+		return persistedSession{}, fmt.Errorf("generate session cache identity: %w", err)
+	}
 	out := persistedSession{
 		Version:    webSessionCacheVersion,
 		UpdatedAt:  now,
-		Generation: newSessionGeneration(),
+		Generation: fmt.Sprintf("%x", generation[:]),
 		UserEmail:  strings.TrimSpace(userEmail),
 		Cookies:    map[string][]pCookie{},
 	}
@@ -292,15 +302,7 @@ func serializeCookieJar(jar http.CookieJar, userEmail string) persistedSession {
 			out.Cookies[u.String()] = list
 		}
 	}
-	return out
-}
-
-func newSessionGeneration() string {
-	var b [16]byte
-	if _, err := rand.Read(b[:]); err == nil {
-		return fmt.Sprintf("%x", b[:])
-	}
-	return ""
+	return out, nil
 }
 
 func hydrateCookieJar(jar http.CookieJar, sess persistedSession) int {
@@ -1226,7 +1228,10 @@ func PersistSession(session *AuthSession) error {
 	}
 
 	key := webSessionCacheKey(username)
-	serialized := serializeCookieJar(session.Client.Jar, username)
+	serialized, err := serializeCookieJarWithError(session.Client.Jar, username)
+	if err != nil {
+		return err
+	}
 	serialized.DeveloperTeamID = strings.TrimSpace(session.DeveloperTeamID)
 	return persistSessionBySelection(selection, key, serialized)
 }
@@ -1545,7 +1550,9 @@ func sessionMirrorEnabled(selection backendSelection) bool {
 func fileSessionCarriesIdentity(key string, stamp time.Time, generation string) bool {
 	sess, ok, err := readSessionFromFile(key)
 	if err != nil {
-		return false
+		// A keychain entry already proven stale may safely clean up a corrupt
+		// mirrored file; leaving it causes repeated fallback failures.
+		return true
 	}
 	return ok && persistedSessionIdentityMatches(sess, stamp, generation)
 }

--- a/internal/web/session_cache.go
+++ b/internal/web/session_cache.go
@@ -39,6 +39,7 @@ const (
 var (
 	ErrCachedSessionExpired          = errors.New("cached web session expired")
 	ErrCachedSessionValidationFailed = errors.New("cached web session could not be validated")
+	errMalformedSessionFile          = errors.New("web session cache is malformed")
 )
 
 type sessionBackend int
@@ -615,7 +616,7 @@ func readSessionFromFile(key string) (persistedSession, bool, error) {
 	}
 	var sess persistedSession
 	if err := json.Unmarshal(raw, &sess); err != nil {
-		return persistedSession{}, false, fmt.Errorf("failed to decode session cache: %w", err)
+		return persistedSession{}, false, fmt.Errorf("%w: %w", errMalformedSessionFile, err)
 	}
 	if sess.Version != webSessionCacheVersion {
 		return persistedSession{}, false, nil
@@ -1552,7 +1553,7 @@ func fileSessionCarriesIdentity(key string, stamp time.Time, generation string) 
 	if err != nil {
 		// A keychain entry already proven stale may safely clean up a corrupt
 		// mirrored file; leaving it causes repeated fallback failures.
-		return true
+		return errors.Is(err, errMalformedSessionFile)
 	}
 	return ok && persistedSessionIdentityMatches(sess, stamp, generation)
 }

--- a/internal/web/session_cache.go
+++ b/internal/web/session_cache.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -68,6 +69,7 @@ type backendSelection struct {
 type persistedSession struct {
 	Version         int                  `json:"version"`
 	UpdatedAt       time.Time            `json:"updated_at"`
+	Generation      string               `json:"generation,omitempty"`
 	UserEmail       string               `json:"user_email,omitempty"`
 	DeveloperTeamID string               `json:"developer_team_id,omitempty"`
 	Cookies         map[string][]pCookie `json:"cookies"`
@@ -254,10 +256,11 @@ func isExpiredCookie(c pCookie, now time.Time) bool {
 func serializeCookieJar(jar http.CookieJar, userEmail string) persistedSession {
 	now := time.Now().UTC()
 	out := persistedSession{
-		Version:   webSessionCacheVersion,
-		UpdatedAt: now,
-		UserEmail: strings.TrimSpace(userEmail),
-		Cookies:   map[string][]pCookie{},
+		Version:    webSessionCacheVersion,
+		UpdatedAt:  now,
+		Generation: newSessionGeneration(),
+		UserEmail:  strings.TrimSpace(userEmail),
+		Cookies:    map[string][]pCookie{},
 	}
 	for _, u := range sessionCookieURLs() {
 		cookies := jar.Cookies(u)
@@ -290,6 +293,14 @@ func serializeCookieJar(jar http.CookieJar, userEmail string) persistedSession {
 		}
 	}
 	return out
+}
+
+func newSessionGeneration() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err == nil {
+		return fmt.Sprintf("%x", b[:])
+	}
+	return ""
 }
 
 func hydrateCookieJar(jar http.CookieJar, sess persistedSession) int {
@@ -511,6 +522,10 @@ func removeLegacyLastKeyFromKeyring(kr keyring.Keyring) error {
 }
 
 func writeSessionToKeychain(key string, sess persistedSession) error {
+	return withSessionStoreLock(func() error { return writeSessionToKeychainUnlocked(key, sess) })
+}
+
+func writeSessionToKeychainUnlocked(key string, sess persistedSession) error {
 	kr, err := sessionKeyringOpen()
 	if err != nil {
 		return err
@@ -993,6 +1008,10 @@ func deleteSessionFromFile(key string) error {
 }
 
 func deleteSessionFromKeychain(key string) error {
+	return withSessionStoreLock(func() error { return deleteSessionFromKeychainUnlocked(key) })
+}
+
+func deleteSessionFromKeychainUnlocked(key string) error {
 	kr, err := sessionKeyringOpen()
 	if err != nil {
 		return err
@@ -1036,6 +1055,10 @@ func clearLastKeyInFile() error {
 }
 
 func clearLastKeyInKeychain() error {
+	return withSessionStoreLock(func() error { return clearLastKeyInKeychainUnlocked() })
+}
+
+func clearLastKeyInKeychainUnlocked() error {
 	kr, err := sessionKeyringOpen()
 	if err != nil {
 		return err
@@ -1081,6 +1104,10 @@ func deleteAllFromFile() error {
 }
 
 func deleteAllFromKeychain() error {
+	return withSessionStoreLock(func() error { return deleteAllFromKeychainUnlocked() })
+}
+
+func deleteAllFromKeychainUnlocked() error {
 	kr, err := sessionKeyringOpen()
 	if err != nil {
 		return err
@@ -1175,10 +1202,11 @@ func loadSessionFromPersistedSession(sess persistedSession) (*AuthSession, bool,
 		return nil, false, nil
 	}
 	return &AuthSession{
-		Client:          newWebHTTPClient(jar),
-		UserEmail:       strings.TrimSpace(sess.UserEmail),
-		DeveloperTeamID: strings.TrimSpace(sess.DeveloperTeamID),
-		cachedUpdatedAt: sess.UpdatedAt,
+		Client:           newWebHTTPClient(jar),
+		UserEmail:        strings.TrimSpace(sess.UserEmail),
+		DeveloperTeamID:  strings.TrimSpace(sess.DeveloperTeamID),
+		cachedUpdatedAt:  sess.UpdatedAt,
+		cachedGeneration: sess.Generation,
 	}, true, nil
 }
 
@@ -1429,7 +1457,7 @@ func DeleteSessionIfMatches(username string, loaded *AuthSession) (bool, error) 
 	if username == "" {
 		return false, nil
 	}
-	if loaded == nil || loaded.cachedUpdatedAt.IsZero() {
+	if loaded == nil || (loaded.cachedUpdatedAt.IsZero() && loaded.cachedGeneration == "") {
 		return true, DeleteSession(username)
 	}
 
@@ -1448,7 +1476,7 @@ func DeleteSessionIfMatches(username string, loaded *AuthSession) (bool, error) 
 		if !ok {
 			return nil
 		}
-		if !current.UpdatedAt.Equal(loaded.cachedUpdatedAt) {
+		if !samePersistedSessionIdentity(current, loaded) {
 			return nil
 		}
 		if sessionCompareDeleteBarrier != nil {
@@ -1458,6 +1486,13 @@ func DeleteSessionIfMatches(username string, loaded *AuthSession) (bool, error) 
 		return deleteMatchedSessionEntryLocked(selection, key, origin, current.UpdatedAt)
 	})
 	return deleted, err
+}
+
+func samePersistedSessionIdentity(current persistedSession, loaded *AuthSession) bool {
+	if loaded.cachedGeneration != "" && current.Generation != "" {
+		return current.Generation == loaded.cachedGeneration
+	}
+	return !loaded.cachedUpdatedAt.IsZero() && current.UpdatedAt.Equal(loaded.cachedUpdatedAt)
 }
 
 // deleteMatchedSessionEntryLocked removes the cache entry whose stamp matched

--- a/internal/web/session_cache.go
+++ b/internal/web/session_cache.go
@@ -1489,8 +1489,8 @@ func DeleteSessionIfMatches(username string, loaded *AuthSession) (bool, error) 
 }
 
 func samePersistedSessionIdentity(current persistedSession, loaded *AuthSession) bool {
-	if loaded.cachedGeneration != "" && current.Generation != "" {
-		return current.Generation == loaded.cachedGeneration
+	if loaded.cachedGeneration != "" || current.Generation != "" {
+		return loaded.cachedGeneration != "" && current.Generation != "" && current.Generation == loaded.cachedGeneration
 	}
 	return !loaded.cachedUpdatedAt.IsZero() && current.UpdatedAt.Equal(loaded.cachedUpdatedAt)
 }

--- a/internal/web/session_cache.go
+++ b/internal/web/session_cache.go
@@ -1483,7 +1483,7 @@ func DeleteSessionIfMatches(username string, loaded *AuthSession) (bool, error) 
 			sessionCompareDeleteBarrier()
 		}
 		deleted = true
-		return deleteMatchedSessionEntryLocked(selection, key, origin, current.UpdatedAt)
+		return deleteMatchedSessionEntryLocked(selection, key, origin, current.UpdatedAt, current.Generation)
 	})
 	return deleted, err
 }
@@ -1500,7 +1500,7 @@ func samePersistedSessionIdentity(current persistedSession, loaded *AuthSession)
 // that one carries the same stamp and is therefore the same proven-stale
 // session. Legacy artifacts are always cleared: nothing writes them any more,
 // so they can only hold a session at least as stale as the matched one.
-func deleteMatchedSessionEntryLocked(selection backendSelection, key string, origin sessionEntryOrigin, stamp time.Time) error {
+func deleteMatchedSessionEntryLocked(selection backendSelection, key string, origin sessionEntryOrigin, stamp time.Time, generation string) error {
 	var err error
 	switch origin {
 	case sessionEntryOriginFile:
@@ -1509,14 +1509,14 @@ func deleteMatchedSessionEntryLocked(selection backendSelection, key string, ori
 		} else {
 			err = clearLastKeyInFileIfMatches(key)
 		}
-		if sessionMirrorEnabled(selection) && keychainSessionCarriesStamp(key, stamp) {
+		if sessionMirrorEnabled(selection) && keychainSessionCarriesIdentity(key, stamp, generation) {
 			err = joinDeleteErrors(err, ignoreUnavailableKeyringError(deleteSessionFromKeychain(key)))
 		}
 	case sessionEntryOriginKeychain:
 		if deleteErr := deleteSessionFromKeychain(key); deleteErr != nil && (!selection.fallbackFile || !isKeyringUnavailable(deleteErr)) {
 			err = deleteErr
 		}
-		if sessionMirrorEnabled(selection) && fileSessionCarriesStamp(key, stamp) {
+		if sessionMirrorEnabled(selection) && fileSessionCarriesIdentity(key, stamp, generation) {
 			err = joinDeleteErrors(err, deleteMirroredSessionFromFile(key))
 		}
 	default:
@@ -1542,23 +1542,30 @@ func sessionMirrorEnabled(selection backendSelection) bool {
 // the matched one. An unreadable entry counts: it cannot be the valid
 // replacement this guard exists to protect, and leaving a corrupt file behind
 // only makes the next invocation fall back to a staler backend.
-func fileSessionCarriesStamp(key string, stamp time.Time) bool {
+func fileSessionCarriesIdentity(key string, stamp time.Time, generation string) bool {
 	sess, ok, err := readSessionFromFile(key)
 	if err != nil {
-		return true
+		return false
 	}
-	return ok && sess.UpdatedAt.Equal(stamp)
+	return ok && persistedSessionIdentityMatches(sess, stamp, generation)
 }
 
 // keychainSessionCarriesStamp reports whether the keychain entry is the same
 // session as the matched one. A keychain that cannot be read is left alone
 // rather than cleared blindly: unavailability says nothing about the entry.
-func keychainSessionCarriesStamp(key string, stamp time.Time) bool {
+func keychainSessionCarriesIdentity(key string, stamp time.Time, generation string) bool {
 	sess, ok, err := readSessionFromKeychain(key)
 	if err != nil {
 		return false
 	}
-	return ok && sess.UpdatedAt.Equal(stamp)
+	return ok && persistedSessionIdentityMatches(sess, stamp, generation)
+}
+
+func persistedSessionIdentityMatches(sess persistedSession, stamp time.Time, generation string) bool {
+	if generation != "" || sess.Generation != "" {
+		return generation != "" && sess.Generation != "" && generation == sess.Generation
+	}
+	return sess.UpdatedAt.Equal(stamp)
 }
 
 // DeleteAllSessions removes all cached web sessions.

--- a/internal/web/session_cache_test.go
+++ b/internal/web/session_cache_test.go
@@ -2636,6 +2636,7 @@ func TestDeleteSessionIfMatchesRemovesAMirrorCarryingTheSameStamp(t *testing.T) 
 
 	key := webSessionCacheKey("user@example.com")
 	mirror := webTestPersistedSession(t, "stale-token", loaded.cachedUpdatedAt)
+	mirror.Generation = loaded.cachedGeneration
 	if err := writeSessionToFile(key, mirror); err != nil {
 		t.Fatalf("writeSessionToFile error: %v", err)
 	}

--- a/internal/web/session_cache_test.go
+++ b/internal/web/session_cache_test.go
@@ -2654,3 +2654,15 @@ func TestDeleteSessionIfMatchesRemovesAMirrorCarryingTheSameStamp(t *testing.T) 
 		t.Fatalf("expected the identically stamped file mirror to be gone, ok=%v error=%v", ok, err)
 	}
 }
+
+func TestSerializeCookieJarAssignsUniqueGeneration(t *testing.T) {
+	jar := webTestSessionJar(t, "generation-token")
+	a := serializeCookieJar(jar, "user@example.com")
+	b := serializeCookieJar(jar, "user@example.com")
+	if a.Generation == "" || b.Generation == "" {
+		t.Fatal("expected non-empty session generations")
+	}
+	if a.Generation == b.Generation {
+		t.Fatalf("expected unique generations, got %q", a.Generation)
+	}
+}

--- a/internal/web/session_cache_test.go
+++ b/internal/web/session_cache_test.go
@@ -2659,7 +2659,7 @@ func TestDeleteSessionIfMatchesRemovesAMirrorCarryingTheSameStamp(t *testing.T) 
 func TestSerializeCookieJarAssignsUniqueGeneration(t *testing.T) {
 	jar := webTestSessionJar(t, "generation-token")
 	a := serializeCookieJar(jar, "user@example.com")
-	b := serializeCookieJar(jar, "user@example.com")
+	b := serializeCookieJar(jar, "other@example.com")
 	if a.Generation == "" || b.Generation == "" {
 		t.Fatal("expected non-empty session generations")
 	}
@@ -2700,6 +2700,15 @@ func TestPersistSessionConcurrentDifferentAppleIDsPreservesBothKeychainEntries(t
 		if stored.UserEmail != email {
 			t.Fatalf("stored wrong identity %q for %s", stored.UserEmail, email)
 		}
+	}
+}
+
+func TestSerializeCookieJarPropagatesGenerationFailure(t *testing.T) {
+	previous := sessionGenerationReader
+	sessionGenerationReader = func([]byte) (int, error) { return 0, errors.New("rng unavailable") }
+	t.Cleanup(func() { sessionGenerationReader = previous })
+	if _, err := serializeCookieJarWithError(webTestSessionJar(t, "token"), "user@example.com"); err == nil {
+		t.Fatal("expected generation failure")
 	}
 }
 

--- a/internal/web/session_cache_test.go
+++ b/internal/web/session_cache_test.go
@@ -2668,6 +2668,41 @@ func TestSerializeCookieJarAssignsUniqueGeneration(t *testing.T) {
 	}
 }
 
+func TestPersistSessionConcurrentDifferentAppleIDsPreservesBothKeychainEntries(t *testing.T) {
+	withArraySessionKeyring(t)
+	t.Setenv(webSessionCacheEnabledEnv, "1")
+	t.Setenv(webSessionBackendEnv, "keychain")
+	t.Setenv(webSessionCacheDirEnv, filepath.Join(t.TempDir(), "web-cache"))
+
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	for _, tc := range []struct{ email, token string }{
+		{email: "first@example.com", token: "first-token"},
+		{email: "second@example.com", token: "second-token"},
+	} {
+		tc := tc
+		go func() {
+			<-start
+			errs <- PersistSession(&AuthSession{Client: &http.Client{Jar: webTestSessionJar(t, tc.token)}, UserEmail: tc.email})
+		}()
+	}
+	close(start)
+	for range 2 {
+		if err := <-errs; err != nil {
+			t.Fatalf("concurrent PersistSession error: %v", err)
+		}
+	}
+	for _, email := range []string{"first@example.com", "second@example.com"} {
+		stored, ok, err := readSessionFromKeychain(webSessionCacheKey(email))
+		if err != nil || !ok {
+			t.Fatalf("expected %s to survive, ok=%v error=%v", email, ok, err)
+		}
+		if stored.UserEmail != email {
+			t.Fatalf("stored wrong identity %q for %s", stored.UserEmail, email)
+		}
+	}
+}
+
 func TestSamePersistedSessionIdentityRejectsDifferentGenerationSameTimestamp(t *testing.T) {
 	now := time.Now().UTC()
 	loaded := &AuthSession{cachedUpdatedAt: now, cachedGeneration: "old"}

--- a/internal/web/session_cache_test.go
+++ b/internal/web/session_cache_test.go
@@ -2667,3 +2667,18 @@ func TestSerializeCookieJarAssignsUniqueGeneration(t *testing.T) {
 		t.Fatalf("expected unique generations, got %q", a.Generation)
 	}
 }
+
+func TestSamePersistedSessionIdentityRejectsDifferentGenerationSameTimestamp(t *testing.T) {
+	now := time.Now().UTC()
+	loaded := &AuthSession{cachedUpdatedAt: now, cachedGeneration: "old"}
+	if samePersistedSessionIdentity(persistedSession{UpdatedAt: now, Generation: "new"}, loaded) {
+		t.Fatal("different generations must not match even with equal timestamps")
+	}
+}
+
+func TestSamePersistedSessionIdentityRejectsGeneratedLegacyPair(t *testing.T) {
+	now := time.Now().UTC()
+	if samePersistedSessionIdentity(persistedSession{UpdatedAt: now}, &AuthSession{cachedUpdatedAt: now, cachedGeneration: "generated"}) {
+		t.Fatal("generated and legacy sessions must not match")
+	}
+}

--- a/internal/web/session_lock.go
+++ b/internal/web/session_lock.go
@@ -49,7 +49,7 @@ func withSessionEntryLock(key string, fn func() error) error {
 func withSessionStoreLock(fn func() error) error {
 	dir := strings.TrimSpace(sessionSharedLockRoot())
 	if dir == "" {
-		return fn()
+		return errSessionStoreLockUnavailable
 	}
 	path := filepath.Join(dir, sessionSharedLockDirName(), "store.lock")
 	if release, ok := acquireSharedSessionLockFile(path); ok {

--- a/internal/web/session_lock.go
+++ b/internal/web/session_lock.go
@@ -23,13 +23,11 @@ import (
 // item. Holding whichever anchors can be created makes those processes exclude
 // each other as long as either anchor is shared.
 //
-// The lock is advisory and best effort by design. Acquisition is bounded, a
-// lock left behind by a killed process remains harmless because advisory locks
-// are released when descriptors close, and any failure to lock falls through
-// to the unlocked operation: refusing to persist or discard a session because
-// a lock file cannot be created would turn a cache
-// optimization into an auth outage, and refusing to discard one would leave a
-// proven-stale jar to burn another 2FA code.
+// The lock is advisory and acquisition is bounded. A lock left behind by a
+// killed process remains harmless because advisory locks are released when
+// descriptors close. Store mutations fail closed when the shared lock cannot
+// be acquired, preventing an aggregate read-modify-write from racing another
+// process and silently dropping a different Apple ID's session.
 var (
 	errSessionLockHeld             = errors.New("session lock is held")
 	errSessionStoreLockUnavailable = errors.New("shared session-store lock unavailable")

--- a/internal/web/session_lock.go
+++ b/internal/web/session_lock.go
@@ -31,10 +31,11 @@ import (
 // optimization into an auth outage, and refusing to discard one would leave a
 // proven-stale jar to burn another 2FA code.
 var (
-	errSessionLockHeld      = errors.New("session lock is held")
-	sessionLockPollInterval = 2 * time.Millisecond
-	sessionLockWaitTimeout  = 2 * time.Second
-	sessionSharedLockRoot   = platformSessionLockRoot
+	errSessionLockHeld             = errors.New("session lock is held")
+	errSessionStoreLockUnavailable = errors.New("shared session-store lock unavailable")
+	sessionLockPollInterval        = 2 * time.Millisecond
+	sessionLockWaitTimeout         = 2 * time.Second
+	sessionSharedLockRoot          = platformSessionLockRoot
 )
 
 // withSessionEntryLock runs fn while holding the advisory lock for one cached
@@ -55,6 +56,8 @@ func withSessionStoreLock(fn func() error) error {
 	path := filepath.Join(dir, sessionSharedLockDirName(), "store.lock")
 	if release, ok := acquireSharedSessionLockFile(path); ok {
 		defer release()
+	} else {
+		return errSessionStoreLockUnavailable
 	}
 	return fn()
 }

--- a/internal/web/session_lock.go
+++ b/internal/web/session_lock.go
@@ -45,6 +45,20 @@ func withSessionEntryLock(key string, fn func() error) error {
 	return fn()
 }
 
+// withSessionStoreLock serializes read-modify-write operations on the single
+// aggregate keychain item shared by all Apple IDs.
+func withSessionStoreLock(fn func() error) error {
+	dir := strings.TrimSpace(sessionSharedLockRoot())
+	if dir == "" {
+		return fn()
+	}
+	path := filepath.Join(dir, sessionSharedLockDirName(), "store.lock")
+	if release, ok := acquireSharedSessionLockFile(path); ok {
+		defer release()
+	}
+	return fn()
+}
+
 // acquireSessionEntryLock takes the entry lock at every anchor that can be
 // locked and returns a release func for them. Anchors that cannot be taken are
 // skipped rather than reported: see the fail-open rationale above.

--- a/internal/web/session_lock_test.go
+++ b/internal/web/session_lock_test.go
@@ -25,6 +25,17 @@ func TestWithSessionStoreLockFailsClosedWhenLockUnavailable(t *testing.T) {
 	}
 }
 
+func TestWithSessionStoreLockFailsClosedWhenRootUnavailable(t *testing.T) {
+	previous := sessionSharedLockRoot
+	sessionSharedLockRoot = func() string { return "" }
+	t.Cleanup(func() { sessionSharedLockRoot = previous })
+	called := false
+	err := withSessionStoreLock(func() error { called = true; return nil })
+	if !errors.Is(err, errSessionStoreLockUnavailable) || called {
+		t.Fatalf("expected fail-closed root error, called=%v err=%v", called, err)
+	}
+}
+
 // The lock is what makes a compare-and-delete and a persist mutually
 // exclusive, so overlapping holders must be impossible.
 func TestWithSessionEntryLockExcludesConcurrentHolders(t *testing.T) {

--- a/internal/web/session_lock_test.go
+++ b/internal/web/session_lock_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -8,6 +9,17 @@ import (
 	"testing"
 	"time"
 )
+
+func TestWithSessionStoreLockFailsClosedWhenLockUnavailable(t *testing.T) {
+	previous := sessionSharedLockRoot
+	sessionSharedLockRoot = func() string { return t.TempDir() + "/blocked" }
+	t.Cleanup(func() { sessionSharedLockRoot = previous })
+	called := false
+	err := withSessionStoreLock(func() error { called = true; return nil })
+	if !errors.Is(err, errSessionStoreLockUnavailable) || called {
+		t.Fatalf("expected fail-closed lock error, called=%v err=%v", called, err)
+	}
+}
 
 // The lock is what makes a compare-and-delete and a persist mutually
 // exclusive, so overlapping holders must be impossible.

--- a/internal/web/session_lock_test.go
+++ b/internal/web/session_lock_test.go
@@ -12,7 +12,11 @@ import (
 
 func TestWithSessionStoreLockFailsClosedWhenLockUnavailable(t *testing.T) {
 	previous := sessionSharedLockRoot
-	sessionSharedLockRoot = func() string { return t.TempDir() + "/blocked" }
+	blocked := filepath.Join(t.TempDir(), "blocked")
+	if err := os.WriteFile(blocked, []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sessionSharedLockRoot = func() string { return blocked }
 	t.Cleanup(func() { sessionSharedLockRoot = previous })
 	called := false
 	err := withSessionStoreLock(func() error { called = true; return nil })


### PR DESCRIPTION
Closes #2367. Serializes aggregate keychain session-store mutations with the existing shared advisory lock and adds a per-write generation identity to conditional deletion, with backward-compatible timestamp fallback for imported/legacy entries. Focused internal/web tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session persistence reliability during concurrent sign-ins, sign-outs, and updates.
  - Prevented cleanup from removing newer or unrelated mirrored sessions.
  - Preserved mirrored session data when it cannot be safely validated.
  - Prevented session operations from overwriting newer sessions saved concurrently.
  - Ensured independently saved sessions remain uniquely identifiable for safer synchronization.
  - Improved compatibility when synchronizing sessions saved by older versions.
  - Prevented session operations from proceeding when the shared session lock is unavailable.
  - Propagated failures when a session cannot receive a secure identity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->