### PR TITLE
docs: add Victus to Wall of Apps

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1841,6 +1841,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/53/c3/b7/53c3b765-6630-5db0-a5f8-abf88f38d181/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Victus: Discipline & Habits",
+    "link": "https://apps.apple.com/us/app/victus-discipline-habits/id6754204999?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/cc/a6/0a/cca60a66-1e16-573f-043e-97f4c092a07d/AppIcon-0-0-1x_U007emarketing-0-11-0-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Video Annotation",
     "link": "https://apps.apple.com/us/app/video-annotation/id6758316355",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/43/c3/a9/43c3a9e9-e32b-081c-8a8b-a4f401846771/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
Adds [Victus: Discipline & Habits](https://apps.apple.com/us/app/victus-discipline-habits/id6754204999) to the Wall of Apps using public App Store metadata.

Validation: `python3 -m json.tool docs/wall-of-apps.json` and `git diff --check`.