### PR TITLE
Protect inherited entitlement inputs before writing signing artifacts

### DIFF
--- a/internal/xcode/signing_settings.go
+++ b/internal/xcode/signing_settings.go
@@ -1148,6 +1148,35 @@ func signingValueInherits(value string) bool {
 	return strings.Contains(value, "$(inherited)") || strings.Contains(value, "${inherited}")
 }
 
+// signingXCConfigHasUnconditionalEntitlementOverride reports whether a
+// collected xcconfig supplies an unconditional value that replaces the lower
+// project setting. Conditional assignments, ?= defaults, += appends, and
+// explicit $(inherited) assignments all retain a lower-layer dependency, so
+// project entitlement seeds must remain in the alias inventory for those
+// cases.
+func signingXCConfigHasUnconditionalEntitlementOverride(paths []string, read func(string) ([]byte, error)) (bool, error) {
+	for _, path := range paths {
+		data, err := read(path)
+		if err != nil {
+			return false, err
+		}
+		document, err := parseXCConfig(data)
+		if err != nil {
+			return false, fmt.Errorf("parse %s: %w", path, err)
+		}
+		for _, assignment := range document.assignments {
+			if assignment.baseKey != "CODE_SIGN_ENTITLEMENTS" ||
+				assignment.key != "CODE_SIGN_ENTITLEMENTS" ||
+				assignment.operator != "=" ||
+				signingValueInherits(assignment.value) {
+				continue
+			}
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func signingConfigurationSourcesAuthorized(
 	project *structuredVersionProject,
 	configuration *versionConfiguration,
@@ -1428,7 +1457,7 @@ func (resolver *signingSettingResolver) resolveInheritedSettingValue(
 			return expanded, nil
 		}
 	}
-	inherited, _, err := resolver.resolveLowerSettingWithContext(configuration, expansionConfiguration, setting)
+	inherited, err := resolver.resolveLowerSettingWithContext(configuration, expansionConfiguration, setting)
 	if err == nil {
 		return inherited, nil
 	}
@@ -1451,27 +1480,28 @@ func (resolver *signingSettingResolver) resolveInheritedSettingValue(
 func (resolver *signingSettingResolver) resolveLowerSettingWithContext(
 	configuration, expansionConfiguration *versionConfiguration,
 	setting string,
-) (string, string, error) {
+) (string, error) {
 	if configuration.baseReferenceID != "" {
 		path, err := resolver.project.fileReferencePath(configuration.baseReferenceID)
 		if err != nil {
-			return "", "", err
+			return "", err
 		}
 		resolved, err := resolver.resolveConfigurationXCConfigWithContext(configuration, expansionConfiguration, path, setting)
 		if err != nil {
-			return "", "", err
+			return "", err
 		}
 		if resolved.found {
 			value, _, err := resolver.expandSettingReferences(expansionConfiguration, resolved.value, map[string]bool{setting: true})
-			return value, resolved.path, err
+			return value, err
 		}
 	}
 	if !configuration.projectLevel {
 		if fallback := resolver.project.projectConfiguration(configuration.name); fallback != nil {
-			return resolver.resolveSettingWithContext(fallback, expansionConfiguration, setting)
+			value, _, err := resolver.resolveSettingWithContext(fallback, expansionConfiguration, setting)
+			return value, err
 		}
 	}
-	return "", "", fmt.Errorf("%s: %w", setting, errVersionSettingNotFound)
+	return "", fmt.Errorf("%s: %w", setting, errVersionSettingNotFound)
 }
 
 func (resolver *signingSettingResolver) resolveSettingReference(configuration *versionConfiguration, setting string, stack map[string]bool) (string, string, error) {
@@ -2900,6 +2930,76 @@ func signingProjectInputPaths(
 						return nil, externalEntitlementPaths, inputBlockers, err
 					}
 					inputBlockers = append(inputBlockers, fmt.Sprintf("target %q configuration %q has an unresolved CODE_SIGN_ENTITLEMENTS input: %v", configuration.target, configuration.name, err))
+				}
+			}
+		}
+		// An unconditional inherited target assignment can consume any
+		// project-level entitlement assignment when the project fallback is
+		// genuinely uncertain. The effective resolver intentionally reports one
+		// value (or falls back to its first literal) for callers that need a
+		// single setting, but the artifact alias inventory must retain every
+		// concrete composition that Xcode may select. Same-object conditional
+		// assignments inherit through the target's unconditional slot, and a
+		// target xcconfig can provide the lower value, so neither case should be
+		// cross-composed with project seeds here.
+		for _, key := range matchingBuildSettingKeys(configuration.buildSettings, "CODE_SIGN_ENTITLEMENTS") {
+			if key != "CODE_SIGN_ENTITLEMENTS" {
+				continue
+			}
+			value, ok := configuration.buildSettings[key].(string)
+			if !ok || !signingValueInherits(value) {
+				continue
+			}
+			if _, err := resolver.resolveLowerSettingWithContext(configuration, configuration, "CODE_SIGN_ENTITLEMENTS"); err == nil {
+				continue
+			}
+			if files := configFiles[configuration.id]; len(files) > 0 {
+				overridesProject, overrideErr := signingXCConfigHasUnconditionalEntitlementOverride(files, resolver.readXCConfig)
+				if overrideErr != nil {
+					return nil, externalEntitlementPaths, inputBlockers, overrideErr
+				}
+				if overridesProject {
+					continue
+				}
+			}
+			for _, projectCfg := range project.configurations {
+				if !projectCfg.projectLevel || projectCfg.name != configuration.name {
+					continue
+				}
+				for _, projectKey := range matchingBuildSettingKeys(projectCfg.buildSettings, "CODE_SIGN_ENTITLEMENTS") {
+					projectValue, ok := projectCfg.buildSettings[projectKey].(string)
+					if !ok {
+						continue
+					}
+					if strings.Contains(projectValue, "$(") || strings.Contains(projectValue, "${") {
+						expanded, _, expandErr := resolver.expandDirectAssignmentWithContext(
+							projectCfg,
+							configuration,
+							"CODE_SIGN_ENTITLEMENTS",
+							projectKey,
+							projectValue,
+							map[string]bool{"CODE_SIGN_ENTITLEMENTS": true},
+						)
+						if expandErr != nil {
+							// The later project-expression scan applies the same
+							// fail-closed lexical handling for an unresolved seed.
+							// Do not invent a composed path here when the target
+							// context cannot resolve the project reference.
+							continue
+						}
+						projectValue = expanded
+					}
+					composed := strings.ReplaceAll(value, "$(inherited)", projectValue)
+					composed = strings.ReplaceAll(composed, "${inherited}", projectValue)
+					if err := appendResolvedEntitlements(configuration, key, composed, false); err != nil {
+						if lexicalErr := appendLexicalEntitlementCandidate(composed); lexicalErr != nil {
+							return nil, externalEntitlementPaths, inputBlockers, lexicalErr
+						}
+						if selected {
+							return nil, externalEntitlementPaths, inputBlockers, err
+						}
+						inputBlockers = append(inputBlockers, fmt.Sprintf("target %q configuration %q has an unresolved inherited CODE_SIGN_ENTITLEMENTS input: %v", configuration.target, configuration.name, err))
+					}
 				}
 			}
 		}

--- a/internal/xcode/signing_settings.go
+++ b/internal/xcode/signing_settings.go
@@ -1148,35 +1148,6 @@ func signingValueInherits(value string) bool {
 	return strings.Contains(value, "$(inherited)") || strings.Contains(value, "${inherited}")
 }
 
-// signingXCConfigHasUnconditionalEntitlementOverride reports whether a
-// collected xcconfig supplies an unconditional value that replaces the lower
-// project setting. Conditional assignments, ?= defaults, += appends, and
-// explicit $(inherited) assignments all retain a lower-layer dependency, so
-// project entitlement seeds must remain in the alias inventory for those
-// cases.
-func signingXCConfigHasUnconditionalEntitlementOverride(paths []string, read func(string) ([]byte, error)) (bool, error) {
-	for _, path := range paths {
-		data, err := read(path)
-		if err != nil {
-			return false, err
-		}
-		document, err := parseXCConfig(data)
-		if err != nil {
-			return false, fmt.Errorf("parse %s: %w", path, err)
-		}
-		for _, assignment := range document.assignments {
-			if assignment.baseKey != "CODE_SIGN_ENTITLEMENTS" ||
-				assignment.key != "CODE_SIGN_ENTITLEMENTS" ||
-				assignment.operator != "=" ||
-				signingValueInherits(assignment.value) {
-				continue
-			}
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
 func signingConfigurationSourcesAuthorized(
 	project *structuredVersionProject,
 	configuration *versionConfiguration,
@@ -1194,6 +1165,78 @@ func signingConfigurationSourcesAuthorized(
 		current = project.projectConfiguration(current.name)
 	}
 	return true
+}
+
+func signingConfigurationDefinesUnconditionalEntitlement(
+	project *structuredVersionProject,
+	configuration *versionConfiguration,
+	configFiles map[string][]string,
+	resolver *signingSettingResolver,
+) bool {
+	value, definesUnconditional := configuration.buildSettings["CODE_SIGN_ENTITLEMENTS"].(string)
+	if definesUnconditional && signingValueInherits(value) {
+		definesUnconditional = false
+	}
+	if !definesUnconditional && signingConfigurationSourcesAuthorized(project, configuration, configFiles) {
+		if files := configFiles[configuration.id]; len(files) > 0 {
+			definesUnconditional = signingConfigurationXCConfigHasLiveUnconditionalEntitlementOverride(configuration, files, resolver)
+		}
+	}
+	return definesUnconditional
+}
+
+func signingConfigurationDefinesUnconditionalPBXEntitlement(configuration *versionConfiguration) bool {
+	value, ok := configuration.buildSettings["CODE_SIGN_ENTITLEMENTS"].(string)
+	return ok && !signingValueInherits(value)
+}
+
+// signingConfigurationXCConfigHasLiveUnconditionalEntitlementOverride keeps
+// project fallback protection only when the target xcconfig's effective
+// unconditional slot is a literal replacement. The sentinel probe rejects
+// effective inherited values, while the candidate traversal excludes
+// conditional-only assignments without replaying the xcconfig graph in a
+// second resolver.
+func signingConfigurationXCConfigHasLiveUnconditionalEntitlementOverride(
+	configuration *versionConfiguration,
+	files []string,
+	resolver *signingSettingResolver,
+) bool {
+	if len(files) == 0 || resolver.xcconfigDependsOnFallback(configuration, files[0], "CODE_SIGN_ENTITLEMENTS") {
+		return false
+	}
+	candidates, _, _, err := signingXCConfigEntitlementAssignmentCandidatesWithExpansions(
+		configuration,
+		files,
+		resolver,
+		xcconfigResolvedValue{},
+	)
+	if err != nil {
+		return false
+	}
+	for _, filePath := range files {
+		data, readErr := resolver.readXCConfig(filePath)
+		if readErr != nil {
+			return false
+		}
+		document, parseErr := parseXCConfig(data)
+		if parseErr != nil {
+			return false
+		}
+		for _, assignment := range document.assignments {
+			if assignment.baseKey != "CODE_SIGN_ENTITLEMENTS" ||
+				assignment.key != "CODE_SIGN_ENTITLEMENTS" ||
+				!candidates[normalizeSigningLexicalPath(filePath)][assignment.lineIndex] {
+				continue
+			}
+			if signingValueInherits(assignment.value) {
+				continue
+			}
+			if assignment.operator == "=" {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // signingSettingResolver is the signing workflow's authorization-aware
@@ -2954,11 +2997,7 @@ func signingProjectInputPaths(
 				continue
 			}
 			if files := configFiles[configuration.id]; len(files) > 0 {
-				overridesProject, overrideErr := signingXCConfigHasUnconditionalEntitlementOverride(files, resolver.readXCConfig)
-				if overrideErr != nil {
-					return nil, externalEntitlementPaths, inputBlockers, overrideErr
-				}
-				if overridesProject {
+				if signingConfigurationXCConfigHasLiveUnconditionalEntitlementOverride(configuration, files, resolver) {
 					continue
 				}
 			}
@@ -3001,21 +3040,33 @@ func signingProjectInputPaths(
 						inputBlockers = append(inputBlockers, fmt.Sprintf("target %q configuration %q has an unresolved inherited CODE_SIGN_ENTITLEMENTS input: %v", configuration.target, configuration.name, err))
 					}
 				}
-			}
-		}
-		value, targetDefinesUnconditional := configuration.buildSettings["CODE_SIGN_ENTITLEMENTS"].(string)
-		if targetDefinesUnconditional && (strings.Contains(value, "$(inherited)") || strings.Contains(value, "${inherited}")) {
-			targetDefinesUnconditional = false
-		}
-		if !targetDefinesUnconditional && authorized {
-			if files := configFiles[configuration.id]; len(files) > 0 {
-				if resolved, resolveErr := resolver.resolveConfigurationXCConfigWithContext(configuration, configuration, files[0], "CODE_SIGN_ENTITLEMENTS"); resolveErr == nil && resolved.found && resolved.exact {
-					if !strings.Contains(resolved.value, "$(inherited)") && !strings.Contains(resolved.value, "${inherited}") {
-						targetDefinesUnconditional = true
+				projectFiles := configFiles[projectCfg.id]
+				if signingConfigurationDefinesUnconditionalPBXEntitlement(projectCfg) {
+					continue
+				}
+				if len(projectFiles) == 0 {
+					continue
+				}
+				projectValues, projectErr := signingProjectXCConfigEntitlementValues(projectCfg, configuration, projectFiles, resolver)
+				if projectErr != nil {
+					return nil, externalEntitlementPaths, inputBlockers, fmt.Errorf("resolve project-level CODE_SIGN_ENTITLEMENTS for target %q configuration %q: %w", configuration.target, configuration.name, projectErr)
+				}
+				for _, projectValue := range projectValues {
+					composed := strings.ReplaceAll(value, "$(inherited)", projectValue)
+					composed = strings.ReplaceAll(composed, "${inherited}", projectValue)
+					if err := appendResolvedEntitlements(configuration, key, composed, false); err != nil {
+						if lexicalErr := appendLexicalEntitlementCandidate(composed); lexicalErr != nil {
+							return nil, externalEntitlementPaths, inputBlockers, lexicalErr
+						}
+						if selected {
+							return nil, externalEntitlementPaths, inputBlockers, err
+						}
+						inputBlockers = append(inputBlockers, fmt.Sprintf("target %q configuration %q has an unresolved inherited CODE_SIGN_ENTITLEMENTS input: %v", configuration.target, configuration.name, err))
 					}
 				}
 			}
 		}
+		targetDefinesUnconditional := signingConfigurationDefinesUnconditionalEntitlement(project, configuration, configFiles, resolver)
 		if targetDefinesUnconditional {
 			continue
 		}
@@ -3102,6 +3153,7 @@ func signingProjectInputPaths(
 		}
 	}
 	knownConfigurationIDs := make(map[string]bool, len(project.configurations))
+	projectEntitlementCandidatesByConfiguration := make(map[string]map[string]map[int]bool)
 	for _, configuration := range project.configurations {
 		knownConfigurationIDs[configuration.id] = true
 		files, ok := configFiles[configuration.id]
@@ -3134,6 +3186,100 @@ func signingProjectInputPaths(
 				}
 				if assignment.baseKey != "CODE_SIGN_ENTITLEMENTS" {
 					continue
+				}
+				if configuration.projectLevel && signingConfigurationDefinesUnconditionalPBXEntitlement(configuration) {
+					continue
+				}
+				if configuration.projectLevel {
+					candidates, cached := projectEntitlementCandidatesByConfiguration[configuration.id]
+					if !cached {
+						var candidateErr error
+						candidates, _, _, candidateErr = signingXCConfigEntitlementAssignmentCandidatesWithExpansions(
+							configuration,
+							files,
+							resolver,
+							xcconfigResolvedValue{},
+						)
+						if candidateErr != nil {
+							return nil, externalEntitlementPaths, inputBlockers, candidateErr
+						}
+						projectEntitlementCandidatesByConfiguration[configuration.id] = candidates
+					}
+					if !candidates[normalizeSigningLexicalPath(filePath)][assignment.lineIndex] {
+						continue
+					}
+				}
+				if configuration.projectLevel && (strings.Contains(assignment.value, "$(") || strings.Contains(assignment.value, "${")) {
+					expandedForTarget := false
+					targetExpansionFailed := false
+					matchingTargetCount := 0
+					shadowedTargetCount := 0
+					for _, targetConfiguration := range project.configurations {
+						if targetConfiguration.projectLevel || targetConfiguration.name != configuration.name {
+							continue
+						}
+						matchingTargetCount++
+						if signingConfigurationDefinesUnconditionalEntitlement(project, targetConfiguration, configFiles, resolver) {
+							shadowedTargetCount++
+							continue
+						}
+						expanded, _, expandErr := resolver.expandDirectAssignmentWithSourceContext(
+							configuration,
+							targetConfiguration,
+							"CODE_SIGN_ENTITLEMENTS",
+							assignment.key,
+							assignment.value,
+							map[string]bool{"CODE_SIGN_ENTITLEMENTS": true},
+							true,
+						)
+						if expandErr != nil {
+							targetExpansionFailed = true
+							continue
+						}
+						projectSeeds, projectSeedErr := signingProjectPBXInheritedEntitlementValues(
+							configuration,
+							targetConfiguration,
+							expanded,
+							resolver,
+						)
+						if projectSeedErr != nil {
+							targetExpansionFailed = true
+							continue
+						}
+						for _, projectSeed := range projectSeeds {
+							targetValues, targetInherited, targetValueErr := signingConfigurationInheritedEntitlementValues(
+								targetConfiguration,
+								configFiles,
+								resolver,
+								projectSeed,
+							)
+							if targetValueErr != nil {
+								targetExpansionFailed = true
+								continue
+							}
+							if !targetInherited {
+								targetValues = []string{projectSeed}
+							}
+							for _, targetValue := range targetValues {
+								if err := appendEntitlements(targetValue); err != nil {
+									return nil, externalEntitlementPaths, inputBlockers, err
+								}
+							}
+						}
+						expandedForTarget = true
+					}
+					if matchingTargetCount > 0 && shadowedTargetCount == matchingTargetCount {
+						continue
+					}
+					if targetExpansionFailed {
+						if lexicalErr := appendLexicalEntitlementCandidate(assignment.value); lexicalErr != nil {
+							return nil, externalEntitlementPaths, inputBlockers, lexicalErr
+						}
+						continue
+					}
+					if expandedForTarget {
+						continue
+					}
 				}
 				if !isConditionalEntitlementKey(assignment.key) {
 					if !uncertainEntitlementConfigurations[configuration.id] {
@@ -3241,6 +3387,332 @@ func signingXCConfigSelectorIdentity(key string) string {
 type signingXCConfigEntitlementAssignmentExpansion struct {
 	value             string
 	inheritedResolved bool
+}
+
+// signingProjectXCConfigEntitlementValues returns the concrete project-level
+// entitlement values that an inherited target assignment can consume. The
+// source configuration owns the xcconfig graph while the target configuration
+// owns build-setting reference expansion; keeping those contexts separate
+// prevents a target's xcconfig from being combined with a sibling project
+// configuration while still resolving references such as $(PRODUCT_NAME) for
+// the target that will inherit the value.
+func signingProjectXCConfigEntitlementValues(
+	projectConfiguration, targetConfiguration *versionConfiguration,
+	files []string,
+	resolver *signingSettingResolver,
+) ([]string, error) {
+	_, composed, _, err := signingXCConfigEntitlementAssignmentCandidatesWithExpansions(
+		projectConfiguration,
+		files,
+		resolver,
+		xcconfigResolvedValue{},
+	)
+	if err != nil {
+		return nil, err
+	}
+	values := make([]string, 0, len(composed))
+	seen := make(map[string]bool, len(composed))
+	for _, value := range composed {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if strings.Contains(value, "$(") || strings.Contains(value, "${") {
+			expanded, _, expandErr := resolver.expandSettingReferences(
+				targetConfiguration,
+				value,
+				map[string]bool{"CODE_SIGN_ENTITLEMENTS": true},
+			)
+			if expandErr != nil {
+				// The ordinary project xcconfig scan retains the raw assignment
+				// for lexical/fail-closed handling when target context cannot
+				// expand a reference. Do not guess a composed path here.
+				continue
+			}
+			value = expanded
+		}
+		if !seen[value] {
+			seen[value] = true
+			values = append(values, value)
+		}
+	}
+	if signingConfigurationDefinesUnconditionalPBXEntitlement(projectConfiguration) {
+		return nil, nil
+	}
+	projectComposed := make([]string, 0, len(values))
+	seen = make(map[string]bool, len(values))
+	for _, value := range values {
+		projectValues, err := signingProjectPBXInheritedEntitlementValues(
+			projectConfiguration,
+			targetConfiguration,
+			value,
+			resolver,
+		)
+		if err != nil {
+			return nil, err
+		}
+		for _, projectValue := range projectValues {
+			if !seen[projectValue] {
+				seen[projectValue] = true
+				projectComposed = append(projectComposed, projectValue)
+			}
+		}
+	}
+	return projectComposed, nil
+}
+
+type signingPBXInheritedEntitlementAssignment struct {
+	key   string
+	value string
+}
+
+// signingPBXInheritedEntitlementValues composes raw PBX inherited
+// assignments through a supplied lower-layer value. Xcode evaluates a
+// conditional assignment's $(inherited) against the same object's effective
+// unconditional slot, so conditional assignments must consume the computed
+// unconditional values rather than the lower layer directly. The raw key is
+// retained for the resolver call; this preserves its assignment-aware
+// recursion and avoids a second syntax-level composition pass.
+func signingPBXInheritedEntitlementValues(
+	configuration, expansionConfiguration *versionConfiguration,
+	lowerValues []string,
+	resolver *signingSettingResolver,
+) ([]string, error) {
+	normalizedLowerValues := make([]string, 0, len(lowerValues))
+	seenLower := make(map[string]bool, len(lowerValues))
+	for _, value := range lowerValues {
+		value = strings.TrimSpace(value)
+		if !seenLower[value] {
+			seenLower[value] = true
+			normalizedLowerValues = append(normalizedLowerValues, value)
+		}
+	}
+	if len(normalizedLowerValues) == 0 {
+		normalizedLowerValues = []string{""}
+	}
+
+	assignments := make([]signingPBXInheritedEntitlementAssignment, 0, len(configuration.buildSettings))
+	for _, key := range matchingBuildSettingKeys(configuration.buildSettings, "CODE_SIGN_ENTITLEMENTS") {
+		value, ok := configuration.buildSettings[key].(string)
+		if ok && signingValueInherits(value) {
+			assignments = append(assignments, signingPBXInheritedEntitlementAssignment{key: key, value: value})
+		}
+	}
+	if len(assignments) == 0 {
+		return normalizedLowerValues, nil
+	}
+
+	expand := func(assignment signingPBXInheritedEntitlementAssignment, lower string) (string, error) {
+		seededConfiguration := *configuration
+		seededConfiguration.buildSettings = cloneSigningSerializedObject(configuration.buildSettings)
+		seededConfiguration.buildSettings["CODE_SIGN_ENTITLEMENTS"] = lower
+		expanded, _, err := resolver.expandDirectAssignmentWithContext(
+			&seededConfiguration,
+			expansionConfiguration,
+			"CODE_SIGN_ENTITLEMENTS",
+			assignment.key,
+			assignment.value,
+			map[string]bool{"CODE_SIGN_ENTITLEMENTS": true},
+		)
+		if err != nil {
+			return "", err
+		}
+		return strings.TrimSpace(expanded), nil
+	}
+
+	// The unconditional assignment establishes the same-object state that a
+	// conditional assignment inherits. With no unconditional assignment, a
+	// conditional slot falls through to the supplied lower-layer values.
+	unconditionalValues := make([]string, 0, len(normalizedLowerValues))
+	seenUnconditional := make(map[string]bool, len(normalizedLowerValues))
+	for _, assignment := range assignments {
+		if assignment.key != "CODE_SIGN_ENTITLEMENTS" {
+			continue
+		}
+		for _, lower := range normalizedLowerValues {
+			expanded, err := expand(assignment, lower)
+			if err != nil {
+				return nil, err
+			}
+			if expanded != "" && !seenUnconditional[expanded] {
+				seenUnconditional[expanded] = true
+				unconditionalValues = append(unconditionalValues, expanded)
+			}
+		}
+	}
+	if len(unconditionalValues) == 0 {
+		unconditionalValues = normalizedLowerValues
+	}
+
+	composed := make([]string, 0, len(assignments)*len(unconditionalValues))
+	seen := make(map[string]bool, len(composed))
+	for _, assignment := range assignments {
+		if assignment.key == "CODE_SIGN_ENTITLEMENTS" {
+			for _, value := range unconditionalValues {
+				if !seen[value] {
+					seen[value] = true
+					composed = append(composed, value)
+				}
+			}
+			continue
+		}
+		for _, lower := range unconditionalValues {
+			expanded, err := expand(assignment, lower)
+			if err != nil {
+				return nil, err
+			}
+			if expanded != "" && !seen[expanded] {
+				seen[expanded] = true
+				composed = append(composed, expanded)
+			}
+		}
+	}
+	if len(composed) == 0 {
+		return normalizedLowerValues, nil
+	}
+	return composed, nil
+}
+
+// signingProjectPBXInheritedEntitlementValues composes a project xcconfig
+// seed through the project's raw PBX entitlement assignment. Project PBX
+// inherited suffixes sit above the project xcconfig and therefore must be
+// applied before a target's inherited suffix is considered.
+func signingProjectPBXInheritedEntitlementValues(
+	projectConfiguration, targetConfiguration *versionConfiguration,
+	projectSeed string,
+	resolver *signingSettingResolver,
+) ([]string, error) {
+	if signingConfigurationDefinesUnconditionalPBXEntitlement(projectConfiguration) {
+		return nil, nil
+	}
+	return signingPBXInheritedEntitlementValues(
+		projectConfiguration,
+		targetConfiguration,
+		[]string{projectSeed},
+		resolver,
+	)
+}
+
+// signingXCConfigInheritedEntitlementValues returns raw target-xcconfig
+// entitlement assignments that remain live and still consume a lower-layer
+// value. The candidate traversal supplies the same replacement semantics used
+// by the uncertain-configuration inventory, so a shadowed assignment cannot
+// re-enter target-context composition merely because it was parsed.
+func signingXCConfigInheritedEntitlementValues(
+	configuration *versionConfiguration,
+	files []string,
+	resolver *signingSettingResolver,
+) ([]string, error) {
+	if len(files) == 0 {
+		return nil, nil
+	}
+	candidates, _, _, err := signingXCConfigEntitlementAssignmentCandidatesWithExpansions(
+		configuration,
+		files,
+		resolver,
+		xcconfigResolvedValue{},
+	)
+	if err != nil {
+		return nil, err
+	}
+	values := make([]string, 0)
+	seen := make(map[string]bool)
+	for _, filePath := range files {
+		data, readErr := resolver.readXCConfig(filePath)
+		if readErr != nil {
+			return nil, readErr
+		}
+		document, parseErr := parseXCConfig(data)
+		if parseErr != nil {
+			return nil, fmt.Errorf("parse %s: %w", filePath, parseErr)
+		}
+		path := normalizeSigningLexicalPath(filePath)
+		for _, assignment := range document.assignments {
+			if assignment.baseKey != "CODE_SIGN_ENTITLEMENTS" ||
+				(!signingValueInherits(assignment.value) && assignment.operator != "+=") ||
+				!candidates[path][assignment.lineIndex] {
+				continue
+			}
+			if !seen[assignment.value] {
+				seen[assignment.value] = true
+				values = append(values, assignment.value)
+			}
+		}
+	}
+	return values, nil
+}
+
+// signingConfigurationInheritedEntitlementValues composes one concrete
+// project seed through the target's raw inherited entitlement sources. The
+// target xcconfig graph is resolved with the supplied seed as its lower layer
+// before any PBX inherited suffix is appended, which keeps a target-xcconfig
+// suffix and a PBX suffix in their actual order and avoids protecting the bare
+// project reference as a synthetic path.
+func signingConfigurationInheritedEntitlementValues(
+	configuration *versionConfiguration,
+	configFiles map[string][]string,
+	resolver *signingSettingResolver,
+	projectSeed string,
+) ([]string, bool, error) {
+	values := []string{strings.TrimSpace(projectSeed)}
+	targetXCConfigValues := values
+	if files := configFiles[configuration.id]; len(files) > 0 {
+		_, composed, _, err := signingXCConfigEntitlementAssignmentCandidatesWithExpansions(
+			configuration,
+			files,
+			resolver,
+			xcconfigResolvedValue{value: projectSeed, found: true, exact: true},
+		)
+		if err != nil {
+			return nil, false, err
+		}
+		targetXCConfigValues = make([]string, 0, len(composed))
+		seen := make(map[string]bool, len(composed))
+		for _, value := range composed {
+			value = strings.TrimSpace(value)
+			if value == "" {
+				continue
+			}
+			if strings.Contains(value, "$(") || strings.Contains(value, "${") {
+				value, _, err = resolver.expandSettingReferences(configuration, value, map[string]bool{"CODE_SIGN_ENTITLEMENTS": true})
+				if err != nil {
+					return nil, false, err
+				}
+			}
+			if !seen[value] {
+				seen[value] = true
+				targetXCConfigValues = append(targetXCConfigValues, value)
+			}
+		}
+		if len(targetXCConfigValues) == 0 {
+			targetXCConfigValues = values
+		}
+	}
+
+	if targetValues, err := signingXCConfigInheritedEntitlementValues(configuration, configFiles[configuration.id], resolver); err != nil {
+		return nil, false, err
+	} else {
+		pbxInherited := make([]string, 0)
+		for _, key := range matchingBuildSettingKeys(configuration.buildSettings, "CODE_SIGN_ENTITLEMENTS") {
+			value, ok := configuration.buildSettings[key].(string)
+			if ok && signingValueInherits(value) {
+				pbxInherited = append(pbxInherited, value)
+			}
+		}
+		if len(pbxInherited) == 0 {
+			return targetXCConfigValues, len(targetValues) > 0, nil
+		}
+		composed, err := signingPBXInheritedEntitlementValues(
+			configuration,
+			configuration,
+			targetXCConfigValues,
+			resolver,
+		)
+		if err != nil {
+			return nil, true, err
+		}
+		return composed, true, nil
+	}
 }
 
 // signingXCConfigEntitlementAssignmentCandidates returns the assignments that

--- a/internal/xcode/signing_settings_test.go
+++ b/internal/xcode/signing_settings_test.go
@@ -6048,6 +6048,992 @@ func TestSigningPlanProtectsDivergentInheritedProjectEntitlementSeeds(t *testing
 	}
 }
 
+func TestSigningPlanProtectsDivergentInheritedProjectXCConfigEntitlementSeeds(t *testing.T) {
+	project := writeDivergentInheritedProjectXCConfigEntitlementFixture(t,
+		`CODE_SIGN_ENTITLEMENTS = "$(inherited)Suffix";`)
+	projectRoot := filepath.Dir(project)
+	seedBytes := map[string]string{
+		"BaseSuffix":  "existing conditional project xcconfig seed bytes\n",
+		"OtherSuffix": "existing unconditional project xcconfig seed bytes\n",
+	}
+	for name, contents := range seedBytes {
+		if err := os.WriteFile(filepath.Join(projectRoot, name), []byte(contents), 0o600); err != nil {
+			t.Fatalf("WriteFile(%s) error = %v", name, err)
+		}
+	}
+
+	tests := []struct {
+		name      string
+		seed      string
+		configure func(*SigningPlanOptions, string)
+	}{
+		{
+			name: "plan aliases conditional project xcconfig seed",
+			seed: "BaseSuffix",
+			configure: func(opts *SigningPlanOptions, path string) {
+				opts.PlanPath = path
+			},
+		},
+		{
+			name: "receipt aliases unconditional project xcconfig seed",
+			seed: "OtherSuffix",
+			configure: func(opts *SigningPlanOptions, path string) {
+				opts.ReceiptPath = path
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			settingsPath := filepath.Join(root, "settings.json")
+			writeSigningSettingsTestFile(t, settingsPath, `{
+				"schemaVersion": 1,
+				"targets": [{"name":"App","configurations":[{"name":"Debug","settings":{"CODE_SIGN_STYLE":"manual"}}]}]
+			}`)
+
+			opts := SigningPlanOptions{
+				ProjectPath: project, SettingsFilePath: settingsPath,
+				StateDir: filepath.Join(root, "state"),
+			}
+			test.configure(&opts, filepath.Join(projectRoot, test.seed))
+			plan, err := BuildSigningPlan(opts)
+			if err == nil || (!strings.Contains(err.Error(), "aliases project input") && !strings.Contains(err.Error(), "protected project input")) {
+				t.Fatalf("BuildSigningPlan() = plan=%#v, error=%v; want %s alias rejection", plan, err, test.seed)
+			}
+			for name, contents := range seedBytes {
+				if got := mustReadVersionTestFile(t, filepath.Join(projectRoot, name)); got != contents {
+					t.Fatalf("project xcconfig entitlement seed %s changed while validating %s: %q", name, test.seed, got)
+				}
+			}
+		})
+	}
+}
+
+func TestSigningPlanExpandsReferencedProjectXCConfigEntitlementSeedInTargetContext(t *testing.T) {
+	project := writeStructuredVersionProject(t, false)
+	pbxprojPath := filepath.Join(project, "project.pbxproj")
+	attachSigningProjectXCConfig(t, project,
+		"CODE_SIGN_ENTITLEMENTS = Other\n"+
+			"CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*] = $(PRODUCT_NAME)\n")
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999993",
+		`CODE_SIGN_ENTITLEMENTS = App.entitlements;`)
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999995",
+		`PRODUCT_NAME = Widget; CODE_SIGN_ENTITLEMENTS = "$(inherited)Suffix";`)
+	projectRoot := filepath.Dir(project)
+	if err := os.WriteFile(filepath.Join(projectRoot, "App.entitlements"), []byte("<?xml version=\"1.0\"?><plist version=\"1.0\"><dict/></plist>\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(App.entitlements) error = %v", err)
+	}
+	protectedPath := filepath.Join(projectRoot, "WidgetSuffix")
+	const existingEntitlements = "existing target-context entitlement seed bytes\n"
+	if err := os.WriteFile(protectedPath, []byte(existingEntitlements), 0o600); err != nil {
+		t.Fatalf("WriteFile(WidgetSuffix) error = %v", err)
+	}
+	root := t.TempDir()
+	settingsPath := filepath.Join(root, "settings.json")
+	writeSigningSettingsTestFile(t, settingsPath, `{
+		"schemaVersion": 1,
+		"targets": [{"name":"App","configurations":[{"name":"Debug","settings":{"CODE_SIGN_STYLE":"manual"}}]}]
+	}`)
+	_, err := BuildSigningPlan(SigningPlanOptions{
+		ProjectPath: project, SettingsFilePath: settingsPath,
+		PlanPath: protectedPath, StateDir: filepath.Join(root, "state"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "aliases project input") {
+		t.Fatalf("BuildSigningPlan() error = %v, want target-context project xcconfig alias rejection", err)
+	}
+	if got := mustReadVersionTestFile(t, protectedPath); got != existingEntitlements {
+		t.Fatalf("target-context entitlement seed changed during alias validation: %q", got)
+	}
+}
+
+func TestSigningPlanSkipsShadowedProjectXCConfigReferenceForTargetOverride(t *testing.T) {
+	project := writeStructuredVersionProject(t, false)
+	pbxprojPath := filepath.Join(project, "project.pbxproj")
+	attachSigningProjectXCConfig(t, project, "CODE_SIGN_ENTITLEMENTS = $(PRODUCT_NAME)\n")
+	attachSigningAppXCConfig(t, project, "CODE_SIGN_ENTITLEMENTS = ShadowedTarget.entitlements\n")
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999993",
+		`PRODUCT_NAME = App; CODE_SIGN_ENTITLEMENTS = App.entitlements;`)
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999995",
+		`PRODUCT_NAME = Widget;`)
+	projectRoot := filepath.Dir(project)
+	for _, name := range []string{"App.entitlements", "ShadowedTarget.entitlements", "Widget"} {
+		if err := os.WriteFile(filepath.Join(projectRoot, name), []byte("existing project input bytes\n"), 0o600); err != nil {
+			t.Fatalf("WriteFile(%s) error = %v", name, err)
+		}
+	}
+	artifactPath := filepath.Join(projectRoot, "App")
+	const existingArtifact = "existing artifact bytes\n"
+	if err := os.WriteFile(artifactPath, []byte(existingArtifact), 0o600); err != nil {
+		t.Fatalf("WriteFile(App artifact) error = %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		configure func(*SigningPlanOptions, string)
+	}{
+		{
+			name: "plan path",
+			configure: func(opts *SigningPlanOptions, path string) {
+				opts.PlanPath = path
+			},
+		},
+		{
+			name: "receipt path",
+			configure: func(opts *SigningPlanOptions, path string) {
+				opts.ReceiptPath = path
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			settingsPath := filepath.Join(root, "settings.json")
+			writeSigningSettingsTestFile(t, settingsPath, `{
+				"schemaVersion": 1,
+				"targets": [{"name":"App","configurations":[{"name":"Debug","settings":{"CODE_SIGN_STYLE":"manual"}}]}]
+			}`)
+			opts := SigningPlanOptions{
+				ProjectPath: project, SettingsFilePath: settingsPath,
+				StateDir: filepath.Join(root, "state"),
+			}
+			test.configure(&opts, artifactPath)
+			plan, err := BuildSigningPlan(opts)
+			if err != nil {
+				t.Fatalf("BuildSigningPlan() error = %v, want shadowed project xcconfig reference ignored", err)
+			}
+			if plan == nil || !plan.Ready {
+				t.Fatalf("BuildSigningPlan() plan = %#v, want ready plan", plan)
+			}
+			if got := mustReadVersionTestFile(t, artifactPath); got != existingArtifact {
+				t.Fatalf("artifact path changed while validating shadowed project reference: %q", got)
+			}
+		})
+	}
+}
+
+func TestSigningPlanProtectsProjectXCConfigReferenceForUnshadowedTarget(t *testing.T) {
+	project := writeStructuredVersionProject(t, false)
+	pbxprojPath := filepath.Join(project, "project.pbxproj")
+	attachSigningProjectXCConfig(t, project, "CODE_SIGN_ENTITLEMENTS = $(PRODUCT_NAME)\n")
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999993",
+		`PRODUCT_NAME = App; CODE_SIGN_ENTITLEMENTS = App.entitlements;`)
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999995",
+		`PRODUCT_NAME = Widget;`)
+	projectRoot := filepath.Dir(project)
+	if err := os.WriteFile(filepath.Join(projectRoot, "App.entitlements"), []byte("<?xml version=\"1.0\"?><plist version=\"1.0\"><dict/></plist>\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(App.entitlements) error = %v", err)
+	}
+	artifactPath := filepath.Join(projectRoot, "Widget")
+	const existingArtifact = "existing unshadowed target artifact bytes\n"
+	if err := os.WriteFile(artifactPath, []byte(existingArtifact), 0o600); err != nil {
+		t.Fatalf("WriteFile(Widget artifact) error = %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		configure func(*SigningPlanOptions, string)
+	}{
+		{
+			name: "plan path",
+			configure: func(opts *SigningPlanOptions, path string) {
+				opts.PlanPath = path
+			},
+		},
+		{
+			name: "receipt path",
+			configure: func(opts *SigningPlanOptions, path string) {
+				opts.ReceiptPath = path
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			settingsPath := filepath.Join(root, "settings.json")
+			writeSigningSettingsTestFile(t, settingsPath, `{
+				"schemaVersion": 1,
+				"targets": [{"name":"App","configurations":[{"name":"Debug","settings":{"CODE_SIGN_STYLE":"manual"}}]}]
+			}`)
+			opts := SigningPlanOptions{
+				ProjectPath: project, SettingsFilePath: settingsPath,
+				StateDir: filepath.Join(root, "state"),
+			}
+			test.configure(&opts, artifactPath)
+			plan, err := BuildSigningPlan(opts)
+			if err == nil || !strings.Contains(err.Error(), "aliases project input") {
+				t.Fatalf("BuildSigningPlan() = plan=%#v, error=%v; want unshadowed Widget project reference rejection", plan, err)
+			}
+			if got := mustReadVersionTestFile(t, artifactPath); got != existingArtifact {
+				t.Fatalf("unshadowed target artifact changed while validating %s: %q", test.name, got)
+			}
+		})
+	}
+}
+
+func TestSigningPlanProtectsProjectXCConfigReferenceWhenTargetExpansionFails(t *testing.T) {
+	project := writeStructuredVersionProject(t, false)
+	pbxprojPath := filepath.Join(project, "project.pbxproj")
+	attachSigningProjectXCConfig(t, project, "CODE_SIGN_ENTITLEMENTS = $(PRODUCT_NAME)\n")
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999993",
+		`PRODUCT_NAME = App;`)
+	projectRoot := filepath.Dir(project)
+	const existingEntitlements = "existing unresolved target entitlement bytes\n"
+	protectedPath := filepath.Join(projectRoot, "Widget")
+	if err := os.WriteFile(protectedPath, []byte(existingEntitlements), 0o600); err != nil {
+		t.Fatalf("WriteFile(Widget) error = %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		configure func(*SigningPlanOptions, string)
+	}{
+		{
+			name: "plan path",
+			configure: func(opts *SigningPlanOptions, path string) {
+				opts.PlanPath = path
+			},
+		},
+		{
+			name: "receipt path",
+			configure: func(opts *SigningPlanOptions, path string) {
+				opts.ReceiptPath = path
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			settingsPath := filepath.Join(root, "settings.json")
+			writeSigningSettingsTestFile(t, settingsPath, `{
+				"schemaVersion": 1,
+				"targets": [{"name":"App","configurations":[{"name":"Debug","settings":{"CODE_SIGN_STYLE":"manual"}}]}]
+			}`)
+			opts := SigningPlanOptions{
+				ProjectPath: project, SettingsFilePath: settingsPath,
+				StateDir: filepath.Join(root, "state"),
+			}
+			test.configure(&opts, protectedPath)
+			plan, err := BuildSigningPlan(opts)
+			if err == nil || (!strings.Contains(err.Error(), "aliases project input") && !strings.Contains(err.Error(), "protected project input") && !strings.Contains(err.Error(), "cannot be safely inventoried")) {
+				t.Fatalf("BuildSigningPlan() = plan=%#v, error=%v; want unresolved Widget input rejected before artifact overwrite", plan, err)
+			}
+			if got := mustReadVersionTestFile(t, protectedPath); got != existingEntitlements {
+				t.Fatalf("unresolved target entitlement was overwritten while validating %s: %q", test.name, got)
+			}
+		})
+	}
+}
+
+func TestSigningPlanSkipsProjectXCConfigExpressionWhenAllTargetsOverride(t *testing.T) {
+	project := writeStructuredVersionProject(t, false)
+	pbxprojPath := filepath.Join(project, "project.pbxproj")
+	attachSigningProjectXCConfig(t, project, "CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*] = $(PRODUCT_NAME)\n")
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999993",
+		`CODE_SIGN_ENTITLEMENTS = App.entitlements;`)
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999995",
+		`CODE_SIGN_ENTITLEMENTS = Widget.entitlements;`)
+	projectRoot := filepath.Dir(project)
+	for _, name := range []string{"App.entitlements", "Widget.entitlements"} {
+		if err := os.WriteFile(filepath.Join(projectRoot, name), []byte("<?xml version=\"1.0\"?><plist version=\"1.0\"><dict/></plist>\n"), 0o600); err != nil {
+			t.Fatalf("WriteFile(%s) error = %v", name, err)
+		}
+	}
+	root := t.TempDir()
+	settingsPath := filepath.Join(root, "settings.json")
+	writeSigningSettingsTestFile(t, settingsPath, `{
+		"schemaVersion": 1,
+		"targets": [{"name":"App","configurations":[{"name":"Debug","settings":{"CODE_SIGN_STYLE":"manual"}}]}]
+	}`)
+
+	plan, err := BuildSigningPlan(SigningPlanOptions{
+		ProjectPath: project, SettingsFilePath: settingsPath,
+		StateDir: filepath.Join(root, "state"),
+	})
+	if err != nil {
+		t.Fatalf("BuildSigningPlan() error = %v, want project xcconfig expression shadowed by all target overrides", err)
+	}
+	if plan == nil || !plan.Ready {
+		t.Fatalf("BuildSigningPlan() plan = %#v, want ready plan", plan)
+	}
+}
+
+func TestSigningPlanComposesProjectXCConfigReferenceThroughInheritedTarget(t *testing.T) {
+	project := writeStructuredVersionProject(t, false)
+	pbxprojPath := filepath.Join(project, "project.pbxproj")
+	attachSigningProjectXCConfig(t, project, "CODE_SIGN_ENTITLEMENTS = $(PRODUCT_NAME)\n")
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999993",
+		`CODE_SIGN_ENTITLEMENTS = App.entitlements;`)
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999995",
+		`PRODUCT_NAME = Widget; CODE_SIGN_ENTITLEMENTS = "$(inherited)Suffix";`)
+	projectRoot := filepath.Dir(project)
+	if err := os.WriteFile(filepath.Join(projectRoot, "App.entitlements"), []byte("<?xml version=\"1.0\"?><plist version=\"1.0\"><dict/></plist>\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(App.entitlements) error = %v", err)
+	}
+	const existingEntitlements = "existing composed target entitlement bytes\n"
+	composedPath := filepath.Join(projectRoot, "WidgetSuffix")
+	if err := os.WriteFile(composedPath, []byte(existingEntitlements), 0o600); err != nil {
+		t.Fatalf("WriteFile(WidgetSuffix) error = %v", err)
+	}
+	artifactPath := filepath.Join(projectRoot, "Widget")
+	const existingArtifact = "existing valid artifact bytes\n"
+	if err := os.WriteFile(artifactPath, []byte(existingArtifact), 0o600); err != nil {
+		t.Fatalf("WriteFile(Widget artifact) error = %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		configure func(*SigningPlanOptions, string)
+	}{
+		{
+			name: "plan path",
+			configure: func(opts *SigningPlanOptions, path string) {
+				opts.PlanPath = path
+			},
+		},
+		{
+			name: "receipt path",
+			configure: func(opts *SigningPlanOptions, path string) {
+				opts.ReceiptPath = path
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			settingsPath := filepath.Join(root, "settings.json")
+			writeSigningSettingsTestFile(t, settingsPath, `{
+				"schemaVersion": 1,
+				"targets": [{"name":"App","configurations":[{"name":"Debug","settings":{"CODE_SIGN_STYLE":"manual"}}]}]
+			}`)
+			opts := SigningPlanOptions{
+				ProjectPath: project, SettingsFilePath: settingsPath,
+				StateDir: filepath.Join(root, "state"),
+			}
+			test.configure(&opts, artifactPath)
+			plan, err := BuildSigningPlan(opts)
+			if err != nil {
+				t.Fatalf("BuildSigningPlan() error = %v, want uncomposed project reference ignored", err)
+			}
+			if plan == nil || !plan.Ready {
+				t.Fatalf("BuildSigningPlan() plan = %#v, want ready plan", plan)
+			}
+			if got := mustReadVersionTestFile(t, artifactPath); got != existingArtifact {
+				t.Fatalf("valid artifact path changed while validating %s: %q", test.name, got)
+			}
+			if got := mustReadVersionTestFile(t, composedPath); got != existingEntitlements {
+				t.Fatalf("composed entitlement input changed while validating %s: %q", test.name, got)
+			}
+		})
+	}
+}
+
+func TestSigningPlanComposesProjectXCConfigReferenceThroughInheritedTargetXCConfig(t *testing.T) {
+	project := writeStructuredVersionProject(t, false)
+	pbxprojPath := filepath.Join(project, "project.pbxproj")
+	attachSigningProjectXCConfig(t, project, "CODE_SIGN_ENTITLEMENTS = $(PRODUCT_NAME)\n")
+	attachSigningWidgetXCConfig(t, project, "CODE_SIGN_ENTITLEMENTS = $(inherited)Suffix\n")
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999993",
+		`CODE_SIGN_ENTITLEMENTS = App.entitlements;`)
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999995",
+		`PRODUCT_NAME = Widget;`)
+	projectRoot := filepath.Dir(project)
+	if err := os.WriteFile(filepath.Join(projectRoot, "App.entitlements"), []byte("<?xml version=\"1.0\"?><plist version=\"1.0\"><dict/></plist>\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(App.entitlements) error = %v", err)
+	}
+	const existingEntitlements = "existing target xcconfig entitlement bytes\n"
+	composedPath := filepath.Join(projectRoot, "WidgetSuffix")
+	if err := os.WriteFile(composedPath, []byte(existingEntitlements), 0o600); err != nil {
+		t.Fatalf("WriteFile(WidgetSuffix) error = %v", err)
+	}
+	artifactPath := filepath.Join(projectRoot, "Widget")
+	const existingArtifact = "existing valid target xcconfig artifact bytes\n"
+	if err := os.WriteFile(artifactPath, []byte(existingArtifact), 0o600); err != nil {
+		t.Fatalf("WriteFile(Widget artifact) error = %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		configure func(*SigningPlanOptions, string)
+	}{
+		{
+			name: "plan path",
+			configure: func(opts *SigningPlanOptions, path string) {
+				opts.PlanPath = path
+			},
+		},
+		{
+			name: "receipt path",
+			configure: func(opts *SigningPlanOptions, path string) {
+				opts.ReceiptPath = path
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			settingsPath := filepath.Join(root, "settings.json")
+			writeSigningSettingsTestFile(t, settingsPath, `{
+				"schemaVersion": 1,
+				"targets": [{"name":"App","configurations":[{"name":"Debug","settings":{"CODE_SIGN_STYLE":"manual"}}]}]
+			}`)
+			opts := SigningPlanOptions{
+				ProjectPath: project, SettingsFilePath: settingsPath,
+				StateDir: filepath.Join(root, "state"),
+			}
+			test.configure(&opts, artifactPath)
+			plan, err := BuildSigningPlan(opts)
+			if err != nil {
+				t.Fatalf("BuildSigningPlan() error = %v, want target xcconfig inherited suffix composed", err)
+			}
+			if plan == nil || !plan.Ready {
+				t.Fatalf("BuildSigningPlan() plan = %#v, want ready plan", plan)
+			}
+			if got := mustReadVersionTestFile(t, artifactPath); got != existingArtifact {
+				t.Fatalf("valid artifact changed while validating %s: %q", test.name, got)
+			}
+			if got := mustReadVersionTestFile(t, composedPath); got != existingEntitlements {
+				t.Fatalf("composed entitlement input changed while validating %s: %q", test.name, got)
+			}
+		})
+	}
+}
+
+func TestSigningPlanSkipsShadowedProjectXCConfigWhenProjectPBXEntitlementOverrides(t *testing.T) {
+	project := writeStructuredVersionProject(t, false)
+	pbxprojPath := filepath.Join(project, "project.pbxproj")
+	attachSigningProjectXCConfig(t, project, "CODE_SIGN_ENTITLEMENTS = $(PRODUCT_NAME)\n")
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999991",
+		`CODE_SIGN_ENTITLEMENTS = Project.entitlements;`)
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999995",
+		`PRODUCT_NAME = Widget; CODE_SIGN_ENTITLEMENTS = "$(inherited)Suffix";`)
+	projectRoot := filepath.Dir(project)
+	if err := os.WriteFile(filepath.Join(projectRoot, "Project.entitlementsSuffix"), []byte("<?xml version=\"1.0\"?><plist version=\"1.0\"><dict/></plist>\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(Project.entitlementsSuffix) error = %v", err)
+	}
+	artifactPath := filepath.Join(projectRoot, "WidgetSuffix")
+	const existingArtifact = "existing artifact bytes for shadowed project xcconfig\n"
+	if err := os.WriteFile(artifactPath, []byte(existingArtifact), 0o600); err != nil {
+		t.Fatalf("WriteFile(WidgetSuffix artifact) error = %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		configure func(*SigningPlanOptions, string)
+	}{
+		{
+			name: "plan path",
+			configure: func(opts *SigningPlanOptions, path string) {
+				opts.PlanPath = path
+			},
+		},
+		{
+			name: "receipt path",
+			configure: func(opts *SigningPlanOptions, path string) {
+				opts.ReceiptPath = path
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			settingsPath := filepath.Join(root, "settings.json")
+			writeSigningSettingsTestFile(t, settingsPath, `{
+				"schemaVersion": 1,
+				"targets": [{"name":"App","configurations":[{"name":"Debug","settings":{"CODE_SIGN_STYLE":"manual"}}]}]
+			}`)
+			opts := SigningPlanOptions{
+				ProjectPath: project, SettingsFilePath: settingsPath,
+				StateDir: filepath.Join(root, "state"),
+			}
+			test.configure(&opts, artifactPath)
+			plan, err := BuildSigningPlan(opts)
+			if err != nil {
+				t.Fatalf("BuildSigningPlan() error = %v, want project PBX entitlement to shadow xcconfig expression", err)
+			}
+			if plan == nil || !plan.Ready {
+				t.Fatalf("BuildSigningPlan() plan = %#v, want ready plan", plan)
+			}
+			if got := mustReadVersionTestFile(t, artifactPath); got != existingArtifact {
+				t.Fatalf("valid artifact changed while validating %s: %q", test.name, got)
+			}
+		})
+	}
+}
+
+func TestSigningPlanComposesProjectAndTargetInheritedEntitlements(t *testing.T) {
+	project := writeStructuredVersionProject(t, false)
+	pbxprojPath := filepath.Join(project, "project.pbxproj")
+	attachSigningProjectXCConfig(t, project, "CODE_SIGN_ENTITLEMENTS = $(PRODUCT_NAME)\n")
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999991",
+		`CODE_SIGN_ENTITLEMENTS = "$(inherited)ProjectSuffix";`)
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999993",
+		`PRODUCT_NAME = App;`)
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999995",
+		`PRODUCT_NAME = Widget; CODE_SIGN_ENTITLEMENTS = "$(inherited)TargetSuffix";`)
+	projectRoot := filepath.Dir(project)
+	tests := []struct {
+		name          string
+		path          string
+		wantAlias     bool
+		existingBytes string
+	}{
+		{
+			name:          "bare target suffix is not protected",
+			path:          filepath.Join(projectRoot, "WidgetTargetSuffix"),
+			wantAlias:     false,
+			existingBytes: "existing raw target suffix artifact bytes\n",
+		},
+		{
+			name:          "fully composed target entitlement is protected",
+			path:          filepath.Join(projectRoot, "WidgetProjectSuffixTargetSuffix"),
+			wantAlias:     true,
+			existingBytes: "existing effective target entitlement artifact bytes\n",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := os.WriteFile(test.path, []byte(test.existingBytes), 0o600); err != nil {
+				t.Fatalf("WriteFile(%s) error = %v", test.path, err)
+			}
+			root := t.TempDir()
+			settingsPath := filepath.Join(root, "settings.json")
+			writeSigningSettingsTestFile(t, settingsPath, `{
+				"schemaVersion": 1,
+				"targets": [{"name":"App","configurations":[{"name":"Debug","settings":{"CODE_SIGN_STYLE":"manual"}}]}]
+			}`)
+			plan, err := BuildSigningPlan(SigningPlanOptions{
+				ProjectPath: project, SettingsFilePath: settingsPath,
+				PlanPath: test.path, StateDir: filepath.Join(root, "state"),
+			})
+			if test.wantAlias {
+				if err == nil || !strings.Contains(err.Error(), "aliases project input") {
+					t.Fatalf("BuildSigningPlan() = plan=%#v, error=%v; want effective inherited entitlement alias rejection", plan, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("BuildSigningPlan() error = %v, want bare target suffix accepted", err)
+				}
+				if plan == nil || !plan.Ready {
+					t.Fatalf("BuildSigningPlan() plan = %#v, want ready plan", plan)
+				}
+			}
+			if got := mustReadVersionTestFile(t, test.path); got != test.existingBytes {
+				t.Fatalf("artifact changed while validating %s: %q", test.name, got)
+			}
+		})
+	}
+}
+
+func TestSigningPlanDoesNotDoubleComposeProjectXCConfigThroughProjectPBX(t *testing.T) {
+	project := writeStructuredVersionProject(t, false)
+	pbxprojPath := filepath.Join(project, "project.pbxproj")
+	attachSigningProjectXCConfig(t, project,
+		"CODE_SIGN_ENTITLEMENTS = Base\n"+
+			"CODE_SIGN_ENTITLEMENTS = $(inherited)$(PRODUCT_NAME)\n")
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999991",
+		`CODE_SIGN_ENTITLEMENTS = "$(inherited)ProjectSuffix";`)
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999993",
+		`CODE_SIGN_ENTITLEMENTS = App.entitlements;`)
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999995",
+		`PRODUCT_NAME = Widget; CODE_SIGN_ENTITLEMENTS = "$(inherited)TargetSuffix";`)
+	projectRoot := filepath.Dir(project)
+	if err := os.WriteFile(filepath.Join(projectRoot, "App.entitlements"), []byte("<?xml version=\"1.0\"?><plist version=\"1.0\"><dict/></plist>\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(App.entitlements) error = %v", err)
+	}
+	cases := []struct {
+		name      string
+		path      string
+		wantAlias bool
+	}{
+		{
+			name:      "singly composed effective path",
+			path:      filepath.Join(projectRoot, "BaseWidgetProjectSuffixTargetSuffix"),
+			wantAlias: true,
+		},
+		{
+			name:      "doubly composed phantom path",
+			path:      filepath.Join(projectRoot, "BaseWidgetProjectSuffixWidgetProjectSuffixTargetSuffix"),
+			wantAlias: false,
+		},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			const existingArtifact = "existing artifact bytes for project xcconfig composition\n"
+			if err := os.WriteFile(test.path, []byte(existingArtifact), 0o600); err != nil {
+				t.Fatalf("WriteFile(%s) error = %v", test.path, err)
+			}
+			root := t.TempDir()
+			settingsPath := filepath.Join(root, "settings.json")
+			writeSigningSettingsTestFile(t, settingsPath, `{
+				"schemaVersion": 1,
+				"targets": [{"name":"App","configurations":[{"name":"Debug","settings":{"CODE_SIGN_STYLE":"manual"}}]}]
+			}`)
+			plan, err := BuildSigningPlan(SigningPlanOptions{
+				ProjectPath: project, SettingsFilePath: settingsPath,
+				PlanPath: test.path, StateDir: filepath.Join(root, "state"),
+			})
+			if test.wantAlias {
+				if err == nil || !strings.Contains(err.Error(), "aliases project input") {
+					t.Fatalf("BuildSigningPlan() = plan=%#v, error=%v; want effective entitlement alias rejection", plan, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("BuildSigningPlan() error = %v, want phantom double-composed path ignored", err)
+				}
+				if plan == nil || !plan.Ready {
+					t.Fatalf("BuildSigningPlan() plan = %#v, want ready plan", plan)
+				}
+			}
+			if got := mustReadVersionTestFile(t, test.path); got != existingArtifact {
+				t.Fatalf("artifact changed while validating project xcconfig composition: %q", got)
+			}
+		})
+	}
+}
+
+func TestSigningPlanComposesProjectConditionalPBXInheritedEntitlementThroughUnconditional(t *testing.T) {
+	project := writeStructuredVersionProject(t, false)
+	pbxprojPath := filepath.Join(project, "project.pbxproj")
+	attachSigningProjectXCConfig(t, project, "CODE_SIGN_ENTITLEMENTS = $(PRODUCT_NAME)\n")
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999991",
+		`CODE_SIGN_ENTITLEMENTS = "$(inherited)Base"; "CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]" = "$(inherited)Device";`)
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999993",
+		`CODE_SIGN_ENTITLEMENTS = App.entitlements;`)
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999995",
+		`PRODUCT_NAME = Widget;`)
+	projectRoot := filepath.Dir(project)
+	if err := os.WriteFile(filepath.Join(projectRoot, "App.entitlements"), []byte("<?xml version=\"1.0\"?><plist version=\"1.0\"><dict/></plist>\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(App.entitlements) error = %v", err)
+	}
+	composedPath := filepath.Join(projectRoot, "WidgetBaseDevice")
+	const existingEntitlements = "existing project conditional inherited entitlement bytes\n"
+	if err := os.WriteFile(composedPath, []byte(existingEntitlements), 0o600); err != nil {
+		t.Fatalf("WriteFile(WidgetBaseDevice) error = %v", err)
+	}
+	root := t.TempDir()
+	settingsPath := filepath.Join(root, "settings.json")
+	writeSigningSettingsTestFile(t, settingsPath, `{
+		"schemaVersion": 1,
+		"targets": [{"name":"App","configurations":[{"name":"Debug","settings":{"CODE_SIGN_STYLE":"manual"}}]}]
+	}`)
+	plan, err := BuildSigningPlan(SigningPlanOptions{
+		ProjectPath: project, SettingsFilePath: settingsPath,
+		PlanPath: composedPath, StateDir: filepath.Join(root, "state"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "aliases project input") {
+		t.Fatalf("BuildSigningPlan() = plan=%#v, error=%v; want conditional PBX inherited entitlement alias rejection", plan, err)
+	}
+	if got := mustReadVersionTestFile(t, composedPath); got != existingEntitlements {
+		t.Fatalf("conditional inherited entitlement was overwritten during planning: %q", got)
+	}
+}
+
+func TestSigningProjectPBXInheritedEntitlementValuesComposeConditionalThroughUnconditional(t *testing.T) {
+	projectPath := writeStructuredVersionProject(t, false)
+	pbxprojPath := filepath.Join(projectPath, "project.pbxproj")
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999991",
+		`CODE_SIGN_ENTITLEMENTS = "$(inherited)Base"; "CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]" = "$(inherited)Device";`)
+	project, err := openSigningStructuredVersionProject(projectPath)
+	if err != nil {
+		t.Fatalf("openSigningStructuredVersionProject() error = %v", err)
+	}
+	var projectConfiguration, targetConfiguration *versionConfiguration
+	for _, configuration := range project.configurations {
+		if configuration.projectLevel && configuration.name == "Debug" {
+			projectConfiguration = configuration
+		}
+		if !configuration.projectLevel && configuration.target == "Widget" && configuration.name == "Debug" {
+			targetConfiguration = configuration
+		}
+	}
+	if projectConfiguration == nil || targetConfiguration == nil {
+		t.Fatal("project fixture is missing Project Debug or Widget Debug configuration")
+	}
+	resolver := newSigningSettingResolver(project, nil, false, nil)
+	values, err := signingProjectPBXInheritedEntitlementValues(projectConfiguration, targetConfiguration, "Widget", resolver)
+	if err != nil {
+		t.Fatalf("signingProjectPBXInheritedEntitlementValues() error = %v", err)
+	}
+	want := map[string]bool{"WidgetBase": true, "WidgetBaseDevice": true}
+	got := make(map[string]bool, len(values))
+	for _, value := range values {
+		got[value] = true
+	}
+	if len(got) != len(want) {
+		t.Fatalf("signingProjectPBXInheritedEntitlementValues() = %#v, want %#v", values, want)
+	}
+	for value := range want {
+		if !got[value] {
+			t.Errorf("signingProjectPBXInheritedEntitlementValues() = %#v, missing %q", values, value)
+		}
+	}
+}
+
+func TestSigningPlanComposesTargetXCConfigAppendThroughProjectSeed(t *testing.T) {
+	project := writeStructuredVersionProject(t, false)
+	pbxprojPath := filepath.Join(project, "project.pbxproj")
+	attachSigningProjectXCConfig(t, project, "CODE_SIGN_ENTITLEMENTS = $(PRODUCT_NAME)\n")
+	attachSigningWidgetXCConfig(t, project, "CODE_SIGN_ENTITLEMENTS += Suffix\n")
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999991",
+		`CODE_SIGN_ENTITLEMENTS = "$(inherited)Base"; "CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]" = "$(inherited)Device";`)
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999993",
+		`CODE_SIGN_ENTITLEMENTS = App.entitlements;`)
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999995",
+		`PRODUCT_NAME = Widget;`)
+	projectRoot := filepath.Dir(project)
+	if err := os.WriteFile(filepath.Join(projectRoot, "App.entitlements"), []byte("<?xml version=\"1.0\"?><plist version=\"1.0\"><dict/></plist>\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(App.entitlements) error = %v", err)
+	}
+	for _, test := range []struct {
+		name string
+		path string
+	}{
+		{name: "unconditional project seed", path: filepath.Join(projectRoot, "WidgetBase Suffix")},
+		{name: "conditional project seed through unconditional", path: filepath.Join(projectRoot, "WidgetBaseDevice Suffix")},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			const existingEntitlements = "existing target xcconfig append entitlement bytes\n"
+			if err := os.WriteFile(test.path, []byte(existingEntitlements), 0o600); err != nil {
+				t.Fatalf("WriteFile(%s) error = %v", test.path, err)
+			}
+			root := t.TempDir()
+			settingsPath := filepath.Join(root, "settings.json")
+			writeSigningSettingsTestFile(t, settingsPath, `{
+				"schemaVersion": 1,
+				"targets": [{"name":"App","configurations":[{"name":"Debug","settings":{"CODE_SIGN_STYLE":"manual"}}]}]
+			}`)
+			plan, err := BuildSigningPlan(SigningPlanOptions{
+				ProjectPath: project, SettingsFilePath: settingsPath,
+				PlanPath: test.path, StateDir: filepath.Join(root, "state"),
+			})
+			if err == nil || !strings.Contains(err.Error(), "aliases project input") {
+				t.Fatalf("BuildSigningPlan() = plan=%#v, error=%v; want target xcconfig append alias rejection", plan, err)
+			}
+			if got := mustReadVersionTestFile(t, test.path); got != existingEntitlements {
+				t.Fatalf("target xcconfig append entitlement was overwritten during planning: %q", got)
+			}
+		})
+	}
+}
+
+func TestSigningPlanComposesConditionalTargetPBXInheritedEntitlementThroughUnconditional(t *testing.T) {
+	project := writeStructuredVersionProject(t, false)
+	pbxprojPath := filepath.Join(project, "project.pbxproj")
+	attachSigningProjectXCConfig(t, project, "CODE_SIGN_ENTITLEMENTS = $(PRODUCT_NAME)\n")
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999993",
+		`CODE_SIGN_ENTITLEMENTS = App.entitlements;`)
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999995",
+		`PRODUCT_NAME = Widget; CODE_SIGN_ENTITLEMENTS = "$(inherited)Base"; "CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]" = "$(inherited)Device";`)
+	projectRoot := filepath.Dir(project)
+	if err := os.WriteFile(filepath.Join(projectRoot, "App.entitlements"), []byte("<?xml version=\"1.0\"?><plist version=\"1.0\"><dict/></plist>\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(App.entitlements) error = %v", err)
+	}
+	artifactPath := filepath.Join(projectRoot, "WidgetBaseDevice")
+	const existingArtifact = "existing conditional target PBX entitlement bytes\n"
+	if err := os.WriteFile(artifactPath, []byte(existingArtifact), 0o600); err != nil {
+		t.Fatalf("WriteFile(WidgetBaseDevice) error = %v", err)
+	}
+	root := t.TempDir()
+	settingsPath := filepath.Join(root, "settings.json")
+	writeSigningSettingsTestFile(t, settingsPath, `{
+		"schemaVersion": 1,
+		"targets": [{"name":"App","configurations":[{"name":"Debug","settings":{"CODE_SIGN_STYLE":"manual"}}]}]
+	}`)
+	plan, err := BuildSigningPlan(SigningPlanOptions{
+		ProjectPath: project, SettingsFilePath: settingsPath,
+		PlanPath: artifactPath, StateDir: filepath.Join(root, "state"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "aliases project input") {
+		t.Fatalf("BuildSigningPlan() = plan=%#v, error=%v; want conditional target PBX inherited entitlement alias rejection", plan, err)
+	}
+	if got := mustReadVersionTestFile(t, artifactPath); got != existingArtifact {
+		t.Fatalf("conditional target PBX inherited entitlement was overwritten during planning: %q", got)
+	}
+}
+
+func TestSigningConfigurationInheritedEntitlementValuesComposeConditionalThroughUnconditional(t *testing.T) {
+	projectPath := writeStructuredVersionProject(t, false)
+	pbxprojPath := filepath.Join(projectPath, "project.pbxproj")
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999995",
+		`PRODUCT_NAME = Widget; CODE_SIGN_ENTITLEMENTS = "$(inherited)Base"; "CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]" = "$(inherited)Device";`)
+	project, err := openSigningStructuredVersionProject(projectPath)
+	if err != nil {
+		t.Fatalf("openSigningStructuredVersionProject() error = %v", err)
+	}
+	_, configFiles, _, _, _, _, lexicalConfigPaths, _, _, err := project.signingXCConfigConsumersWithOptionalMissing(nil, false)
+	if err != nil {
+		t.Fatalf("signingXCConfigConsumersWithOptionalMissing() error = %v", err)
+	}
+	resolver := newSigningSettingResolver(project, configFiles, false, lexicalConfigPaths)
+	var targetConfiguration *versionConfiguration
+	for _, configuration := range project.configurations {
+		if !configuration.projectLevel && configuration.target == "Widget" && configuration.name == "Debug" {
+			targetConfiguration = configuration
+			break
+		}
+	}
+	if targetConfiguration == nil {
+		t.Fatal("project fixture is missing Widget Debug configuration")
+	}
+	values, inherited, err := signingConfigurationInheritedEntitlementValues(targetConfiguration, configFiles, resolver, "Widget")
+	if err != nil {
+		t.Fatalf("signingConfigurationInheritedEntitlementValues() error = %v", err)
+	}
+	if !inherited {
+		t.Fatal("signingConfigurationInheritedEntitlementValues() inherited = false, want true")
+	}
+	want := map[string]bool{"WidgetBase": true, "WidgetBaseDevice": true}
+	got := make(map[string]bool, len(values))
+	for _, value := range values {
+		got[value] = true
+	}
+	if len(got) != len(want) {
+		t.Fatalf("signingConfigurationInheritedEntitlementValues() = %#v, want %#v", values, want)
+	}
+	for value := range want {
+		if !got[value] {
+			t.Errorf("signingConfigurationInheritedEntitlementValues() = %#v, missing %q", values, value)
+		}
+	}
+}
+
+func TestSigningPlanIgnoresShadowedProjectXCConfigExpression(t *testing.T) {
+	project := writeStructuredVersionProject(t, false)
+	pbxprojPath := filepath.Join(project, "project.pbxproj")
+	attachSigningProjectXCConfig(t, project,
+		"CODE_SIGN_ENTITLEMENTS = App.entitlements\n"+
+			"CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*] = $(PRODUCT_NAME)\n"+
+			"CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*] = App.entitlements\n")
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999993",
+		`CODE_SIGN_ENTITLEMENTS = App.entitlements;`)
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999995",
+		`PRODUCT_NAME = Widget;`)
+	projectRoot := filepath.Dir(project)
+	if err := os.WriteFile(filepath.Join(projectRoot, "App.entitlements"), []byte("<?xml version=\"1.0\"?><plist version=\"1.0\"><dict/></plist>\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(App.entitlements) error = %v", err)
+	}
+	artifactPath := filepath.Join(projectRoot, "Widget")
+	const existingArtifact = "existing artifact bytes for shadowed expression\n"
+	if err := os.WriteFile(artifactPath, []byte(existingArtifact), 0o600); err != nil {
+		t.Fatalf("WriteFile(Widget artifact) error = %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		configure func(*SigningPlanOptions, string)
+	}{
+		{
+			name: "plan path",
+			configure: func(opts *SigningPlanOptions, path string) {
+				opts.PlanPath = path
+			},
+		},
+		{
+			name: "receipt path",
+			configure: func(opts *SigningPlanOptions, path string) {
+				opts.ReceiptPath = path
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			settingsPath := filepath.Join(root, "settings.json")
+			writeSigningSettingsTestFile(t, settingsPath, `{
+				"schemaVersion": 1,
+				"targets": [{"name":"App","configurations":[{"name":"Debug","settings":{"CODE_SIGN_STYLE":"manual"}}]}]
+			}`)
+			opts := SigningPlanOptions{
+				ProjectPath: project, SettingsFilePath: settingsPath,
+				StateDir: filepath.Join(root, "state"),
+			}
+			test.configure(&opts, artifactPath)
+			plan, err := BuildSigningPlan(opts)
+			if err != nil {
+				t.Fatalf("BuildSigningPlan() error = %v, want shadowed project xcconfig expression ignored", err)
+			}
+			if plan == nil || !plan.Ready {
+				t.Fatalf("BuildSigningPlan() plan = %#v, want ready plan", plan)
+			}
+			if got := mustReadVersionTestFile(t, artifactPath); got != existingArtifact {
+				t.Fatalf("valid artifact path changed while validating %s: %q", test.name, got)
+			}
+		})
+	}
+}
+
+func TestSigningConfigurationXCConfigInheritedEntitlementIsNotUnconditional(t *testing.T) {
+	projectPath := writeStructuredVersionProject(t, false)
+	pbxprojPath := filepath.Join(projectPath, "project.pbxproj")
+	attachSigningProjectXCConfig(t, projectPath, "CODE_SIGN_ENTITLEMENTS = $(PRODUCT_NAME)\n")
+	attachSigningWidgetXCConfig(t, projectPath, "CODE_SIGN_ENTITLEMENTS = $(inherited)Suffix\n")
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999995",
+		`PRODUCT_NAME = Widget;`)
+	project, err := openSigningStructuredVersionProject(projectPath)
+	if err != nil {
+		t.Fatalf("openSigningStructuredVersionProject() error = %v", err)
+	}
+	_, configFiles, _, _, _, _, lexicalConfigPaths, _, _, err := project.signingXCConfigConsumersWithOptionalMissing(nil, false)
+	if err != nil {
+		t.Fatalf("signingXCConfigConsumersWithOptionalMissing() error = %v", err)
+	}
+	resolver := newSigningSettingResolver(project, configFiles, false, lexicalConfigPaths)
+	var widgetConfiguration *versionConfiguration
+	for _, configuration := range project.configurations {
+		if configuration.target == "Widget" && configuration.name == "Debug" {
+			widgetConfiguration = configuration
+			break
+		}
+	}
+	if widgetConfiguration == nil {
+		t.Fatal("project fixture has no Widget Debug configuration")
+	}
+	if signingConfigurationDefinesUnconditionalEntitlement(project, widgetConfiguration, configFiles, resolver) {
+		t.Fatal("target xcconfig CODE_SIGN_ENTITLEMENTS = $(inherited)Suffix was classified as an unconditional override")
+	}
+}
+
+func TestSigningPlanTreatsRepeatedTargetXCConfigInheritedAfterLiteralAsLocal(t *testing.T) {
+	project := writeStructuredVersionProject(t, false)
+	pbxprojPath := filepath.Join(project, "project.pbxproj")
+	attachSigningProjectXCConfig(t, project, "CODE_SIGN_ENTITLEMENTS = $(PRODUCT_NAME)\n")
+	attachSigningWidgetXCConfig(t, project,
+		"CODE_SIGN_ENTITLEMENTS = Fixed.entitlements\n"+
+			"CODE_SIGN_ENTITLEMENTS = $(inherited)Suffix\n")
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999993",
+		`CODE_SIGN_ENTITLEMENTS = App.entitlements;`)
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999995",
+		`PRODUCT_NAME = Widget;`)
+	projectRoot := filepath.Dir(project)
+	if err := os.WriteFile(filepath.Join(projectRoot, "App.entitlements"), []byte("<?xml version=\"1.0\"?><plist version=\"1.0\"><dict/></plist>\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(App.entitlements) error = %v", err)
+	}
+	artifactPath := filepath.Join(projectRoot, "Widget")
+	const existingArtifact = "existing artifact bytes for local target xcconfig\n"
+	if err := os.WriteFile(artifactPath, []byte(existingArtifact), 0o600); err != nil {
+		t.Fatalf("WriteFile(Widget) error = %v", err)
+	}
+	root := t.TempDir()
+	settingsPath := filepath.Join(root, "settings.json")
+	writeSigningSettingsTestFile(t, settingsPath, `{
+		"schemaVersion": 1,
+		"targets": [{"name":"App","configurations":[{"name":"Debug","settings":{"CODE_SIGN_STYLE":"manual"}}]}]
+	}`)
+	plan, err := BuildSigningPlan(SigningPlanOptions{
+		ProjectPath: project, SettingsFilePath: settingsPath,
+		PlanPath: artifactPath, StateDir: filepath.Join(root, "state"),
+	})
+	if err != nil {
+		t.Fatalf("BuildSigningPlan() error = %v, want local repeated target xcconfig assignment to shadow project expression", err)
+	}
+	if plan == nil || !plan.Ready {
+		t.Fatalf("BuildSigningPlan() plan = %#v, want ready plan", plan)
+	}
+	if got := mustReadVersionTestFile(t, artifactPath); got != existingArtifact {
+		t.Fatalf("artifact changed while validating local repeated target xcconfig assignment: %q", got)
+	}
+}
+
 func TestSigningPlanProtectsReferencedDivergentInheritedProjectEntitlementSeeds(t *testing.T) {
 	project := writeReferencedDivergentInheritedProjectEntitlementFixture(t,
 		`CODE_SIGN_ENTITLEMENTS = "$(inherited)Suffix";`, "")
@@ -6225,6 +7211,23 @@ func writeDivergentInheritedProjectEntitlementFixture(t *testing.T, widgetSettin
 	return writeInheritedProjectEntitlementFixture(t,
 		`CODE_SIGN_ENTITLEMENTS = Other; "CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]" = Base;`,
 		widgetSettings, widgetXCConfig)
+}
+
+func writeDivergentInheritedProjectXCConfigEntitlementFixture(t *testing.T, widgetSettings string) string {
+	t.Helper()
+	project := writeStructuredVersionProject(t, false)
+	pbxprojPath := filepath.Join(project, "project.pbxproj")
+	attachSigningProjectXCConfig(t, project,
+		"CODE_SIGN_ENTITLEMENTS = Other\n"+
+			"CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*] = Base\n")
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999993",
+		`CODE_SIGN_ENTITLEMENTS = App.entitlements;`)
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999995", widgetSettings)
+	projectRoot := filepath.Dir(project)
+	if err := os.WriteFile(filepath.Join(projectRoot, "App.entitlements"), []byte("<?xml version=\"1.0\"?><plist version=\"1.0\"><dict/></plist>\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(App.entitlements) error = %v", err)
+	}
+	return project
 }
 
 func writeReferencedDivergentInheritedProjectEntitlementFixture(t *testing.T, widgetSettings, widgetXCConfig string) string {
@@ -6801,6 +7804,37 @@ func attachSigningWidgetXCConfig(t *testing.T, project, contents string) string 
 		t.Fatalf("WriteFile(project.pbxproj) error = %v", err)
 	}
 	return configPath
+}
+
+func attachSigningProjectXCConfig(t *testing.T, project, contents string) {
+	t.Helper()
+	projectRoot := filepath.Dir(project)
+	configDir := filepath.Join(projectRoot, "Configs")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(config) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "Project.xcconfig"), []byte(contents), 0o640); err != nil {
+		t.Fatalf("WriteFile(project xcconfig) error = %v", err)
+	}
+
+	pbxprojPath := filepath.Join(project, "project.pbxproj")
+	projectContents := mustReadVersionTestFile(t, pbxprojPath)
+	const projectReference = "BBBBBBBBBBBBBBBBBBBBBBBB"
+	fileReference := "\t\t" + projectReference + " /* Project.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Configs/Project.xcconfig; sourceTree = SOURCE_ROOT; };\n"
+	marker := "\t\t111111111111111111111111 /* Project object */ = {"
+	if !strings.Contains(projectContents, marker) {
+		t.Fatalf("project fixture is missing project object marker")
+	}
+	projectContents = strings.Replace(projectContents, marker, fileReference+marker, 1)
+	projectConfiguration := "999999999999999999999991 /* Project Debug */ = {isa = XCBuildConfiguration; buildSettings = {}; name = Debug; };"
+	updatedProjectConfiguration := "999999999999999999999991 /* Project Debug */ = {isa = XCBuildConfiguration; baseConfigurationReference = " + projectReference + "; buildSettings = {}; name = Debug; };"
+	if !strings.Contains(projectContents, projectConfiguration) {
+		t.Fatalf("project fixture is missing Project Debug configuration")
+	}
+	projectContents = strings.Replace(projectContents, projectConfiguration, updatedProjectConfiguration, 1)
+	if err := os.WriteFile(pbxprojPath, []byte(projectContents), 0o644); err != nil {
+		t.Fatalf("WriteFile(project.pbxproj) error = %v", err)
+	}
 }
 
 func attachSigningAppXCConfig(t *testing.T, project, contents string) {

--- a/internal/xcode/signing_settings_test.go
+++ b/internal/xcode/signing_settings_test.go
@@ -5987,6 +5987,274 @@ func TestSigningPlanProtectsTargetConditionalInheritedEntitlementComposition(t *
 	}
 }
 
+func TestSigningPlanProtectsDivergentInheritedProjectEntitlementSeeds(t *testing.T) {
+	project := writeDivergentInheritedProjectEntitlementFixture(t,
+		`CODE_SIGN_ENTITLEMENTS = "$(inherited)Suffix";`, "")
+	projectRoot := filepath.Dir(project)
+	seedBytes := map[string]string{
+		"BaseSuffix":  "existing conditional project seed bytes\n",
+		"OtherSuffix": "existing unconditional project seed bytes\n",
+	}
+	for name, contents := range seedBytes {
+		if err := os.WriteFile(filepath.Join(projectRoot, name), []byte(contents), 0o600); err != nil {
+			t.Fatalf("WriteFile(%s) error = %v", name, err)
+		}
+	}
+
+	tests := []struct {
+		name      string
+		seed      string
+		configure func(*SigningPlanOptions, string)
+	}{
+		{
+			name: "plan aliases conditional project seed",
+			seed: "BaseSuffix",
+			configure: func(opts *SigningPlanOptions, path string) {
+				opts.PlanPath = path
+			},
+		},
+		{
+			name: "receipt aliases unconditional project seed",
+			seed: "OtherSuffix",
+			configure: func(opts *SigningPlanOptions, path string) {
+				opts.ReceiptPath = path
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			settingsPath := filepath.Join(root, "settings.json")
+			writeSigningSettingsTestFile(t, settingsPath, `{
+				"schemaVersion": 1,
+				"targets": [{"name":"App","configurations":[{"name":"Debug","settings":{"CODE_SIGN_STYLE":"manual"}}]}]
+			}`)
+
+			opts := SigningPlanOptions{
+				ProjectPath: project, SettingsFilePath: settingsPath,
+				StateDir: filepath.Join(root, "state"),
+			}
+			test.configure(&opts, filepath.Join(projectRoot, test.seed))
+			plan, err := BuildSigningPlan(opts)
+			if err == nil || (!strings.Contains(err.Error(), "aliases project input") && !strings.Contains(err.Error(), "protected project input")) {
+				t.Fatalf("BuildSigningPlan() = plan=%#v, error=%v; want %s alias rejection", plan, err, test.seed)
+			}
+			for name, contents := range seedBytes {
+				if got := mustReadVersionTestFile(t, filepath.Join(projectRoot, name)); got != contents {
+					t.Fatalf("project entitlement seed %s changed while validating %s: %q", name, test.seed, got)
+				}
+			}
+		})
+	}
+}
+
+func TestSigningPlanProtectsReferencedDivergentInheritedProjectEntitlementSeeds(t *testing.T) {
+	project := writeReferencedDivergentInheritedProjectEntitlementFixture(t,
+		`CODE_SIGN_ENTITLEMENTS = "$(inherited)Suffix";`, "")
+	protectedPath := filepath.Join(filepath.Dir(project), "WidgetSuffix")
+	const existingEntitlements = "existing referenced entitlement seed bytes\n"
+	if err := os.WriteFile(protectedPath, []byte(existingEntitlements), 0o600); err != nil {
+		t.Fatalf("WriteFile(referenced entitlement) error = %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		configure func(*SigningPlanOptions, string)
+	}{
+		{
+			name: "plan aliases referenced project seed",
+			configure: func(opts *SigningPlanOptions, path string) {
+				opts.PlanPath = path
+			},
+		},
+		{
+			name: "receipt aliases referenced project seed",
+			configure: func(opts *SigningPlanOptions, path string) {
+				opts.ReceiptPath = path
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			settingsPath := filepath.Join(root, "settings.json")
+			writeSigningSettingsTestFile(t, settingsPath, `{
+				"schemaVersion": 1,
+				"targets": [{"name":"App","configurations":[{"name":"Debug","settings":{"CODE_SIGN_STYLE":"manual"}}]}]
+			}`)
+
+			opts := SigningPlanOptions{
+				ProjectPath: project, SettingsFilePath: settingsPath,
+				StateDir: filepath.Join(root, "state"),
+			}
+			test.configure(&opts, protectedPath)
+			plan, err := BuildSigningPlan(opts)
+			if err == nil || (!strings.Contains(err.Error(), "aliases project input") && !strings.Contains(err.Error(), "protected project input")) {
+				t.Fatalf("BuildSigningPlan() = plan=%#v, error=%v; want referenced project seed alias rejection", plan, err)
+			}
+			if got := mustReadVersionTestFile(t, protectedPath); got != existingEntitlements {
+				t.Fatalf("referenced entitlement seed changed while validating %s: %q", test.name, got)
+			}
+		})
+	}
+}
+
+func TestSigningPlanProtectsProjectSeedBelowConditionalTargetXCConfig(t *testing.T) {
+	project := writeDivergentInheritedProjectEntitlementFixture(t,
+		`CODE_SIGN_ENTITLEMENTS = "$(inherited)Suffix";`,
+		"CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*] = Target\n")
+	protectedPath := filepath.Join(filepath.Dir(project), "BaseSuffix")
+	const existingEntitlements = "existing conditional target xcconfig fallback bytes\n"
+	if err := os.WriteFile(protectedPath, []byte(existingEntitlements), 0o600); err != nil {
+		t.Fatalf("WriteFile(conditional target xcconfig fallback) error = %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		configure func(*SigningPlanOptions, string)
+	}{
+		{
+			name: "plan aliases project fallback",
+			configure: func(opts *SigningPlanOptions, path string) {
+				opts.PlanPath = path
+			},
+		},
+		{
+			name: "receipt aliases project fallback",
+			configure: func(opts *SigningPlanOptions, path string) {
+				opts.ReceiptPath = path
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			settingsPath := filepath.Join(root, "settings.json")
+			writeSigningSettingsTestFile(t, settingsPath, `{
+				"schemaVersion": 1,
+				"targets": [{"name":"App","configurations":[{"name":"Debug","settings":{"CODE_SIGN_STYLE":"manual"}}]}]
+			}`)
+
+			opts := SigningPlanOptions{
+				ProjectPath: project, SettingsFilePath: settingsPath,
+				StateDir: filepath.Join(root, "state"),
+			}
+			test.configure(&opts, protectedPath)
+			plan, err := BuildSigningPlan(opts)
+			if err == nil || (!strings.Contains(err.Error(), "aliases project input") && !strings.Contains(err.Error(), "protected project input")) {
+				t.Fatalf("BuildSigningPlan() = plan=%#v, error=%v; want project fallback alias rejection", plan, err)
+			}
+			if got := mustReadVersionTestFile(t, protectedPath); got != existingEntitlements {
+				t.Fatalf("project fallback entitlement changed while validating %s: %q", test.name, got)
+			}
+		})
+	}
+}
+
+func TestSigningPlanDoesNotCrossComposeDivergentProjectEntitlementSeeds(t *testing.T) {
+	tests := []struct {
+		name           string
+		widgetSettings string
+		widgetXCConfig string
+		actualSeed     string
+	}{
+		{
+			name:           "target xcconfig override",
+			widgetSettings: `CODE_SIGN_ENTITLEMENTS = "$(inherited)Suffix";`,
+			widgetXCConfig: "CODE_SIGN_ENTITLEMENTS = Target\n",
+			actualSeed:     "TargetSuffix",
+		},
+		{
+			name:           "target conditional inherits local slot",
+			widgetSettings: `CODE_SIGN_ENTITLEMENTS = Local; "CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]" = "$(inherited)Suffix";`,
+			actualSeed:     "LocalSuffix",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			project := writeDivergentInheritedProjectEntitlementFixture(t, test.widgetSettings, test.widgetXCConfig)
+			projectRoot := filepath.Dir(project)
+			actualPath := filepath.Join(projectRoot, test.actualSeed)
+			const existingActual = "existing live entitlement seed bytes\n"
+			if err := os.WriteFile(actualPath, []byte(existingActual), 0o600); err != nil {
+				t.Fatalf("WriteFile(%s) error = %v", test.actualSeed, err)
+			}
+
+			root := t.TempDir()
+			settingsPath := filepath.Join(root, "settings.json")
+			writeSigningSettingsTestFile(t, settingsPath, `{
+				"schemaVersion": 1,
+				"targets": [{"name":"App","configurations":[{"name":"Debug","settings":{"CODE_SIGN_STYLE":"manual"}}]}]
+			}`)
+			phantomPath := filepath.Join(projectRoot, "BaseSuffix")
+			plan, err := BuildSigningPlan(SigningPlanOptions{
+				ProjectPath: project, SettingsFilePath: settingsPath,
+				PlanPath: phantomPath, StateDir: filepath.Join(root, "state"),
+			})
+			if err != nil {
+				t.Fatalf("BuildSigningPlan() for phantom project seed = plan=%#v, error=%v; want no alias rejection", plan, err)
+			}
+			if plan == nil {
+				t.Fatal("BuildSigningPlan() returned nil plan for phantom project seed")
+			}
+			if strings.Contains(strings.Join(plan.Blockers, "\n"), "aliases project input") || strings.Contains(strings.Join(plan.Blockers, "\n"), "protected project input") {
+				t.Fatalf("phantom project seed became an artifact alias blocker: %#v", plan.Blockers)
+			}
+
+			actualRoot := t.TempDir()
+			actualSettingsPath := filepath.Join(actualRoot, "settings.json")
+			writeSigningSettingsTestFile(t, actualSettingsPath, `{
+				"schemaVersion": 1,
+				"targets": [{"name":"App","configurations":[{"name":"Debug","settings":{"CODE_SIGN_STYLE":"manual"}}]}]
+			}`)
+			actualPlan, err := BuildSigningPlan(SigningPlanOptions{
+				ProjectPath: project, SettingsFilePath: actualSettingsPath,
+				PlanPath: actualPath, StateDir: filepath.Join(actualRoot, "state"),
+			})
+			if err == nil || (!strings.Contains(err.Error(), "aliases project input") && !strings.Contains(err.Error(), "protected project input")) {
+				t.Fatalf("BuildSigningPlan() for live project seed = plan=%#v, error=%v; want actual entitlement alias rejection", actualPlan, err)
+			}
+			if got := mustReadVersionTestFile(t, actualPath); got != existingActual {
+				t.Fatalf("live entitlement seed changed during alias validation: %q", got)
+			}
+		})
+	}
+}
+
+func writeDivergentInheritedProjectEntitlementFixture(t *testing.T, widgetSettings, widgetXCConfig string) string {
+	return writeInheritedProjectEntitlementFixture(t,
+		`CODE_SIGN_ENTITLEMENTS = Other; "CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]" = Base;`,
+		widgetSettings, widgetXCConfig)
+}
+
+func writeReferencedDivergentInheritedProjectEntitlementFixture(t *testing.T, widgetSettings, widgetXCConfig string) string {
+	project := writeInheritedProjectEntitlementFixture(t,
+		`CODE_SIGN_ENTITLEMENTS = Other; "CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]" = "$(PRODUCT_NAME)";`,
+		widgetSettings, widgetXCConfig)
+	pbxprojPath := filepath.Join(project, "project.pbxproj")
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999993", `PRODUCT_NAME = App;`)
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999995", `PRODUCT_NAME = Widget;`)
+	return project
+}
+
+func writeInheritedProjectEntitlementFixture(t *testing.T, projectSettings, widgetSettings, widgetXCConfig string) string {
+	t.Helper()
+	project := writeStructuredVersionProject(t, false)
+	pbxprojPath := filepath.Join(project, "project.pbxproj")
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999991", projectSettings)
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999993",
+		`CODE_SIGN_ENTITLEMENTS = App.entitlements;`)
+	if widgetXCConfig != "" {
+		attachSigningWidgetXCConfig(t, project, widgetXCConfig)
+	}
+	injectSigningBuildSetting(t, pbxprojPath, "999999999999999999999995", widgetSettings)
+	projectRoot := filepath.Dir(project)
+	if err := os.WriteFile(filepath.Join(projectRoot, "App.entitlements"), []byte("<?xml version=\"1.0\"?><plist version=\"1.0\"><dict/></plist>\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(App.entitlements) error = %v", err)
+	}
+	return project
+}
+
 // TestSigningPlanProtectsIdenticalConditionalInheritedEntitlementComposition
 // pins Xcode's build-setting evaluation for a conditional assignment whose text
 // matches the object's unconditional assignment. Xcode resolves $(inherited) to


### PR DESCRIPTION
## Problem

Signing plans and structured-version receipts can be written over an
entitlement input that belongs to another target or configuration. This was
possible when the input was supplied by a project-level PBX assignment or
project xcconfig and the consuming target used `$(inherited)`, especially
when conditional assignments or append operations produced a composed path.
Passing `--overwrite` must never allow the plan or receipt artifact to replace
such a live input.

## Change

The signing input inventory now resolves project PBX and project xcconfig
seeds in each consuming target context before an artifact write. It preserves
target override precedence, expands referenced project xcconfig values before
applying target inheritance, and retains the concrete paths that can
contribute through conditional and append assignments. Shadowed or
nonexistent paths are skipped. If a target-context expansion cannot be
resolved safely, the inventory keeps the lexical candidate or fails closed
through the existing validation path rather than guessing a path.

The protection applies to both signing-plan artifacts and structured-version
receipts. Alias detection happens before artifact publication, so the
pre-existing entitlement bytes remain unchanged when a protected input is
selected. Effective setting resolution for a valid, non-alias plan is
unchanged.

The existing commands remain the interface:

```bash
asc xcode signing plan --project ./App.xcodeproj --settings-file .asc/xcode-signing.json
asc xcode signing plan --project ./App.xcodeproj --settings-file .asc/xcode-signing.json --state-dir .asc/xcode/signing --output json
asc xcode signing apply --plan .asc/xcode/signing/plan.json --confirm
asc xcode signing apply --plan .asc/xcode/signing/plan.json --confirm --output json
```

No new CLI command, flag, Apple endpoint, request, response, or output shape
is added. The behavior is local filesystem protection inside
`internal/xcode/signing_settings.go`.

## Regression coverage

The regression suite covers plan and receipt aliases plus the resolver cases
that previously allowed an overwrite:

- `TestSigningPlanProtectsDivergentInheritedProjectEntitlementSeeds`
- `TestSigningPlanProtectsDivergentInheritedProjectXCConfigEntitlementSeeds`
- `TestSigningPlanExpandsReferencedProjectXCConfigEntitlementSeedInTargetContext`
- `TestSigningPlanSkipsShadowedProjectXCConfigReferenceForTargetOverride`
- `TestSigningPlanProtectsProjectXCConfigReferenceWhenTargetExpansionFails`
- `TestSigningPlanSkipsProjectXCConfigExpressionWhenAllTargetsOverride`
- `TestSigningPlanComposesProjectXCConfigReferenceThroughInheritedTarget`
- `TestSigningPlanComposesProjectXCConfigReferenceThroughInheritedTargetXCConfig`
- `TestSigningPlanDoesNotCrossComposeDivergentProjectEntitlementSeeds`
- `TestSigningPlanTreatsRepeatedTargetXCConfigInheritedAfterLiteralAsLocal`
- `TestSigningPlanSkipsShadowedProjectXCConfigWhenProjectPBXEntitlementOverrides`
- `TestSigningPlanProtectsProjectSeedBelowConditionalTargetXCConfig`

## Validation

The focused project and xcconfig acceptance command passed:

```bash
ASC_BYPASS_KEYCHAIN=1 GOMAXPROCS=2 go test -p=1 -parallel=1 ./internal/xcode -run 'TestSigningPlan(ProtectsDivergentInheritedProjectXCConfigEntitlementSeeds|ExpandsReferencedProjectXCConfigEntitlementSeedInTargetContext|Protects(DivergentInheritedProjectEntitlementSeeds|ReferencedDivergentInheritedProjectEntitlementSeeds|ProjectSeedBelowConditionalTargetXCConfig)|DoesNotCrossComposeDivergentProjectEntitlementSeeds)' -count=1
```

Recorded result:

```text
ok github.com/rudrankriyam/App-Store-Connect-CLI/internal/xcode 0.480s
```

The repository gates and commit hook passed:

```bash
make build
make format
make check-docs
make lint
ASC_BYPASS_KEYCHAIN=1 make test
```

The full test gate completed successfully in 139.45 seconds. The final
full-branch review of head `142a1e3d592fe812b8813d1b12024f31f3bc610e` against
`main` at `7d78e32ef7fc3393750ff1573589db8a42bcf438` reported no actionable
defects. No Apple account, provider request, or live signing artifact is
used by this change.

Fixes #2366.


## Final merge validation

The final committed head `36677b4ea5a2f85a92b40823bb6d49aa8908aa14` was reviewed against `main` at `bd5ef09765ddfe11493db0c5066ca4994b3cc1f0`. Required local build, formatting, documentation, lint and test gates and the normal commit hook passed. The final full-branch local `/review` reported no actionable findings. This additive update preserves the PR history. GitHub-required checks are verified separately before merge.
