### PR TITLE
fix(rootfs): preserve identity guarantees during quarantine cleanup

### DIFF
--- a/internal/rootfs/identity_test.go
+++ b/internal/rootfs/identity_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -1905,8 +1906,8 @@ func TestRemoveFileIfSameIdentityRejectsInPlaceQuarantineWrite(t *testing.T) {
 	if !errors.Is(err, ErrQuarantineCleanupUncertain) {
 		t.Fatalf("RemoveFileIfSameIdentity() error = %v, want ErrQuarantineCleanupUncertain", err)
 	}
-	if errors.Is(err, ErrFileIdentityRemoved) {
-		t.Fatalf("RemoveFileIfSameIdentity() error = %v, must not claim the file was removed", err)
+	if !errors.Is(err, ErrFileIdentityRemoved) {
+		t.Fatalf("RemoveFileIfSameIdentity() error = %v, want removed sentinel while canonical path is absent", err)
 	}
 	if !wrote {
 		t.Fatal("quarantine removal seam was not invoked")
@@ -1920,5 +1921,113 @@ func TestRemoveFileIfSameIdentityRejectsInPlaceQuarantineWrite(t *testing.T) {
 	}
 	if got := mustRead(t, matches[0]); got != concurrent {
 		t.Fatalf("preserved quarantine content = %q, want the concurrent edit %q", got, concurrent)
+	}
+}
+
+func TestRemoveFileIfSameIdentityReportsRemovedAfterQuarantineCleanupFailure(t *testing.T) {
+	requireStrictIdentityPlatform(t)
+	dir := t.TempDir()
+	root := mustRoot(t, dir)
+	t.Cleanup(func() { _ = root.Close() })
+	path := filepath.Join(dir, "receipt.json")
+	if err := os.WriteFile(path, []byte("receipt"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	identity, err := root.CaptureFile("receipt.json")
+	if err != nil {
+		t.Fatalf("CaptureFile() error = %v", err)
+	}
+	var quarantineName string
+	root.beforeConditionalQuarantineRemovalForTest = func(parent *os.Root, name string) {
+		quarantineName = name
+		file, openErr := parent.OpenFile(name, os.O_WRONLY, 0)
+		if openErr != nil {
+			t.Fatalf("open quarantined file: %v", openErr)
+		}
+		if chmodErr := file.Chmod(0o640); chmodErr != nil {
+			_ = file.Close()
+			t.Fatalf("change quarantined file mode: %v", chmodErr)
+		}
+		if closeErr := file.Close(); closeErr != nil {
+			t.Fatalf("close changed quarantine: %v", closeErr)
+		}
+	}
+
+	err = root.RemoveFileIfSameIdentity("receipt.json", identity)
+	if !errors.Is(err, ErrQuarantineCleanupUncertain) {
+		t.Fatalf("RemoveFileIfSameIdentity() error = %v, want quarantine uncertainty", err)
+	}
+	if !errors.Is(err, ErrFileIdentityRemoved) {
+		t.Fatalf("RemoveFileIfSameIdentity() error = %v, want removed sentinel after canonical absence", err)
+	}
+	if _, statErr := os.Lstat(path); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("destination after cleanup failure = %v, want absent", statErr)
+	}
+	if quarantineName == "" {
+		t.Fatal("quarantine cleanup hook did not capture the random name")
+	}
+	quarantinePath := filepath.Join(dir, quarantineName)
+	quarantineInfo, statErr := os.Stat(quarantinePath)
+	if statErr != nil {
+		t.Fatalf("stat preserved quarantine: %v", statErr)
+	}
+	if got := quarantineInfo.Mode().Perm(); got != 0o640 {
+		t.Fatalf("preserved quarantine mode = %o, want changed mode 640", got)
+	}
+	if !strings.Contains(err.Error(), quarantineName) {
+		t.Fatalf("cleanup error = %v, want quarantine name %q", err, quarantineName)
+	}
+}
+
+func TestRemoveFileIfSameIdentityDoesNotReportRemovedWhenCleanupReplacementAppears(t *testing.T) {
+	requireStrictIdentityPlatform(t)
+	dir := t.TempDir()
+	root := mustRoot(t, dir)
+	t.Cleanup(func() { _ = root.Close() })
+	path := filepath.Join(dir, "receipt.json")
+	if err := os.WriteFile(path, []byte("receipt"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "replacement"), []byte("replacement"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	identity, err := root.CaptureFile("receipt.json")
+	if err != nil {
+		t.Fatalf("CaptureFile() error = %v", err)
+	}
+	var quarantineName string
+	root.beforeConditionalQuarantineRemovalForTest = func(parent *os.Root, name string) {
+		quarantineName = name
+		file, openErr := parent.OpenFile(name, os.O_WRONLY, 0)
+		if openErr != nil {
+			t.Fatalf("open quarantined file: %v", openErr)
+		}
+		if chmodErr := file.Chmod(0o640); chmodErr != nil {
+			_ = file.Close()
+			t.Fatalf("change quarantined file mode: %v", chmodErr)
+		}
+		if closeErr := file.Close(); closeErr != nil {
+			t.Fatalf("close changed quarantine: %v", closeErr)
+		}
+		if renameErr := parent.Rename("replacement", "receipt.json"); renameErr != nil {
+			t.Fatalf("install replacement receipt: %v", renameErr)
+		}
+	}
+
+	err = root.RemoveFileIfSameIdentity("receipt.json", identity)
+	if !errors.Is(err, ErrQuarantineCleanupUncertain) {
+		t.Fatalf("RemoveFileIfSameIdentity() error = %v, want quarantine uncertainty", err)
+	}
+	if errors.Is(err, ErrFileIdentityRemoved) {
+		t.Fatalf("RemoveFileIfSameIdentity() error = %v, must not claim the replacement was removed", err)
+	}
+	if got := mustRead(t, path); got != "replacement" {
+		t.Fatalf("replacement receipt = %q, want preserved replacement", got)
+	}
+	if quarantineName == "" {
+		t.Fatal("quarantine cleanup hook did not capture the random name")
+	}
+	if got := mustRead(t, filepath.Join(dir, quarantineName)); got != "receipt" {
+		t.Fatalf("preserved quarantine = %q, want original receipt", got)
 	}
 }

--- a/internal/rootfs/rootfs.go
+++ b/internal/rootfs/rootfs.go
@@ -1811,8 +1811,26 @@ func (r Root) RemoveFileIfSameIdentity(name string, expected *FileIdentity) (res
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return errors.Join(err, r.restoreExpectedQuarantine(parent, quarantineName, base, expected, err))
 	}
-	if err := r.removeExpectedIdentityQuarantine(parent, quarantineName, expected); err != nil {
-		return err
+	if cleanupErr := r.removeExpectedIdentityQuarantine(parent, quarantineName, expected); cleanupErr != nil {
+		// Cleanup deliberately leaves the quarantine in place when its final
+		// identity check is uncertain. A fresh observation of the canonical
+		// pathname distinguishes a removed receipt, which permits callers to
+		// roll back earlier writes, from a replacement that must be preserved.
+		_, destinationErr := parent.Lstat(base)
+		switch {
+		case destinationErr == nil:
+			return errors.Join(
+				fmt.Errorf("%w: destination was replaced while cleaning up the expected file", ErrFileIdentityChanged),
+				cleanupErr,
+			)
+		case errors.Is(destinationErr, os.ErrNotExist):
+			return errors.Join(ErrFileIdentityRemoved, cleanupErr)
+		default:
+			return errors.Join(
+				cleanupErr,
+				fmt.Errorf("verify destination after quarantine cleanup: %w", destinationErr),
+			)
+		}
 	}
 	removed = true
 	syncErr := r.syncConditionalParentDirectory(parent)
@@ -2791,7 +2809,7 @@ func (r Root) removeExpectedQuarantine(parent *os.Root, quarantineName string, e
 		_ = file.Close()
 		return fmt.Errorf("recheck quarantined file before removal: %w", err)
 	}
-	if !os.SameFile(info, latest) || latest.Mode().Perm() != info.Mode().Perm() {
+	if !os.SameFile(info, latest) || latest.Mode() != info.Mode() || latest.Mode() != expected.Mode() {
 		_ = file.Close()
 		return fmt.Errorf("quarantined file identity changed before removal")
 	}

--- a/internal/rootfs/rootfs_test.go
+++ b/internal/rootfs/rootfs_test.go
@@ -1468,6 +1468,78 @@ func TestRemoveFileIfSamePreservesReplacementBetweenQuarantineCheckAndRemoval(t 
 	}
 }
 
+func TestLegacyConditionalMutationsRejectQuarantineModeDrift(t *testing.T) {
+	for _, testCase := range []struct {
+		name       string
+		invoke     func(Root, os.FileInfo) error
+		wantResult string
+	}{
+		{
+			name: "remove",
+			invoke: func(root Root, expected os.FileInfo) error {
+				return root.RemoveFileIfSame("settings.xcconfig", expected, []byte("old"))
+			},
+		},
+		{
+			name: "write",
+			invoke: func(root Root, expected os.FileInfo) error {
+				return root.WriteFileIfSame("settings.xcconfig", []byte("new"), 0o640, expected, []byte("old"), true)
+			},
+			wantResult: "new",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			dir := t.TempDir()
+			root := mustRoot(t, dir)
+			t.Cleanup(func() { _ = root.Close() })
+			path := filepath.Join(dir, "settings.xcconfig")
+			if err := os.WriteFile(path, []byte("old"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			expected, err := os.Stat(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var quarantineName string
+			root.openExpectedFileForTest = func(parent *os.Root, name string, expected os.FileInfo, expectedData []byte) (*os.File, os.FileInfo, error) {
+				file, info, err := openExpectedRootedFile(parent, name, expected, expectedData)
+				if err != nil || name == "settings.xcconfig" {
+					return file, info, err
+				}
+				quarantineName = name
+				if err := file.Chmod(0o640); err != nil {
+					_ = file.Close()
+					t.Fatalf("chmod quarantined file: %v", err)
+				}
+				return file, info, nil
+			}
+
+			err = testCase.invoke(root, expected)
+			if err == nil {
+				t.Fatal("legacy conditional mutation succeeded after quarantine mode drift")
+			}
+			if quarantineName == "" {
+				t.Fatal("quarantine mode race hook did not observe a quarantine entry")
+			}
+			quarantinePath := filepath.Join(dir, quarantineName)
+			quarantineInfo, statErr := os.Stat(quarantinePath)
+			if statErr != nil {
+				t.Fatalf("stat preserved quarantine: %v", statErr)
+			}
+			if got := quarantineInfo.Mode().Perm(); got != 0o640 {
+				t.Fatalf("preserved quarantine mode = %o, want drifted mode 640", got)
+			}
+			if testCase.wantResult == "" {
+				if _, statErr := os.Lstat(path); !errors.Is(statErr, os.ErrNotExist) {
+					t.Fatalf("removed destination = %v, want absent", statErr)
+				}
+			} else if got := mustRead(t, path); got != testCase.wantResult {
+				t.Fatalf("published destination = %q, want %q", got, testCase.wantResult)
+			}
+		})
+	}
+}
+
 func TestWriteFileIfSameClosesStagingBeforePublication(t *testing.T) {
 	dir := t.TempDir()
 	root := mustRoot(t, dir)

--- a/internal/rootfs/rootfs_test.go
+++ b/internal/rootfs/rootfs_test.go
@@ -1469,6 +1469,9 @@ func TestRemoveFileIfSamePreservesReplacementBetweenQuarantineCheckAndRemoval(t 
 }
 
 func TestLegacyConditionalMutationsRejectQuarantineModeDrift(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits beyond owner-writable are unsupported on Windows; 0600 and 0640 both report as writable")
+	}
 	for _, testCase := range []struct {
 		name       string
 		invoke     func(Root, os.FileInfo) error

--- a/internal/xcode/version_structured_test.go
+++ b/internal/xcode/version_structured_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -2591,6 +2592,146 @@ func TestStructuredVersion_ReceiptCleanupReplacementKeepsEarlierWrites(t *testin
 	}
 	if replacementInfo == nil || !os.SameFile(replacementInfo, finalReceiptInfo) {
 		t.Fatal("replacement receipt inode was not preserved")
+	}
+}
+
+func TestStructuredVersion_QuarantineCleanupFailureAfterCanonicalAbsenceRollsBackEarlierWrites(t *testing.T) {
+	requireStrictVersionMutationPlatform(t)
+	root := t.TempDir()
+	path := filepath.Join(root, "settings.xcconfig")
+	receiptPath := filepath.Join(root, "receipt.json")
+	if err := os.WriteFile(path, []byte("old"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	injectedErr := errors.New("injected post-publication receipt failure")
+	originalCreator := atomicCreateVersionFileFn
+	atomicCreateVersionFileFn = func(write preparedVersionWrite, data []byte) (*rootfs.FileIdentity, error) {
+		identity, err := originalCreator(write, data)
+		if err != nil || !write.createOnly {
+			return identity, err
+		}
+		return identity, injectedErr
+	}
+	t.Cleanup(func() { atomicCreateVersionFileFn = originalCreator })
+
+	originalRemover := removeCreatedVersionFileFn
+	removeCreatedVersionFileFn = func(write preparedVersionWrite) error {
+		if err := os.Remove(write.path); err != nil {
+			t.Fatalf("remove canonical receipt: %v", err)
+		}
+		quarantinePath := filepath.Join(root, ".asc-tmp-rollback-receipt")
+		if err := os.WriteFile(quarantinePath, write.updated, 0o600); err != nil {
+			t.Fatalf("preserve receipt quarantine: %v", err)
+		}
+		return errors.Join(
+			rootfs.ErrQuarantineCleanupUncertain,
+			rootfs.ErrFileIdentityRemoved,
+			fmt.Errorf("quarantined file %q was left in place", quarantinePath),
+		)
+	}
+	t.Cleanup(func() { removeCreatedVersionFileFn = originalRemover })
+
+	fileRoot, err := rootfs.New(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalIdentity, err := fileRoot.CaptureFile(filepath.Base(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	receiptRoot, err := rootfs.New(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = commitVersionWrites([]preparedVersionWrite{
+		{path: path, root: fileRoot, name: filepath.Base(path), original: []byte("old"), updated: []byte("new"), mode: 0o640, preserveMetadata: true, originalIdentity: originalIdentity, strictIdentity: true},
+		{path: receiptPath, root: receiptRoot, name: filepath.Base(receiptPath), updated: []byte("receipt"), mode: 0o600, createOnly: true},
+	})
+	if !errors.Is(err, injectedErr) || !errors.Is(err, rootfs.ErrQuarantineCleanupUncertain) || !errors.Is(err, rootfs.ErrFileIdentityRemoved) {
+		t.Fatalf("commitVersionWrites() error = %v, want receipt cleanup failure with removed sentinel", err)
+	}
+	if got := mustReadVersionTestFile(t, path); got != "old" {
+		t.Fatalf("ordinary write after absent receipt cleanup failure = %q, want old", got)
+	}
+	if _, statErr := os.Lstat(receiptPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("canonical receipt after cleanup failure = %v, want absent", statErr)
+	}
+	if !strings.Contains(err.Error(), ".asc-tmp-rollback-receipt") {
+		t.Fatalf("cleanup error = %v, want quarantine evidence", err)
+	}
+}
+
+func TestStructuredVersion_QuarantineCleanupFailureWithReplacementKeepsEarlierWrites(t *testing.T) {
+	requireStrictVersionMutationPlatform(t)
+	root := t.TempDir()
+	path := filepath.Join(root, "settings.xcconfig")
+	receiptPath := filepath.Join(root, "receipt.json")
+	if err := os.WriteFile(path, []byte("old"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	injectedErr := errors.New("injected post-publication receipt failure")
+	originalCreator := atomicCreateVersionFileFn
+	atomicCreateVersionFileFn = func(write preparedVersionWrite, data []byte) (*rootfs.FileIdentity, error) {
+		identity, err := originalCreator(write, data)
+		if err != nil || !write.createOnly {
+			return identity, err
+		}
+		return identity, injectedErr
+	}
+	t.Cleanup(func() { atomicCreateVersionFileFn = originalCreator })
+
+	originalRemover := removeCreatedVersionFileFn
+	removeCreatedVersionFileFn = func(write preparedVersionWrite) error {
+		if err := os.Remove(write.path); err != nil {
+			t.Fatalf("remove transaction receipt: %v", err)
+		}
+		replacementPath := write.path + ".replacement"
+		if err := os.WriteFile(replacementPath, []byte("concurrent receipt"), 0o600); err != nil {
+			t.Fatalf("write replacement receipt: %v", err)
+		}
+		if err := os.Rename(replacementPath, write.path); err != nil {
+			t.Fatalf("install replacement receipt: %v", err)
+		}
+		quarantinePath := filepath.Join(root, ".asc-tmp-rollback-receipt")
+		if err := os.WriteFile(quarantinePath, write.updated, 0o600); err != nil {
+			t.Fatalf("preserve receipt quarantine: %v", err)
+		}
+		return errors.Join(
+			rootfs.ErrQuarantineCleanupUncertain,
+			fmt.Errorf("quarantined file %q was left in place", quarantinePath),
+		)
+	}
+	t.Cleanup(func() { removeCreatedVersionFileFn = originalRemover })
+
+	fileRoot, err := rootfs.New(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalIdentity, err := fileRoot.CaptureFile(filepath.Base(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	receiptRoot, err := rootfs.New(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = commitVersionWrites([]preparedVersionWrite{
+		{path: path, root: fileRoot, name: filepath.Base(path), original: []byte("old"), updated: []byte("new"), mode: 0o640, preserveMetadata: true, originalIdentity: originalIdentity, strictIdentity: true},
+		{path: receiptPath, root: receiptRoot, name: filepath.Base(receiptPath), updated: []byte("receipt"), mode: 0o600, createOnly: true},
+	})
+	if !errors.Is(err, injectedErr) || !errors.Is(err, rootfs.ErrQuarantineCleanupUncertain) || errors.Is(err, rootfs.ErrFileIdentityRemoved) {
+		t.Fatalf("commitVersionWrites() error = %v, want surviving replacement without removed sentinel", err)
+	}
+	if got := mustReadVersionTestFile(t, path); got != "new" {
+		t.Fatalf("ordinary write after replacement receipt cleanup failure = %q, want new", got)
+	}
+	if got := mustReadVersionTestFile(t, receiptPath); got != "concurrent receipt" {
+		t.Fatalf("replacement receipt = %q, want concurrent receipt", got)
+	}
+	if got := mustReadVersionTestFile(t, filepath.Join(root, ".asc-tmp-rollback-receipt")); got != "receipt" {
+		t.Fatalf("preserved receipt quarantine = %q, want transaction receipt", got)
 	}
 }
 


### PR DESCRIPTION
## Problem

The conditional rootfs mutation path moves a file into quarantine before it
removes or replaces the canonical entry. The legacy `os.FileInfo` adapter was
checking a fresh descriptor stat against a fresh directory-entry stat after
that move. A mode change made after quarantine could therefore pass the final
check and allow cleanup or publication even though the original identity
contract was no longer true.

Strict structured-version receipt cleanup had a separate ambiguity. If the
receipt had already moved to quarantine and cleanup then failed, rollback could
not tell whether the canonical path was still absent or whether another writer
had installed a replacement.

## Change

This change keeps the original expected mode attached to the quarantined
identity and compares the quarantined entry's final mode with that expectation
before unlinking or publishing. A mode drift now leaves the quarantine entry
available for recovery and returns the existing cleanup failure.

When strict receipt cleanup fails after quarantine, the code performs one fresh
canonical-path check. It exposes `ErrFileIdentityRemoved` only when that check
proves the canonical path is absent. If a replacement is present, the sentinel
is suppressed so structured-version rollback preserves the concurrent
replacement and the earlier project writes. Quarantine evidence remains
available when cleanup is uncertain.

The affected interfaces are the existing `rootfs.Root` methods
`RemoveFileIfSame`, `WriteFileIfSame`, and `RemoveFileIfSameIdentity`, together
with the existing xcode transaction rollback path. There is no new CLI command,
flag, Apple endpoint, request, response, or output shape.

## Compatibility and limits

Successful cleanup and publication keep their existing behavior. The
additional check only changes the result when the quarantined identity has
drifted or cleanup has an uncertain outcome. An unconditional
`ErrFileIdentityRemoved` would discard a concurrent replacement; treating
every cleanup failure as a surviving receipt would prevent rollback when the
receipt is actually gone. The fresh destination check keeps those cases
separate.

The portable path-based unlink interval remains the documented rootfs
limitation. This change does not use Apple accounts, browser state, signing
identities, or provider requests.

## Regression coverage

The full test gate covered these cases:

- `TestLegacyConditionalMutationsRejectQuarantineModeDrift`
- `TestRemoveFileIfSameIdentityReportsRemovedAfterQuarantineCleanupFailure`
- `TestRemoveFileIfSameIdentityDoesNotReportRemovedWhenCleanupReplacementAppears`
- `TestStructuredVersion_QuarantineCleanupFailureAfterCanonicalAbsenceRollsBackEarlierWrites`
- `TestStructuredVersion_QuarantineCleanupFailureWithReplacementKeepsEarlierWrites`

The mode-drift test exercises both legacy conditional mutation methods. The
strict cleanup tests distinguish an absent canonical path from a replacement
and assert that quarantine evidence and earlier writes are preserved as
required.

## Validation

The recorded repository gates all passed:

```bash
make build
make format
make check-docs
make lint
ASC_BYPASS_KEYCHAIN=1 make test
```

The test gate completed successfully in 323.07 seconds. The final committed
review of head `1eb482b31bb9f7d90be2eef7edcb197582643a13` against `main` at
`7d78e32ef7fc3393750ff1573589db8a42bcf438` reported no actionable
correctness issue. That review ran in a read-only sandbox and could not create
Go's build directory for its own focused execution; the passing manager-owned
repository gate above is the executable test evidence.

Fixes #2365. Fixes #2374.
