### PR TITLE
fix(rootfs): detect ACL and extended attribute identity drift

### DIFF
--- a/docs/design/rootfs-identity-primitives.md
+++ b/docs/design/rootfs-identity-primitives.md
@@ -65,7 +65,11 @@ because a `chmod` of a special bit or a `chown` changes neither the ordinary
 permission bits nor the modification time. `preserveMetadata` would otherwise
 carry drifted ownership onto the replacement and silently drop the special
 bits. `preserveMetadata` deliberately preserves those special bits: after ACL/xattr copying and content writes, the complete source mode is reapplied immediately before publication. Access-control lists and extended attributes are copied from the
-identity-retained descriptor but are not yet part of the compared snapshot.
+identity-retained descriptor and are included in the bounded strict identity
+snapshot. Darwin and Linux strict verification re-reads descriptor-backed ACL
+and xattr digests before any entry move; legacy `FileInfo` adapters retain
+their prior compatibility boundary, and platforms without the descriptor
+metadata facilities do not claim this stronger check.
 
 The historical `os.FileInfo` methods remain compatibility adapters and do not
 inherit the strict 8 MiB input-snapshot limit. The existing `WithInfo` forms

--- a/internal/rootfs/metadata_identity.go
+++ b/internal/rootfs/metadata_identity.go
@@ -1,0 +1,83 @@
+package rootfs
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"hash"
+)
+
+// fileIdentityMetadataSizeLimit bounds the amount of filesystem metadata that
+// one identity capture will inspect. The retained identity stores only the
+// fixed-size digests below, but the bound also prevents a provider-controlled
+// xattr list or value from forcing an unbounded temporary allocation.
+const fileIdentityMetadataSizeLimit int64 = 1 << 20
+
+type fileIdentityMetadata struct {
+	acl    metadataDigest
+	xattrs metadataDigest
+}
+
+type metadataDigest struct {
+	supported bool
+	size      uint64
+	sum       [sha256.Size]byte
+}
+
+func (first metadataDigest) equal(second metadataDigest) bool {
+	return first.supported == second.supported &&
+		first.size == second.size && first.sum == second.sum
+}
+
+func sameFileIdentityMetadata(first, second fileIdentityMetadata) bool {
+	return first.acl.equal(second.acl) && first.xattrs.equal(second.xattrs)
+}
+
+func supportedEmptyMetadataDigest() metadataDigest {
+	return metadataDigest{supported: true, sum: sha256.Sum256(nil)}
+}
+
+func unsupportedMetadataDigest() metadataDigest {
+	return metadataDigest{}
+}
+
+func metadataDigestFromHash(hasher hash.Hash, size uint64) metadataDigest {
+	var sum [sha256.Size]byte
+	copy(sum[:], hasher.Sum(nil))
+	return metadataDigest{supported: true, size: size, sum: sum}
+}
+
+type boundedMetadataHasher struct {
+	hash hash.Hash
+	size uint64
+	kind string
+}
+
+func newBoundedMetadataHasher(kind string) *boundedMetadataHasher {
+	return &boundedMetadataHasher{
+		hash: sha256.New(),
+		kind: kind,
+	}
+}
+
+func (hasher *boundedMetadataHasher) append(data []byte) error {
+	if hasher.size > uint64(fileIdentityMetadataSizeLimit) ||
+		uint64(len(data)) > uint64(fileIdentityMetadataSizeLimit)-hasher.size {
+		return fmt.Errorf("%s exceeds %d-byte identity metadata limit: %w", hasher.kind, fileIdentityMetadataSizeLimit, ErrFileIdentityDataTooLarge)
+	}
+	if _, err := hasher.hash.Write(data); err != nil {
+		return fmt.Errorf("hash %s: %w", hasher.kind, err)
+	}
+	hasher.size += uint64(len(data))
+	return nil
+}
+
+func (hasher *boundedMetadataHasher) appendUint64(value uint64) error {
+	var encoded [8]byte
+	binary.BigEndian.PutUint64(encoded[:], value)
+	return hasher.append(encoded[:])
+}
+
+func (hasher *boundedMetadataHasher) digest() metadataDigest {
+	return metadataDigestFromHash(hasher.hash, hasher.size)
+}

--- a/internal/rootfs/metadata_identity_darwin.go
+++ b/internal/rootfs/metadata_identity_darwin.go
@@ -1,0 +1,110 @@
+//go:build darwin
+
+package rootfs
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"syscall"
+	"unsafe"
+)
+
+const darwinACLTypeExtended = 0x100
+
+func captureFileIdentityACL(file *os.File) (metadataDigest, error) {
+	aclRef, _, errno := metadataSyscallPtrCall(
+		libcACLGetFdNpIdentityTrampolineAddr,
+		file.Fd(),
+		darwinACLTypeExtended,
+		0,
+	)
+	runtime.KeepAlive(file)
+	if aclRef == 0 {
+		if errno == 0 || errors.Is(errno, syscall.ENOENT) {
+			return supportedEmptyMetadataDigest(), nil
+		}
+		if metadataOperationUnsupported(errno) {
+			return unsupportedMetadataDigest(), nil
+		}
+		return metadataDigest{}, fmt.Errorf("read file identity access control list: %w", errno)
+	}
+	defer func() {
+		_, _, _ = syscall6(
+			libcACLFreeIdentityTrampolineAddr,
+			aclRef,
+			0,
+			0,
+			0,
+			0,
+			0,
+		)
+	}()
+
+	rawSize, _, errno := syscall6(
+		libcACLSizeIdentityTrampolineAddr,
+		aclRef,
+		0,
+		0,
+		0,
+		0,
+		0,
+	)
+	size := int64(rawSize)
+	if size < 0 {
+		if errno == 0 {
+			errno = syscall.EINVAL
+		}
+		return metadataDigest{}, fmt.Errorf("inspect file identity access control list size: %w", errno)
+	}
+	if size > fileIdentityMetadataSizeLimit {
+		return metadataDigest{}, fmt.Errorf("access control list exceeds %d-byte identity metadata limit: %w", fileIdentityMetadataSizeLimit, ErrFileIdentityDataTooLarge)
+	}
+	if size == 0 {
+		return supportedEmptyMetadataDigest(), nil
+	}
+	serialized := make([]byte, size)
+	copiedRaw, _, errno := syscall6(
+		libcACLCopyExtIdentityTrampolineAddr,
+		uintptr(unsafe.Pointer(&serialized[0])),
+		aclRef,
+		uintptr(size),
+		0,
+		0,
+		0,
+	)
+	copied := int64(copiedRaw)
+	if copied < 0 {
+		if errno == 0 {
+			errno = syscall.EINVAL
+		}
+		return metadataDigest{}, fmt.Errorf("serialize file identity access control list: %w", errno)
+	}
+	if copied != size {
+		return metadataDigest{}, fmt.Errorf("serialize file identity access control list returned %d bytes, want %d", copied, size)
+	}
+	hasher := newBoundedMetadataHasher("file identity access control list")
+	if err := hasher.append([]byte("asc-rootfs-darwin-acl\x00")); err != nil {
+		return metadataDigest{}, err
+	}
+	if err := hasher.append(serialized); err != nil {
+		return metadataDigest{}, err
+	}
+	return hasher.digest(), nil
+}
+
+var (
+	libcACLGetFdNpIdentityTrampolineAddr uintptr
+	libcACLFreeIdentityTrampolineAddr    uintptr
+	libcACLSizeIdentityTrampolineAddr    uintptr
+	libcACLCopyExtIdentityTrampolineAddr uintptr
+)
+
+//go:cgo_import_dynamic libc_acl_get_fd_np_identity acl_get_fd_np "/usr/lib/libSystem.B.dylib"
+//go:cgo_import_dynamic libc_acl_free_identity acl_free "/usr/lib/libSystem.B.dylib"
+//go:cgo_import_dynamic libc_acl_size_identity acl_size "/usr/lib/libSystem.B.dylib"
+//go:cgo_import_dynamic libc_acl_copy_ext_identity acl_copy_ext "/usr/lib/libSystem.B.dylib"
+
+//go:linkname metadataSyscallPtrCall syscall.syscallPtr
+func metadataSyscallPtrCall(fn, a1, a2, a3 uintptr) (r1, r2 uintptr, err syscall.Errno)

--- a/internal/rootfs/metadata_identity_darwin_amd64.s
+++ b/internal/rootfs/metadata_identity_darwin_amd64.s
@@ -1,0 +1,21 @@
+#include "textflag.h"
+
+TEXT libc_acl_get_fd_np_identity_trampoline<>(SB),NOSPLIT,$0-0
+	JMP libc_acl_get_fd_np_identity(SB)
+GLOBL ·libcACLGetFdNpIdentityTrampolineAddr(SB), RODATA, $8
+DATA ·libcACLGetFdNpIdentityTrampolineAddr(SB)/8, $libc_acl_get_fd_np_identity_trampoline<>(SB)
+
+TEXT libc_acl_free_identity_trampoline<>(SB),NOSPLIT,$0-0
+	JMP libc_acl_free_identity(SB)
+GLOBL ·libcACLFreeIdentityTrampolineAddr(SB), RODATA, $8
+DATA ·libcACLFreeIdentityTrampolineAddr(SB)/8, $libc_acl_free_identity_trampoline<>(SB)
+
+TEXT libc_acl_size_identity_trampoline<>(SB),NOSPLIT,$0-0
+	JMP libc_acl_size_identity(SB)
+GLOBL ·libcACLSizeIdentityTrampolineAddr(SB), RODATA, $8
+DATA ·libcACLSizeIdentityTrampolineAddr(SB)/8, $libc_acl_size_identity_trampoline<>(SB)
+
+TEXT libc_acl_copy_ext_identity_trampoline<>(SB),NOSPLIT,$0-0
+	JMP libc_acl_copy_ext_identity(SB)
+GLOBL ·libcACLCopyExtIdentityTrampolineAddr(SB), RODATA, $8
+DATA ·libcACLCopyExtIdentityTrampolineAddr(SB)/8, $libc_acl_copy_ext_identity_trampoline<>(SB)

--- a/internal/rootfs/metadata_identity_darwin_arm64.s
+++ b/internal/rootfs/metadata_identity_darwin_arm64.s
@@ -1,0 +1,21 @@
+#include "textflag.h"
+
+TEXT libc_acl_get_fd_np_identity_trampoline<>(SB),NOSPLIT,$0-0
+	JMP libc_acl_get_fd_np_identity(SB)
+GLOBL ·libcACLGetFdNpIdentityTrampolineAddr(SB), RODATA, $8
+DATA ·libcACLGetFdNpIdentityTrampolineAddr(SB)/8, $libc_acl_get_fd_np_identity_trampoline<>(SB)
+
+TEXT libc_acl_free_identity_trampoline<>(SB),NOSPLIT,$0-0
+	JMP libc_acl_free_identity(SB)
+GLOBL ·libcACLFreeIdentityTrampolineAddr(SB), RODATA, $8
+DATA ·libcACLFreeIdentityTrampolineAddr(SB)/8, $libc_acl_free_identity_trampoline<>(SB)
+
+TEXT libc_acl_size_identity_trampoline<>(SB),NOSPLIT,$0-0
+	JMP libc_acl_size_identity(SB)
+GLOBL ·libcACLSizeIdentityTrampolineAddr(SB), RODATA, $8
+DATA ·libcACLSizeIdentityTrampolineAddr(SB)/8, $libc_acl_size_identity_trampoline<>(SB)
+
+TEXT libc_acl_copy_ext_identity_trampoline<>(SB),NOSPLIT,$0-0
+	JMP libc_acl_copy_ext_identity(SB)
+GLOBL ·libcACLCopyExtIdentityTrampolineAddr(SB), RODATA, $8
+DATA ·libcACLCopyExtIdentityTrampolineAddr(SB)/8, $libc_acl_copy_ext_identity_trampoline<>(SB)

--- a/internal/rootfs/metadata_identity_darwin_test.go
+++ b/internal/rootfs/metadata_identity_darwin_test.go
@@ -1,0 +1,91 @@
+//go:build darwin
+
+package rootfs
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCaptureFileIdentityMetadataDetectsDarwinACLDrift(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "acl.txt")
+	if err := os.WriteFile(path, []byte("acl"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	addDarwinIdentityACL(t, path, "everyone allow read")
+
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer file.Close()
+	before, err := captureFileIdentityMetadata(file)
+	if err != nil {
+		t.Fatalf("capture ACL before drift: %v", err)
+	}
+	if !before.acl.supported {
+		t.Fatal("ACL setup succeeded but capture reported unsupported metadata")
+	}
+	if before.acl.equal(supportedEmptyMetadataDigest()) {
+		t.Fatal("ACL setup did not produce a non-empty ACL snapshot")
+	}
+
+	addDarwinIdentityACL(t, path, "everyone allow write")
+	after, err := captureFileIdentityMetadata(file)
+	if err != nil {
+		t.Fatalf("capture ACL after drift: %v", err)
+	}
+	if sameFileIdentityMetadata(before, after) {
+		t.Fatal("ACL drift should compare unequal")
+	}
+	if before.acl.equal(after.acl) {
+		t.Fatal("ACL drift should change the ACL digest")
+	}
+}
+
+func TestStrictIdentityRejectsDarwinACLDriftBeforePublication(t *testing.T) {
+	requireStrictIdentityPlatform(t)
+	dir := t.TempDir()
+	root := mustRoot(t, dir)
+	t.Cleanup(func() { _ = root.Close() })
+	path := filepath.Join(dir, "acl.txt")
+	const original = "acl"
+	if err := os.WriteFile(path, []byte(original), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	identity, err := root.CaptureFile("acl.txt")
+	if err != nil {
+		t.Fatalf("CaptureFile() error = %v", err)
+	}
+	addDarwinIdentityACL(t, path, "everyone allow read")
+
+	installed, err := root.ReplaceFileIfSame("acl.txt", identity, []byte("replacement"), 0o640, true)
+	if installed != nil {
+		t.Fatal("ReplaceFileIfSame() returned an identity after ACL drift")
+	}
+	if !errors.Is(err, ErrFileIdentityChanged) {
+		t.Fatalf("ReplaceFileIfSame() error = %v, want ErrFileIdentityChanged", err)
+	}
+	if got := mustRead(t, path); got != original {
+		t.Fatalf("source after ACL drift = %q, want %q", got, original)
+	}
+}
+
+func addDarwinIdentityACL(t *testing.T, path, entry string) {
+	t.Helper()
+	output, err := exec.Command("chmod", "+a", entry, path).CombinedOutput()
+	if err == nil {
+		return
+	}
+	message := strings.ToLower(string(output))
+	if strings.Contains(message, "operation not supported") || strings.Contains(message, "not supported") {
+		t.Skipf("Darwin ACLs are unavailable on this filesystem: %v", err)
+	}
+	t.Fatalf("add Darwin ACL %q: %v\n%s", entry, err, output)
+}

--- a/internal/rootfs/metadata_identity_linux.go
+++ b/internal/rootfs/metadata_identity_linux.go
@@ -1,0 +1,54 @@
+//go:build linux
+
+package rootfs
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+const linuxPOSIXACLAccessIdentityAttribute = "system.posix_acl_access"
+
+func captureFileIdentityACL(file *os.File) (metadataDigest, error) {
+	fd := int(file.Fd())
+	size, err := unix.Fgetxattr(fd, linuxPOSIXACLAccessIdentityAttribute, nil)
+	if err != nil {
+		if errors.Is(err, unix.ENODATA) {
+			return supportedEmptyMetadataDigest(), nil
+		}
+		if metadataOperationUnsupported(err) {
+			return unsupportedMetadataDigest(), nil
+		}
+		return metadataDigest{}, fmt.Errorf("read file identity POSIX access ACL size: %w", err)
+	}
+	if size < 0 {
+		return metadataDigest{}, fmt.Errorf("read file identity POSIX access ACL returned negative size %d", size)
+	}
+	if int64(size) > fileIdentityMetadataSizeLimit {
+		return metadataDigest{}, fmt.Errorf("POSIX access ACL exceeds %d-byte identity metadata limit: %w", fileIdentityMetadataSizeLimit, ErrFileIdentityDataTooLarge)
+	}
+	value := make([]byte, size)
+	if size > 0 {
+		readSize, err := unix.Fgetxattr(fd, linuxPOSIXACLAccessIdentityAttribute, value)
+		if err != nil {
+			if metadataOperationUnsupported(err) {
+				return unsupportedMetadataDigest(), nil
+			}
+			return metadataDigest{}, fmt.Errorf("read file identity POSIX access ACL: %w", err)
+		}
+		if readSize != size {
+			return metadataDigest{}, fmt.Errorf("read file identity POSIX access ACL returned %d bytes, want %d", readSize, size)
+		}
+	}
+	hasher := newBoundedMetadataHasher("file identity POSIX access ACL")
+	if err := hasher.append([]byte("asc-rootfs-posix-acl-access\x00")); err != nil {
+		return metadataDigest{}, err
+	}
+	if err := hasher.append(value); err != nil {
+		return metadataDigest{}, err
+	}
+	return hasher.digest(), nil
+}

--- a/internal/rootfs/metadata_identity_linux_test.go
+++ b/internal/rootfs/metadata_identity_linux_test.go
@@ -1,0 +1,134 @@
+//go:build linux
+
+package rootfs
+
+import (
+	"encoding/binary"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestCaptureFileIdentityMetadataDetectsLinuxACLDrift(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "acl.txt")
+	if err := os.WriteFile(path, []byte("acl"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	file, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("OpenFile() error = %v", err)
+	}
+	defer file.Close()
+	setLinuxIdentityACL(t, file, 4)
+
+	before, err := captureFileIdentityMetadata(file)
+	if err != nil {
+		t.Fatalf("capture ACL before drift: %v", err)
+	}
+	if !before.acl.supported {
+		t.Fatal("ACL setup succeeded but capture reported unsupported metadata")
+	}
+	if before.acl.equal(supportedEmptyMetadataDigest()) {
+		t.Fatal("ACL setup did not produce a non-empty ACL snapshot")
+	}
+
+	setLinuxIdentityACL(t, file, 2)
+	after, err := captureFileIdentityMetadata(file)
+	if err != nil {
+		t.Fatalf("capture ACL after drift: %v", err)
+	}
+	if sameFileIdentityMetadata(before, after) {
+		t.Fatal("ACL drift should compare unequal")
+	}
+	if before.acl.equal(after.acl) {
+		t.Fatal("ACL drift should change the ACL digest")
+	}
+}
+
+func TestStrictIdentityRejectsLinuxACLDriftBeforePublication(t *testing.T) {
+	requireStrictIdentityPlatform(t)
+	dir := t.TempDir()
+	root := mustRoot(t, dir)
+	t.Cleanup(func() { _ = root.Close() })
+	path := filepath.Join(dir, "acl.txt")
+	const original = "acl"
+	if err := os.WriteFile(path, []byte(original), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	identity, err := root.CaptureFile("acl.txt")
+	if err != nil {
+		t.Fatalf("CaptureFile() error = %v", err)
+	}
+	file, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("OpenFile() error = %v", err)
+	}
+	defer file.Close()
+	setLinuxIdentityACL(t, file, 4)
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	installed, err := root.ReplaceFileIfSame("acl.txt", identity, []byte("replacement"), 0o640, true)
+	if installed != nil {
+		t.Fatal("ReplaceFileIfSame() returned an identity after ACL drift")
+	}
+	if !errors.Is(err, ErrFileIdentityChanged) {
+		t.Fatalf("ReplaceFileIfSame() error = %v, want ErrFileIdentityChanged", err)
+	}
+	if got := mustRead(t, path); got != original {
+		t.Fatalf("source after ACL drift = %q, want %q", got, original)
+	}
+}
+
+func setLinuxIdentityACL(t *testing.T, file *os.File, namedUserPermissions uint16) {
+	t.Helper()
+	err := unix.Fsetxattr(int(file.Fd()), linuxPOSIXACLAccessIdentityAttribute, linuxIdentityACLBlob(namedUserPermissions), 0)
+	if errors.Is(err, unix.ENOTSUP) || errors.Is(err, unix.EOPNOTSUPP) || errors.Is(err, unix.ENOSYS) {
+		t.Skipf("POSIX ACLs are unavailable on this filesystem: %v", err)
+	}
+	if err != nil {
+		t.Fatalf("set Linux POSIX access ACL: %v", err)
+	}
+	if size, err := unix.Fgetxattr(int(file.Fd()), linuxPOSIXACLAccessIdentityAttribute, nil); err != nil {
+		t.Fatalf("verify Linux POSIX access ACL: %v", err)
+	} else if size == 0 {
+		t.Fatal("Linux POSIX access ACL disappeared after setting it")
+	}
+}
+
+func linuxIdentityACLBlob(namedUserPermissions uint16) []byte {
+	const (
+		aclUserObj  = 0x01
+		aclUser     = 0x02
+		aclGroupObj = 0x04
+		aclMask     = 0x10
+		aclOther    = 0x20
+		undefinedID = 0xFFFFFFFF
+	)
+	blob := make([]byte, 4+5*8)
+	binary.LittleEndian.PutUint32(blob[0:4], 2)
+	entries := []struct {
+		tag  uint16
+		perm uint16
+		id   uint32
+	}{
+		{aclUserObj, 6, undefinedID},
+		{aclUser, namedUserPermissions, 12345},
+		{aclGroupObj, 0, undefinedID},
+		{aclMask, 4, undefinedID},
+		{aclOther, 0, undefinedID},
+	}
+	for index, entry := range entries {
+		offset := 4 + index*8
+		binary.LittleEndian.PutUint16(blob[offset:], entry.tag)
+		binary.LittleEndian.PutUint16(blob[offset+2:], entry.perm)
+		binary.LittleEndian.PutUint32(blob[offset+4:], entry.id)
+	}
+	return blob
+}

--- a/internal/rootfs/metadata_identity_other.go
+++ b/internal/rootfs/metadata_identity_other.go
@@ -1,0 +1,12 @@
+//go:build !darwin && !linux
+
+package rootfs
+
+import "os"
+
+// Other platforms do not expose a portable ACL/xattr descriptor API here. The
+// strict identity mutation path is already unavailable on Windows, and the
+// zero snapshot preserves the existing read-only identity behavior elsewhere.
+func captureFileIdentityMetadata(_ *os.File) (fileIdentityMetadata, error) {
+	return fileIdentityMetadata{}, nil
+}

--- a/internal/rootfs/metadata_identity_test.go
+++ b/internal/rootfs/metadata_identity_test.go
@@ -1,0 +1,39 @@
+package rootfs
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestMetadataHasherRejectsOversizeInput(t *testing.T) {
+	hasher := newBoundedMetadataHasher("test metadata")
+	oversize := make([]byte, fileIdentityMetadataSizeLimit+1)
+	if err := hasher.append(oversize); !errors.Is(err, ErrFileIdentityDataTooLarge) {
+		t.Fatalf("boundedMetadataHasher.append() error = %v, want ErrFileIdentityDataTooLarge", err)
+	}
+}
+
+func TestSameFileIdentityMetadataComparesACLAndXattrs(t *testing.T) {
+	base := fileIdentityMetadata{
+		acl:    metadataDigest{supported: true, size: 1, sum: [32]byte{1}},
+		xattrs: metadataDigest{supported: true, size: 1, sum: [32]byte{2}},
+	}
+	if !sameFileIdentityMetadata(base, base) {
+		t.Fatal("identical metadata snapshots should compare equal")
+	}
+	changedACL := base
+	changedACL.acl.sum[0]++
+	if sameFileIdentityMetadata(base, changedACL) {
+		t.Fatal("ACL drift should compare unequal")
+	}
+	changedXattrs := base
+	changedXattrs.xattrs.sum[0]++
+	if sameFileIdentityMetadata(base, changedXattrs) {
+		t.Fatal("xattr drift should compare unequal")
+	}
+	unsupported := base
+	unsupported.xattrs.supported = false
+	if sameFileIdentityMetadata(base, unsupported) {
+		t.Fatal("supported to unsupported metadata transition should compare unequal")
+	}
+}

--- a/internal/rootfs/metadata_identity_unix.go
+++ b/internal/rootfs/metadata_identity_unix.go
@@ -1,0 +1,139 @@
+//go:build darwin || linux
+
+package rootfs
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+
+	"golang.org/x/sys/unix"
+)
+
+func captureFileIdentityMetadata(file *os.File) (fileIdentityMetadata, error) {
+	if file == nil {
+		return fileIdentityMetadata{}, fmt.Errorf("capture file identity metadata: nil descriptor")
+	}
+	acl, err := captureFileIdentityACL(file)
+	if err != nil {
+		return fileIdentityMetadata{}, err
+	}
+	xattrs, err := captureFileIdentityXattrs(file)
+	if err != nil {
+		return fileIdentityMetadata{}, err
+	}
+	return fileIdentityMetadata{acl: acl, xattrs: xattrs}, nil
+}
+
+func captureFileIdentityXattrs(file *os.File) (metadataDigest, error) {
+	fd := int(file.Fd())
+	size, err := unix.Flistxattr(fd, nil)
+	if err != nil {
+		if metadataOperationUnsupported(err) {
+			return unsupportedMetadataDigest(), nil
+		}
+		return metadataDigest{}, fmt.Errorf("list file identity extended attributes: %w", err)
+	}
+	if size < 0 {
+		return metadataDigest{}, fmt.Errorf("list file identity extended attributes returned negative size %d", size)
+	}
+	if int64(size) > fileIdentityMetadataSizeLimit {
+		return metadataDigest{}, fmt.Errorf("extended attribute names exceed %d-byte identity metadata limit: %w", fileIdentityMetadataSizeLimit, ErrFileIdentityDataTooLarge)
+	}
+	if size == 0 {
+		return supportedEmptyMetadataDigest(), nil
+	}
+	namesBuffer := make([]byte, size)
+	readSize, err := unix.Flistxattr(fd, namesBuffer)
+	if err != nil {
+		if metadataOperationUnsupported(err) {
+			return unsupportedMetadataDigest(), nil
+		}
+		return metadataDigest{}, fmt.Errorf("read file identity extended attribute names: %w", err)
+	}
+	if readSize != size {
+		return metadataDigest{}, fmt.Errorf("file identity extended attribute name list changed during capture: got %d bytes, want %d", readSize, size)
+	}
+	names, err := parseIdentityXattrNames(namesBuffer[:readSize])
+	if err != nil {
+		return metadataDigest{}, err
+	}
+
+	hasher := newBoundedMetadataHasher("file identity extended attributes")
+	if err := hasher.append([]byte("asc-rootfs-xattrs\x00")); err != nil {
+		return metadataDigest{}, err
+	}
+	for _, name := range names {
+		valueSize, err := unix.Fgetxattr(fd, name, nil)
+		if err != nil {
+			if metadataOperationUnsupported(err) {
+				return unsupportedMetadataDigest(), nil
+			}
+			return metadataDigest{}, fmt.Errorf("read file identity extended attribute %q size: %w", name, err)
+		}
+		if valueSize < 0 {
+			return metadataDigest{}, fmt.Errorf("read file identity extended attribute %q returned negative size %d", name, valueSize)
+		}
+		if err := hasher.appendUint64(uint64(len(name))); err != nil {
+			return metadataDigest{}, err
+		}
+		if err := hasher.append([]byte(name)); err != nil {
+			return metadataDigest{}, err
+		}
+		if err := hasher.appendUint64(uint64(valueSize)); err != nil {
+			return metadataDigest{}, err
+		}
+		if int64(valueSize) > fileIdentityMetadataSizeLimit-int64(hasher.size) {
+			return metadataDigest{}, fmt.Errorf("extended attribute %q exceeds %d-byte identity metadata limit: %w", name, fileIdentityMetadataSizeLimit, ErrFileIdentityDataTooLarge)
+		}
+		value := make([]byte, valueSize)
+		if valueSize > 0 {
+			readValueSize, err := unix.Fgetxattr(fd, name, value)
+			if err != nil {
+				if metadataOperationUnsupported(err) {
+					return unsupportedMetadataDigest(), nil
+				}
+				return metadataDigest{}, fmt.Errorf("read file identity extended attribute %q: %w", name, err)
+			}
+			if readValueSize != valueSize {
+				return metadataDigest{}, fmt.Errorf("read file identity extended attribute %q returned %d bytes, want %d", name, readValueSize, valueSize)
+			}
+		}
+		if err := hasher.append(value); err != nil {
+			return metadataDigest{}, fmt.Errorf("hash file identity extended attribute %q: %w", name, err)
+		}
+	}
+	return hasher.digest(), nil
+}
+
+func parseIdentityXattrNames(raw []byte) ([]string, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	if raw[len(raw)-1] != 0 {
+		return nil, fmt.Errorf("file identity extended attribute names are not NUL terminated")
+	}
+	parts := bytes.Split(raw, []byte{0})
+	names := make([]string, 0, len(parts)-1)
+	for _, part := range parts[:len(parts)-1] {
+		if len(part) == 0 {
+			return nil, fmt.Errorf("file identity extended attribute names contain an empty entry")
+		}
+		names = append(names, string(part))
+	}
+	sort.Strings(names)
+	for index := 1; index < len(names); index++ {
+		if names[index] == names[index-1] {
+			return nil, fmt.Errorf("file identity extended attribute names contain duplicate %q", names[index])
+		}
+	}
+	return names, nil
+}
+
+func metadataOperationUnsupported(err error) bool {
+	return errors.Is(err, unix.ENOTSUP) ||
+		errors.Is(err, unix.EOPNOTSUPP) ||
+		errors.Is(err, unix.ENOSYS)
+}

--- a/internal/rootfs/metadata_identity_unix_test.go
+++ b/internal/rootfs/metadata_identity_unix_test.go
@@ -1,0 +1,126 @@
+//go:build darwin || linux
+
+package rootfs
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestCaptureFileIdentityMetadataDetectsXattrDrift(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "metadata.txt")
+	if err := os.WriteFile(path, []byte("metadata"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	file, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer file.Close()
+	name := identityMetadataTestXattrName()
+	if err := unix.Fsetxattr(int(file.Fd()), name, []byte("before"), 0); err != nil {
+		if metadataOperationUnsupported(err) {
+			t.Skipf("extended attributes are unavailable on this filesystem: %v", err)
+		}
+		t.Fatalf("set test extended attribute: %v", err)
+	}
+
+	before, err := captureFileIdentityMetadata(file)
+	if err != nil {
+		t.Fatalf("capture metadata before drift: %v", err)
+	}
+	if !before.xattrs.supported {
+		t.Fatal("xattr setup succeeded but capture reported unsupported metadata")
+	}
+	unchanged, err := captureFileIdentityMetadata(file)
+	if err != nil {
+		t.Fatalf("capture unchanged metadata: %v", err)
+	}
+	if !sameFileIdentityMetadata(before, unchanged) {
+		t.Fatal("unchanged metadata should compare equal")
+	}
+
+	if err := unix.Fsetxattr(int(file.Fd()), name, []byte("after"), 0); err != nil {
+		t.Fatalf("change test extended attribute: %v", err)
+	}
+	after, err := captureFileIdentityMetadata(file)
+	if err != nil {
+		t.Fatalf("capture metadata after drift: %v", err)
+	}
+	if sameFileIdentityMetadata(before, after) {
+		t.Fatal("xattr value drift should compare unequal")
+	}
+	if before.xattrs.equal(after.xattrs) {
+		t.Fatal("xattr value drift should change the xattr digest")
+	}
+}
+
+func TestStrictIdentityRejectsXattrDriftBeforePublication(t *testing.T) {
+	requireStrictIdentityPlatform(t)
+	dir := t.TempDir()
+	root := mustRoot(t, dir)
+	t.Cleanup(func() { _ = root.Close() })
+	path := filepath.Join(dir, "metadata.txt")
+	const original = "metadata"
+	if err := os.WriteFile(path, []byte(original), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	identity, err := root.CaptureFile("metadata.txt")
+	if err != nil {
+		t.Fatalf("CaptureFile() error = %v", err)
+	}
+	file, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("OpenFile() error = %v", err)
+	}
+	if err := unix.Fsetxattr(int(file.Fd()), identityMetadataTestXattrName(), []byte("drift"), 0); err != nil {
+		_ = file.Close()
+		if metadataOperationUnsupported(err) {
+			t.Skipf("extended attributes are unavailable on this filesystem: %v", err)
+		}
+		t.Fatalf("set test extended attribute after capture: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	installed, err := root.ReplaceFileIfSame("metadata.txt", identity, []byte("replacement"), 0o640, true)
+	if installed != nil {
+		t.Fatal("ReplaceFileIfSame() returned an identity after xattr drift")
+	}
+	if !errors.Is(err, ErrFileIdentityChanged) {
+		t.Fatalf("ReplaceFileIfSame() error = %v, want ErrFileIdentityChanged", err)
+	}
+	if got := mustRead(t, path); got != original {
+		t.Fatalf("source after xattr drift = %q, want %q", got, original)
+	}
+}
+
+func identityMetadataTestXattrName() string {
+	if runtime.GOOS == "darwin" {
+		return "com.rork.asc-rootfs-identity-test"
+	}
+	return "user.asc-rootfs-identity-test"
+}
+
+func TestCaptureFileIdentityMetadataRejectsMalformedXattrNameList(t *testing.T) {
+	if _, err := parseIdentityXattrNames([]byte("user.test")); err == nil {
+		t.Fatal("unterminated xattr name list should fail closed")
+	}
+}
+
+func TestCaptureFileIdentityMetadataUnsupportedErrorClassification(t *testing.T) {
+	if !metadataOperationUnsupported(unix.ENOTSUP) || !metadataOperationUnsupported(unix.EOPNOTSUPP) || !metadataOperationUnsupported(unix.ENOSYS) {
+		t.Fatal("unsupported xattr errors should be classified as unsupported")
+	}
+	if metadataOperationUnsupported(unix.EPERM) || errors.Is(unix.EPERM, unix.ENOTSUP) {
+		t.Fatal("permission errors must not be treated as unsupported metadata")
+	}
+}

--- a/internal/rootfs/rootfs.go
+++ b/internal/rootfs/rootfs.go
@@ -196,6 +196,8 @@ type FileIdentity struct {
 	data              []byte
 	path              string
 	multipleHardLinks bool
+	metadata          fileIdentityMetadata
+	metadataCaptured  bool
 }
 
 // Info returns the captured file metadata snapshot. The snapshot is useful for
@@ -363,6 +365,10 @@ func (identity *rootIdentity) releaseFile(file *os.File) error {
 }
 
 func (identity *rootIdentity) retainIdentity(file *os.File, info os.FileInfo, data []byte, path string) (*FileIdentity, error) {
+	return identity.retainIdentityWithMetadata(file, info, data, path, fileIdentityMetadata{}, false)
+}
+
+func (identity *rootIdentity) retainIdentityWithMetadata(file *os.File, info os.FileInfo, data []byte, path string, metadata fileIdentityMetadata, metadataCaptured bool) (*FileIdentity, error) {
 	if file == nil || info == nil {
 		if file != nil {
 			_ = file.Close()
@@ -388,6 +394,8 @@ func (identity *rootIdentity) retainIdentity(file *os.File, info os.FileInfo, da
 		data:              bytes.Clone(data),
 		path:              filepath.Clean(path),
 		multipleHardLinks: multipleHardLinks,
+		metadata:          metadata,
+		metadataCaptured:  metadataCaptured,
 	}, nil
 }
 
@@ -423,6 +431,15 @@ func (identity *FileIdentity) validateOwner(owner *rootIdentity) error {
 	}
 	if currentMultipleLinks != identity.multipleHardLinks {
 		return fmt.Errorf("%w: file hard-link state changed", ErrFileIdentityChanged)
+	}
+	if identity.metadataCaptured {
+		currentMetadata, err := captureFileIdentityMetadata(identity.file)
+		if err != nil {
+			return errors.Join(ErrFileIdentityChanged, fmt.Errorf("capture current file identity metadata: %w", err))
+		}
+		if !sameFileIdentityMetadata(identity.metadata, currentMetadata) {
+			return fmt.Errorf("%w: file ACL or extended attributes changed", ErrFileIdentityChanged)
+		}
 	}
 	return nil
 }
@@ -1220,6 +1237,10 @@ func (r Root) CaptureFileLimited(name string, limit int64) (*FileIdentity, error
 	if err != nil {
 		return nil, fmt.Errorf("inspect captured file links: %w", err)
 	}
+	initialMetadata, err := captureFileIdentityMetadata(file)
+	if err != nil {
+		return nil, fmt.Errorf("capture file identity metadata: %w", err)
+	}
 	readSnapshot := func() ([]byte, error) {
 		if _, err := file.Seek(0, io.SeekStart); err != nil {
 			return nil, err
@@ -1244,6 +1265,10 @@ func (r Root) CaptureFileLimited(name string, limit int64) (*FileIdentity, error
 	if err != nil {
 		return nil, err
 	}
+	middleMetadata, err := captureFileIdentityMetadata(file)
+	if err != nil {
+		return nil, fmt.Errorf("recapture file identity metadata: %w", err)
+	}
 	verifiedData, err := readSnapshot()
 	if err != nil {
 		return nil, err
@@ -1251,6 +1276,10 @@ func (r Root) CaptureFileLimited(name string, limit int64) (*FileIdentity, error
 	finalInfo, err := file.Stat()
 	if err != nil {
 		return nil, err
+	}
+	finalMetadata, err := captureFileIdentityMetadata(file)
+	if err != nil {
+		return nil, fmt.Errorf("recapture final file identity metadata: %w", err)
 	}
 	finalMultipleLinks, err := hasMultipleHardLinks(file, finalInfo)
 	if err != nil {
@@ -1260,13 +1289,20 @@ func (r Root) CaptureFileLimited(name string, limit int64) (*FileIdentity, error
 	if err != nil {
 		return nil, errors.Join(ErrFileIdentityChanged, err)
 	}
+	rootedMetadata, err := captureFileIdentityMetadata(file)
+	if err != nil {
+		return nil, fmt.Errorf("recapture rooted file identity metadata: %w", err)
+	}
 	if rootedInfo.Mode()&os.ModeSymlink != 0 || !rootedInfo.Mode().IsRegular() ||
 		!sameFileIdentitySnapshot(info, middleInfo) || !sameFileIdentitySnapshot(middleInfo, finalInfo) ||
 		!sameFileIdentitySnapshot(finalInfo, rootedInfo) || initialMultipleLinks != finalMultipleLinks ||
+		!sameFileIdentityMetadata(initialMetadata, middleMetadata) ||
+		!sameFileIdentityMetadata(middleMetadata, finalMetadata) ||
+		!sameFileIdentityMetadata(finalMetadata, rootedMetadata) ||
 		!bytes.Equal(data, verifiedData) || finalInfo.Size() != int64(len(verifiedData)) {
 		return nil, fmt.Errorf("%w: %q changed during identity capture", ErrFileIdentityChanged, resolved)
 	}
-	identity, err := r.selectedIdentity.retainIdentity(file, finalInfo, verifiedData, resolved)
+	identity, err := r.selectedIdentity.retainIdentityWithMetadata(file, finalInfo, verifiedData, resolved, finalMetadata, true)
 	if err != nil {
 		return nil, err
 	}
@@ -1328,6 +1364,15 @@ func (r Root) CheckFileIdentity(name string, expected *FileIdentity) error {
 	latestMultipleLinks, latestLinksErr := hasMultipleHardLinks(file, latest)
 	if latestLinksErr != nil {
 		return errors.Join(ErrFileIdentityChanged, latestLinksErr, file.Close())
+	}
+	if expected.metadataCaptured {
+		latestMetadata, metadataErr := captureFileIdentityMetadata(file)
+		if metadataErr != nil {
+			return errors.Join(ErrFileIdentityChanged, fmt.Errorf("capture file identity metadata after verification: %w", metadataErr), file.Close())
+		}
+		if !sameFileIdentityMetadata(expected.metadata, latestMetadata) {
+			return errors.Join(ErrFileIdentityChanged, fmt.Errorf("file ACL or extended attributes changed after verification"), file.Close())
+		}
 	}
 	if latest.Mode()&os.ModeSymlink != 0 || !latest.Mode().IsRegular() ||
 		!sameFileIdentitySnapshot(info, latest) || latestMultipleLinks != expected.multipleHardLinks {
@@ -2075,6 +2120,7 @@ func (r Root) writeFileIfSame(
 		return nil, errors.Join(err, restoreQuarantine(quarantineName))
 	}
 	var temporaryInfo os.FileInfo
+	var temporaryMetadata fileIdentityMetadata
 	temporaryDone := false
 	temporaryClosed := false
 	temporaryRetained := false
@@ -2145,6 +2191,12 @@ func (r Root) writeFileIfSame(
 	if !temporaryInfo.Mode().IsRegular() {
 		return nil, errors.Join(fmt.Errorf("staging file is not regular"), restoreQuarantine(quarantineName))
 	}
+	if strictIdentity {
+		temporaryMetadata, err = captureFileIdentityMetadata(temporary)
+		if err != nil {
+			return nil, errors.Join(fmt.Errorf("capture staged file identity metadata: %w", err), restoreQuarantine(quarantineName))
+		}
+	}
 	// Ordinary non-identity writes do not return a publication identity, so
 	// close the staging descriptor before publication. If that close fails,
 	// the quarantine can still be restored. The identity-returning path keeps
@@ -2205,7 +2257,7 @@ func (r Root) writeFileIfSame(
 		if !retainPublishedIdentity || temporaryRetained || temporaryClosed || runtime.GOOS == "windows" || r.simulateWindowsCloseForTest {
 			return nil
 		}
-		installed, retainErr := r.selectedIdentity.retainIdentity(temporary, temporaryInfo, retainedData, resolved)
+		installed, retainErr := r.selectedIdentity.retainIdentityWithMetadata(temporary, temporaryInfo, retainedData, resolved, temporaryMetadata, strictIdentity)
 		if retainErr != nil {
 			temporaryClosed = true
 			return fmt.Errorf("retain staged file identity: %w", retainErr)
@@ -2268,6 +2320,14 @@ func (r Root) writeFileIfSame(
 		_ = publishedFile.Close()
 		return postPublicationIdentityFailure(fmt.Errorf("published file is not regular"))
 	}
+	var publishedMetadata fileIdentityMetadata
+	if strictIdentity {
+		publishedMetadata, err = captureFileIdentityMetadata(publishedFile)
+		if err != nil {
+			_ = publishedFile.Close()
+			return postPublicationIdentityFailure(fmt.Errorf("capture published file identity metadata: %w", err))
+		}
+	}
 	if (strictIdentity && !sameFileIdentitySnapshot(temporaryInfo, publishedStat)) ||
 		(!strictIdentity && !os.SameFile(temporaryInfo, publishedStat)) {
 		_ = publishedFile.Close()
@@ -2276,6 +2336,10 @@ func (r Root) writeFileIfSame(
 			changedErr = fmt.Errorf("%w: published file identity changed during publication", ErrFileIdentityChanged)
 		}
 		return postPublicationIdentityFailure(changedErr)
+	}
+	if strictIdentity && !sameFileIdentityMetadata(temporaryMetadata, publishedMetadata) {
+		_ = publishedFile.Close()
+		return postPublicationIdentityFailure(fmt.Errorf("%w: published file ACL or extended attributes changed during publication", ErrFileIdentityChanged))
 	}
 	var publishedContentErr error
 	var strictPublishedLinks bool
@@ -2317,6 +2381,13 @@ func (r Root) writeFileIfSame(
 	if err != nil {
 		return postPublicationIdentityFailure(fmt.Errorf("recheck published file: %w", err))
 	}
+	var latestMetadata fileIdentityMetadata
+	if strictIdentity {
+		latestMetadata, err = captureFileIdentityMetadata(publishedFile)
+		if err != nil {
+			return postPublicationIdentityFailure(fmt.Errorf("capture published file identity metadata after publication: %w", err))
+		}
+	}
 	latestMatches := os.SameFile(publishedStat, latestInfo)
 	if strictIdentity {
 		latestMatches = sameFileIdentitySnapshot(publishedStat, latestInfo)
@@ -2327,6 +2398,9 @@ func (r Root) writeFileIfSame(
 			changedErr = fmt.Errorf("%w: published file identity changed after publication", ErrFileIdentityChanged)
 		}
 		return postPublicationIdentityFailure(changedErr)
+	}
+	if strictIdentity && !sameFileIdentityMetadata(publishedMetadata, latestMetadata) {
+		return postPublicationIdentityFailure(fmt.Errorf("%w: published file ACL or extended attributes changed after publication", ErrFileIdentityChanged))
 	}
 	if strictIdentity {
 		// The final entry check must validate the complete retained snapshot, not
@@ -2342,12 +2416,18 @@ func (r Root) writeFileIfSame(
 		if linksErr != nil {
 			return postPublicationIdentityFailure(fmt.Errorf("inspect published file links after content verification: %w", linksErr))
 		}
+		finalPublishedMetadata, metadataErr := captureFileIdentityMetadata(publishedFile)
+		if metadataErr != nil {
+			return postPublicationIdentityFailure(fmt.Errorf("%w: capture published file identity metadata after content verification: %w", ErrFileIdentityChanged, metadataErr))
+		}
 		stagedLinks, linksErr := hasMultipleHardLinks(temporary, temporaryInfo)
 		if linksErr != nil {
 			return postPublicationIdentityFailure(fmt.Errorf("inspect staged file links after content verification: %w", linksErr))
 		}
 		if !sameFileIdentitySnapshot(publishedStat, finalPublishedInfo) ||
-			!sameFileIdentitySnapshot(finalPublishedInfo, latestInfo) || finalLinks != stagedLinks {
+			!sameFileIdentitySnapshot(finalPublishedInfo, latestInfo) || finalLinks != stagedLinks ||
+			!sameFileIdentityMetadata(publishedMetadata, finalPublishedMetadata) ||
+			!sameFileIdentityMetadata(finalPublishedMetadata, latestMetadata) {
 			return postPublicationIdentityFailure(fmt.Errorf("%w: published file metadata changed after content verification", ErrFileIdentityChanged))
 		}
 		if _, seekErr := publishedFile.Seek(0, io.SeekStart); seekErr != nil {
@@ -2374,6 +2454,13 @@ func (r Root) writeFileIfSame(
 		if finalRootedInfo.Mode()&os.ModeSymlink != 0 || !finalRootedInfo.Mode().IsRegular() ||
 			!sameFileIdentitySnapshot(finalPublishedInfo, finalRootedInfo) || rootedLinks != finalLinks {
 			return postPublicationIdentityFailure(fmt.Errorf("%w: published file changed after final content verification", ErrFileIdentityChanged))
+		}
+		finalRootedMetadata, metadataErr := captureFileIdentityMetadata(publishedFile)
+		if metadataErr != nil {
+			return postPublicationIdentityFailure(fmt.Errorf("%w: capture final published file identity metadata: %w", ErrFileIdentityChanged, metadataErr))
+		}
+		if !sameFileIdentityMetadata(finalPublishedMetadata, finalRootedMetadata) {
+			return postPublicationIdentityFailure(fmt.Errorf("%w: published file ACL or extended attributes changed after final content verification", ErrFileIdentityChanged))
 		}
 		strictPublishedLinks = finalLinks
 		publishedInfo = finalPublishedInfo
@@ -2432,10 +2519,18 @@ func (r Root) writeFileIfSame(
 				publicationCleanupErr,
 			)
 		}
-		if finalRootedInfo.Mode()&os.ModeSymlink != 0 || !finalRootedInfo.Mode().IsRegular() ||
-			!sameFileIdentitySnapshot(publishedInfo, finalRootedInfo) || rootedLinks != strictPublishedLinks {
+		finalMetadata, metadataErr := captureFileIdentityMetadata(temporary)
+		if metadataErr != nil {
 			return publishedInfo, errors.Join(
-				fmt.Errorf("%w: published file changed before conditional write completed", ErrFileIdentityChanged),
+				fmt.Errorf("%w: capture final published file identity metadata: %w", ErrFileIdentityChanged, metadataErr),
+				publicationCleanupErr,
+			)
+		}
+		if finalRootedInfo.Mode()&os.ModeSymlink != 0 || !finalRootedInfo.Mode().IsRegular() ||
+			!sameFileIdentitySnapshot(publishedInfo, finalRootedInfo) || rootedLinks != strictPublishedLinks ||
+			!sameFileIdentityMetadata(temporaryMetadata, finalMetadata) {
+			return publishedInfo, errors.Join(
+				fmt.Errorf("%w: published file metadata changed before conditional write completed", ErrFileIdentityChanged),
 				publicationCleanupErr,
 			)
 		}
@@ -2497,6 +2592,16 @@ func (r Root) openExpectedIdentityRootedFile(parent *os.Root, name string, expec
 	if !sameFileOwnership(expected.info, info) {
 		return nil, nil, fmt.Errorf("%w: file ownership changed", ErrFileIdentityChanged)
 	}
+	var initialMetadata fileIdentityMetadata
+	if expected.metadataCaptured {
+		initialMetadata, err = captureFileIdentityMetadata(file)
+		if err != nil {
+			return nil, nil, errors.Join(ErrFileIdentityChanged, fmt.Errorf("capture current file identity metadata: %w", err))
+		}
+		if !sameFileIdentityMetadata(expected.metadata, initialMetadata) {
+			return nil, nil, fmt.Errorf("%w: file ACL or extended attributes changed", ErrFileIdentityChanged)
+		}
+	}
 	currentMultipleLinks, err := hasMultipleHardLinks(file, info)
 	if err != nil {
 		return nil, nil, fmt.Errorf("inspect current file links: %w", err)
@@ -2524,6 +2629,13 @@ func (r Root) openExpectedIdentityRootedFile(parent *os.Root, name string, expec
 	if err != nil {
 		return nil, nil, err
 	}
+	middleMetadata := initialMetadata
+	if expected.metadataCaptured {
+		middleMetadata, err = captureFileIdentityMetadata(file)
+		if err != nil {
+			return nil, nil, errors.Join(ErrFileIdentityChanged, fmt.Errorf("recapture current file identity metadata: %w", err))
+		}
+	}
 	verifiedContents, err := readExpected()
 	if err != nil {
 		return nil, nil, err
@@ -2532,12 +2644,21 @@ func (r Root) openExpectedIdentityRootedFile(parent *os.Root, name string, expec
 	if err != nil {
 		return nil, nil, err
 	}
+	finalMetadata := middleMetadata
+	if expected.metadataCaptured {
+		finalMetadata, err = captureFileIdentityMetadata(file)
+		if err != nil {
+			return nil, nil, errors.Join(ErrFileIdentityChanged, fmt.Errorf("recapture final file identity metadata: %w", err))
+		}
+	}
 	finalMultipleLinks, err := hasMultipleHardLinks(file, finalInfo)
 	if err != nil {
 		return nil, nil, fmt.Errorf("reinspect current file links: %w", err)
 	}
 	if !sameFileIdentitySnapshot(info, middleInfo) || !sameFileIdentitySnapshot(middleInfo, finalInfo) ||
-		!bytes.Equal(verifiedContents, expected.data) || finalMultipleLinks != expected.multipleHardLinks {
+		!bytes.Equal(verifiedContents, expected.data) || finalMultipleLinks != expected.multipleHardLinks ||
+		(expected.metadataCaptured && (!sameFileIdentityMetadata(expected.metadata, middleMetadata) ||
+			!sameFileIdentityMetadata(middleMetadata, finalMetadata))) {
 		return nil, nil, fmt.Errorf("%w: file changed during identity verification", ErrFileIdentityChanged)
 	}
 	closeOnError = false
@@ -2886,6 +3007,15 @@ func (r Root) removeExpectedIdentityQuarantine(parent *os.Root, quarantineName s
 	}
 	if !sameFileIdentitySnapshot(info, finalInfo) {
 		return uncertain("quarantined file metadata changed before removal", nil)
+	}
+	if expected.metadataCaptured {
+		finalMetadata, metadataErr := captureFileIdentityMetadata(file)
+		if metadataErr != nil {
+			return uncertain("capture quarantined file identity metadata before removal", metadataErr)
+		}
+		if !sameFileIdentityMetadata(expected.metadata, finalMetadata) {
+			return uncertain("quarantined file ACL or extended attributes changed before removal", nil)
+		}
 	}
 	finalMultipleLinks, err := hasMultipleHardLinks(file, finalInfo)
 	if err != nil {
@@ -3275,6 +3405,7 @@ func (r Root) createNewFromWithInfo(name string, reader io.Reader, perm os.FileM
 	stagingClosed := false
 	stagingRetained := false
 	var stagedInfo os.FileInfo
+	var stagedMetadata fileIdentityMetadata
 	retainedData := identityData
 	if !strictIdentity {
 		retainedData = nil
@@ -3304,7 +3435,7 @@ func (r Root) createNewFromWithInfo(name string, reader io.Reader, perm os.FileM
 		if !published || !retainPublishedIdentity || stagingClosed || stagingRetained || runtime.GOOS == "windows" || r.simulateWindowsCloseForTest {
 			return nil
 		}
-		identity, retainErr := r.selectedIdentity.retainIdentity(file, stagedInfo, retainedData, resolved)
+		identity, retainErr := r.selectedIdentity.retainIdentityWithMetadata(file, stagedInfo, retainedData, resolved, stagedMetadata, strictIdentity)
 		if retainErr != nil {
 			stagingClosed = true
 			return fmt.Errorf("retain staged file identity: %w", retainErr)
@@ -3396,6 +3527,12 @@ func (r Root) createNewFromWithInfo(name string, reader io.Reader, perm os.FileM
 	}
 	if !stagedInfo.Mode().IsRegular() {
 		return written, nil, fmt.Errorf("staged file %q is not regular", resolved)
+	}
+	if strictIdentity {
+		stagedMetadata, err = captureFileIdentityMetadata(file)
+		if err != nil {
+			return written, nil, fmt.Errorf("capture staged file %q identity metadata: %w", resolved, err)
+		}
 	}
 	// Ordinary writes do not return a publication identity, so close the
 	// staging descriptor before publication. If that close fails, no durable
@@ -3503,6 +3640,13 @@ func (r Root) createNewFromWithInfo(name string, reader io.Reader, perm os.FileM
 	if !publishedInfo.Mode().IsRegular() {
 		return postPublicationIdentityFailure(fmt.Errorf("opened published file %q is not regular", resolved))
 	}
+	var publishedMetadata fileIdentityMetadata
+	if strictIdentity {
+		publishedMetadata, err = captureFileIdentityMetadata(publishedFile)
+		if err != nil {
+			return postPublicationIdentityFailure(fmt.Errorf("capture published file %q identity metadata: %w", resolved, err))
+		}
+	}
 	publishedMatches := os.SameFile(stagedInfo, publishedInfo)
 	if strictIdentity {
 		publishedMatches = sameFileIdentitySnapshot(stagedInfo, publishedInfo)
@@ -3512,6 +3656,9 @@ func (r Root) createNewFromWithInfo(name string, reader io.Reader, perm os.FileM
 			return postPublicationIdentityFailure(fmt.Errorf("%w: published file %q identity changed before reopen", ErrFileIdentityChanged, resolved))
 		}
 		return postPublicationIdentityFailure(fmt.Errorf("published file %q identity changed before reopen", resolved))
+	}
+	if strictIdentity && !sameFileIdentityMetadata(stagedMetadata, publishedMetadata) {
+		return postPublicationIdentityFailure(fmt.Errorf("%w: published file %q ACL or extended attributes changed before reopen", ErrFileIdentityChanged, resolved))
 	}
 	if retainPublishedIdentity && !strictIdentity && !stagingRetained {
 		identity, retainErr := r.selectedIdentity.retainIdentity(publishedFile, publishedInfo, retainedData, resolved)
@@ -3548,6 +3695,13 @@ func (r Root) createNewFromWithInfo(name string, reader io.Reader, perm os.FileM
 	if latestInfo.Mode()&os.ModeSymlink != 0 || !latestInfo.Mode().IsRegular() {
 		return postPublicationIdentityFailure(fmt.Errorf("recheck published file %q is not regular", resolved))
 	}
+	var latestMetadata fileIdentityMetadata
+	if strictIdentity {
+		latestMetadata, err = captureFileIdentityMetadata(publishedFile)
+		if err != nil {
+			return postPublicationIdentityFailure(fmt.Errorf("capture published file %q identity metadata after reopen: %w", resolved, err))
+		}
+	}
 	latestMatches := os.SameFile(publishedInfo, latestInfo)
 	if strictIdentity {
 		latestMatches = sameFileIdentitySnapshot(publishedInfo, latestInfo)
@@ -3557,6 +3711,9 @@ func (r Root) createNewFromWithInfo(name string, reader io.Reader, perm os.FileM
 			return postPublicationIdentityFailure(fmt.Errorf("%w: published file %q identity changed after reopen", ErrFileIdentityChanged, resolved))
 		}
 		return postPublicationIdentityFailure(fmt.Errorf("published file %q identity changed after reopen", resolved))
+	}
+	if strictIdentity && !sameFileIdentityMetadata(publishedMetadata, latestMetadata) {
+		return postPublicationIdentityFailure(fmt.Errorf("%w: published file %q ACL or extended attributes changed after reopen", ErrFileIdentityChanged, resolved))
 	}
 	if strictIdentity {
 		// Revalidate the complete retained snapshot after the final content
@@ -3570,12 +3727,18 @@ func (r Root) createNewFromWithInfo(name string, reader io.Reader, perm os.FileM
 		if linksErr != nil {
 			return postPublicationIdentityFailure(fmt.Errorf("%w: inspect published file links after content verification: %w", ErrFileIdentityChanged, linksErr))
 		}
+		finalPublishedMetadata, metadataErr := captureFileIdentityMetadata(publishedFile)
+		if metadataErr != nil {
+			return postPublicationIdentityFailure(fmt.Errorf("%w: capture published file %q identity metadata after content verification: %w", ErrFileIdentityChanged, resolved, metadataErr))
+		}
 		stagedLinks, linksErr := hasMultipleHardLinks(file, stagedInfo)
 		if linksErr != nil {
 			return postPublicationIdentityFailure(fmt.Errorf("%w: inspect staged file links after content verification: %w", ErrFileIdentityChanged, linksErr))
 		}
 		if !sameFileIdentitySnapshot(publishedInfo, finalPublishedInfo) ||
-			!sameFileIdentitySnapshot(finalPublishedInfo, latestInfo) || finalLinks != stagedLinks {
+			!sameFileIdentitySnapshot(finalPublishedInfo, latestInfo) || finalLinks != stagedLinks ||
+			!sameFileIdentityMetadata(publishedMetadata, finalPublishedMetadata) ||
+			!sameFileIdentityMetadata(finalPublishedMetadata, latestMetadata) {
 			return postPublicationIdentityFailure(fmt.Errorf("%w: published file metadata changed after content verification", ErrFileIdentityChanged))
 		}
 		if _, seekErr := publishedFile.Seek(0, io.SeekStart); seekErr != nil {
@@ -3602,6 +3765,13 @@ func (r Root) createNewFromWithInfo(name string, reader io.Reader, perm os.FileM
 		if finalRootedInfo.Mode()&os.ModeSymlink != 0 || !finalRootedInfo.Mode().IsRegular() ||
 			!sameFileIdentitySnapshot(finalPublishedInfo, finalRootedInfo) || rootedLinks != finalLinks {
 			return postPublicationIdentityFailure(fmt.Errorf("%w: published file changed after final content verification", ErrFileIdentityChanged))
+		}
+		finalRootedMetadata, metadataErr := captureFileIdentityMetadata(publishedFile)
+		if metadataErr != nil {
+			return postPublicationIdentityFailure(fmt.Errorf("%w: capture final published file %q identity metadata: %w", ErrFileIdentityChanged, resolved, metadataErr))
+		}
+		if !sameFileIdentityMetadata(finalPublishedMetadata, finalRootedMetadata) {
+			return postPublicationIdentityFailure(fmt.Errorf("%w: published file %q ACL or extended attributes changed after final content verification", ErrFileIdentityChanged, resolved))
 		}
 		strictPublishedLinks = finalLinks
 		publishedInfo = finalPublishedInfo
@@ -3637,8 +3807,13 @@ func (r Root) createNewFromWithInfo(name string, reader io.Reader, perm os.FileM
 		if linksErr != nil {
 			return postPublicationIdentityFailure(fmt.Errorf("%w: inspect final rooted published-file links: %w", ErrFileIdentityChanged, linksErr))
 		}
+		finalRootedMetadata, metadataErr := captureFileIdentityMetadata(file)
+		if metadataErr != nil {
+			return postPublicationIdentityFailure(fmt.Errorf("%w: capture final published file identity metadata: %w", ErrFileIdentityChanged, metadataErr))
+		}
 		if finalRootedInfo.Mode()&os.ModeSymlink != 0 || !finalRootedInfo.Mode().IsRegular() ||
-			!sameFileIdentitySnapshot(publishedInfo, finalRootedInfo) || rootedLinks != strictPublishedLinks {
+			!sameFileIdentitySnapshot(publishedInfo, finalRootedInfo) || rootedLinks != strictPublishedLinks ||
+			!sameFileIdentityMetadata(stagedMetadata, finalRootedMetadata) {
 			return postPublicationIdentityFailure(fmt.Errorf("%w: published file changed before create completed", ErrFileIdentityChanged))
 		}
 	}

--- a/internal/rootfs/rootfs_test.go
+++ b/internal/rootfs/rootfs_test.go
@@ -1469,6 +1469,9 @@ func TestRemoveFileIfSamePreservesReplacementBetweenQuarantineCheckAndRemoval(t 
 }
 
 func TestLegacyConditionalMutationsRejectQuarantineModeDrift(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits beyond owner-writable are unsupported on Windows; 0600 and 0640 both report as writable")
+	}
 	for _, testCase := range []struct {
 		name       string
 		invoke     func(Root, os.FileInfo) error


### PR DESCRIPTION
## Problem

Strict file identity checks previously covered inode, mode, size, and time
metadata but could accept a file after its ACL or extended-attribute set had
changed. A concurrent metadata edit could therefore pass the identity check
used before publication, reopening, or quarantine cleanup.

## Change

The identity snapshot now captures bounded, descriptor-backed digests for
extended attributes and ACL data on Darwin and Linux. Xattr names are sorted
before hashing, and names plus values are read through the retained file
descriptor so pathname replacement cannot supply the metadata being checked.
The snapshot stores fixed-size SHA-256 digests, byte counts, and a supported
state; it does not retain raw ACL entries or xattr values. A metadata set over
the fixed 1 MiB budget returns `ErrFileIdentityDataTooLarge`.

Supported empty metadata and an unsupported filesystem are represented
differently. Darwin captures extended ACL data through the existing dynamic
libSystem, no-cgo path. Linux includes the POSIX access ACL xattr and the
complete xattr set. Missing metadata is a supported empty set; only the
platform's documented unsupported errors disable that metadata class.
Permission errors, malformed data, and unexpected read failures remain
errors.

Strict capture, publication, rooted reopen, and quarantine cleanup now
re-read and compare the snapshot. Legacy `FileInfo` adapters retain their
previous behavior through the explicit metadata-captured state. The change
adds no CLI command, flag, Apple endpoint, request, response, or output shape.

This PR originally stacked on #2415. After #2415 merged, GitHub retargeted this PR to `main`. The cleanup behavior supplied by that preceding PR is a dependency and is not duplicated here.

## Regression coverage

The metadata tests cover real descriptor-backed drift and state handling:

- `TestCaptureFileIdentityMetadataDetectsDarwinACLDrift`
- `TestStrictIdentityRejectsDarwinACLDriftBeforePublication`
- `TestCaptureFileIdentityMetadataDetectsXattrDrift`
- `TestStrictIdentityRejectsXattrDriftBeforePublication`
- `TestCaptureFileIdentityMetadataRejectsMalformedXattrNameList`
- `TestCaptureFileIdentityMetadataUnsupportedErrorClassification`
- `TestMetadataHasherRejectsOversizeInput`
- `TestSameFileIdentityMetadataComparesACLAndXattrs`

Darwin and Linux filesystem cases skip only when the relevant operation is
reported unsupported by the platform or filesystem. Permission and malformed
metadata failures remain test failures.

## Validation

The focused metadata command passed:

```bash
ASC_BYPASS_KEYCHAIN=1 GOMAXPROCS=2 go test -count=1 -p=1 -parallel=1 ./internal/rootfs -run 'TestCaptureFileIdentityMetadata'
```

Recorded result:

```text
ok github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs 0.412s
```

The repository gates also passed:

```bash
make build
make format
make check-docs
make lint
ASC_BYPASS_KEYCHAIN=1 make test
```

The initial full test gate passed. The initial committed `/review` compared head
`e7d93845b6c0cf4793408cf229e0906fecd7a678` with the current stacked base,
`codex/18-rootfs-cleanup-20260905` at `1eb482b31bb9f7d90be2eef7edcb197582643a13`,
and found no actionable defects. The merge-base is
`97dfa3f93ebb171628366ab430ecd83da8e4cdd5`.

The original non-main base excluded primary GitHub CI. After retargeting, an explicit CI run exposed the missing Windows guard from the parent PR. The three-line guard is now included in an additive commit; it skips the POSIX-only 0600-versus-0640 assertion on Windows. Fresh primary CI runs on the updated head, and its required checks must pass before merge.

No Apple account, browser state, provider request, or live filesystem outside
the test fixtures is used.

Fixes #2373.


## Final merge validation

The final committed head `06cd35c0a8c503dc6d7e756f113ec587f9844455` was reviewed against `main` at `46794b82315757dc2826fa57af7a6edc69363bc0`. Required local build, formatting, documentation, lint and test gates and the normal commit hook passed. The final full-branch local `/review` reported no actionable findings. This additive update preserves the PR history. GitHub-required checks are verified separately before merge.
