### PR TITLE
ci: extend full-module lint timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ GO := go
 GOMOD := go.mod
 GOBIN := $(shell $(GO) env GOPATH)/bin
 GO_TOOLCHAIN_VERSION := $(shell $(GO) env GOVERSION)
-GOLANGCI_LINT_TIMEOUT ?= 10m
+# Cold hosted runners can require more than ten minutes for the full-module lint.
+GOLANGCI_LINT_TIMEOUT ?= 15m
 INSTALL_PREFIX ?= /usr/local/bin
 GOFUMPT_VERSION ?= v0.10.0
 GOLANGCI_LINT_VERSION ?= v2.12.1

--- a/scripts/test_ci_workflows.py
+++ b/scripts/test_ci_workflows.py
@@ -21,6 +21,13 @@ DEPENDABOT_CONFIG = ROOT / ".github/dependabot.yml"
 MAKEFILE = ROOT / "Makefile"
 
 
+def assert_lint_timeout_budget() -> None:
+    makefile = MAKEFILE.read_text()
+    match = re.search(r"^GOLANGCI_LINT_TIMEOUT \?= (\d+)m$", makefile, re.MULTILINE)
+    assert match, "Makefile must define the golangci-lint timeout in minutes"
+    assert int(match.group(1)) >= 15, "full-module lint needs at least a 15-minute cold-run budget"
+
+
 def assert_go_toolchain_source() -> None:
     workflow_dir = ROOT / ".github/workflows"
     workflows = sorted([*workflow_dir.glob("*.yml"), *workflow_dir.glob("*.yaml")])
@@ -756,6 +763,7 @@ def assert_security_target_contract() -> None:
 
 
 def main() -> None:
+    assert_lint_timeout_budget()
     assert_go_toolchain_source_accepts_normalized_scalars()
     assert_go_toolchain_source_rejects_step_local_violations()
     assert_go_toolchain_source()


### PR DESCRIPTION
Raise the default golangci-lint budget from 10 to 15 minutes for cold hosted runners. Recent unrelated PRs reached the 10-minute boundary after reporting zero issues, which failed the required quality aggregator despite every other parallel check passing.

Adds a CI contract assertion so the full-module budget cannot silently regress below 15 minutes.

Validation:
- `python3 scripts/test_ci_workflows.py`
- normal pre-commit hook: docs, format, lint, full short test suite