### PR TITLE
Test competing writes during web session import

### DIFF
--- a/internal/web/session_transfer_test.go
+++ b/internal/web/session_transfer_test.go
@@ -673,6 +673,116 @@ func TestImportSessionBundleNoOverwriteDoesNotReplaceKeychainSession(t *testing.
 	}
 }
 
+// The command-layer preflight can observe an empty file cache while another
+// process writes the same account to the keychain before import reaches its
+// final persistence boundary. The file backend's keychain fallback must treat
+// that writer as an occupied entry and preserve its last-session choice.
+func TestImportSessionBundleNoOverwritePreservesSessionWrittenDuringKeychainFallbackPreflight(t *testing.T) {
+	withArraySessionKeyring(t)
+	t.Setenv(webSessionCacheEnabledEnv, "1")
+	t.Setenv(webSessionCacheDirEnv, filepath.Join(t.TempDir(), "web-cache"))
+	withStubbedSessionSharedLockRoot(t, t.TempDir())
+
+	key := webSessionCacheKey(webTestSessionEmail)
+	importer := backendSelection{backend: sessionBackendFile, fallbackKeychain: true}
+	writer := backendSelection{backend: sessionBackendKeychain}
+
+	if _, ok, err := readSessionBySelection(importer, key); err != nil || ok {
+		t.Fatalf("import preflight = (%v, %v), want an empty cache", ok, err)
+	}
+	if err := persistSessionBySelection(writer, key, webTestPersistedSession(t, "keychain-token", time.Now().UTC())); err != nil {
+		t.Fatalf("concurrent keychain writer error: %v", err)
+	}
+
+	err := persistImportedSessionBySelection(importer, key, webTestPersistedSession(t, "import-token", time.Now().UTC()), false)
+	if !errors.Is(err, os.ErrExist) {
+		t.Fatalf("no-overwrite import error = %v, want an atomic keychain-fallback conflict", err)
+	}
+	stored, ok, err := readSessionFromKeychain(key)
+	if err != nil || !ok {
+		t.Fatalf("readSessionFromKeychain() = (%v, %v), want the concurrent writer", ok, err)
+	}
+	if got := persistedMyacinfoCookieValue(stored, "https://appstoreconnect.apple.com/"); got != "keychain-token" {
+		t.Fatalf("keychain cookie = %q, want keychain-token", got)
+	}
+	last, ok, err := readLastSessionFromKeychain()
+	if err != nil || !ok || last.UserEmail != webTestSessionEmail {
+		t.Fatalf("readLastSessionFromKeychain() = (%+v, %v, %v), want the concurrent writer's marker", last, ok, err)
+	}
+}
+
+// The selected file backend must enforce the same guarantee at its final
+// O_EXCL create, even when both the preflight and the writer use that backend.
+func TestImportSessionBundleNoOverwritePreservesSessionWrittenDuringFilePreflight(t *testing.T) {
+	withArraySessionKeyring(t)
+	t.Setenv(webSessionCacheEnabledEnv, "1")
+	t.Setenv(webSessionCacheDirEnv, filepath.Join(t.TempDir(), "web-cache"))
+	withStubbedSessionSharedLockRoot(t, t.TempDir())
+
+	key := webSessionCacheKey(webTestSessionEmail)
+	selection := backendSelection{backend: sessionBackendFile}
+
+	if _, ok, err := readSessionBySelection(selection, key); err != nil || ok {
+		t.Fatalf("import preflight = (%v, %v), want an empty cache", ok, err)
+	}
+	if err := persistSessionBySelection(selection, key, webTestPersistedSession(t, "file-token", time.Now().UTC())); err != nil {
+		t.Fatalf("concurrent file writer error: %v", err)
+	}
+
+	err := persistImportedSessionBySelection(selection, key, webTestPersistedSession(t, "import-token", time.Now().UTC()), false)
+	if !errors.Is(err, os.ErrExist) {
+		t.Fatalf("no-overwrite import error = %v, want an atomic file conflict", err)
+	}
+	stored, ok, err := readSessionFromFile(key)
+	if err != nil || !ok {
+		t.Fatalf("readSessionFromFile() = (%v, %v), want the concurrent writer", ok, err)
+	}
+	if got := persistedMyacinfoCookieValue(stored, "https://appstoreconnect.apple.com/"); got != "file-token" {
+		t.Fatalf("file cookie = %q, want file-token", got)
+	}
+	lastKey, ok, err := readLastKeyFromFile()
+	if err != nil || !ok || lastKey != key {
+		t.Fatalf("readLastKeyFromFile() = (%q, %v, %v), want the concurrent writer's marker", lastKey, ok, err)
+	}
+}
+
+// The reverse configuration has the same final-write guarantee: a keychain
+// selected import must not replace a file entry that appeared after its
+// command-layer preflight.
+func TestImportSessionBundleNoOverwritePreservesSessionWrittenDuringFileFallbackPreflight(t *testing.T) {
+	withArraySessionKeyring(t)
+	t.Setenv(webSessionCacheEnabledEnv, "1")
+	t.Setenv(webSessionCacheDirEnv, filepath.Join(t.TempDir(), "web-cache"))
+	withStubbedSessionSharedLockRoot(t, t.TempDir())
+
+	key := webSessionCacheKey(webTestSessionEmail)
+	importer := backendSelection{backend: sessionBackendKeychain, fallbackFile: true}
+	writer := backendSelection{backend: sessionBackendFile}
+
+	if _, ok, err := readSessionBySelection(importer, key); err != nil || ok {
+		t.Fatalf("import preflight = (%v, %v), want an empty cache", ok, err)
+	}
+	if err := persistSessionBySelection(writer, key, webTestPersistedSession(t, "file-token", time.Now().UTC())); err != nil {
+		t.Fatalf("concurrent file writer error: %v", err)
+	}
+
+	err := persistImportedSessionBySelection(importer, key, webTestPersistedSession(t, "import-token", time.Now().UTC()), false)
+	if !errors.Is(err, os.ErrExist) {
+		t.Fatalf("no-overwrite import error = %v, want an atomic file-fallback conflict", err)
+	}
+	stored, ok, err := readSessionFromFile(key)
+	if err != nil || !ok {
+		t.Fatalf("readSessionFromFile() = (%v, %v), want the concurrent writer", ok, err)
+	}
+	if got := persistedMyacinfoCookieValue(stored, "https://appstoreconnect.apple.com/"); got != "file-token" {
+		t.Fatalf("file cookie = %q, want file-token", got)
+	}
+	lastKey, ok, err := readLastKeyFromFile()
+	if err != nil || !ok || lastKey != key {
+		t.Fatalf("readLastKeyFromFile() = (%q, %v, %v), want the concurrent writer's marker", lastKey, ok, err)
+	}
+}
+
 func TestImportSessionBundleOverwriteRemovesFileFallbackOnKeychainBackend(t *testing.T) {
 	withArraySessionKeyring(t)
 	withSessionInfoStub(t)


### PR DESCRIPTION
## Problem

Web session import has a no-overwrite contract: an import must not replace a
session that another writer installs after command preflight but before final
persistence. The existing persistence code already uses exclusive file
creation and create-if-absent keychain operations under the shared locks. The
remaining gap for #2382 was deterministic proof across the file, keychain
fallback, and cross-backend fallback paths.

Issue #567 is a separate environment-input proposal. Its exact variable
format, account binding, persistence behavior, cookie or bundle representation,
and provider/CSRF requirements are not captured well enough to add safely in
this PR.

## Change

This PR adds only `internal/web/session_transfer_test.go`. It adds no
production code, command, flag, cache schema, output shape, Apple request, or
authentication mechanism.

The three new tests arrange a competing writer at the final persistence
boundary without timing sleeps or network calls:

- `TestImportSessionBundleNoOverwritePreservesSessionWrittenDuringFilePreflight`
- `TestImportSessionBundleNoOverwritePreservesSessionWrittenDuringKeychainFallbackPreflight`
- `TestImportSessionBundleNoOverwritePreservesSessionWrittenDuringFileFallbackPreflight`

Each case asserts the no-overwrite conflict, preserves the competing
credentials and last-session marker, and exercises the final exclusive writer
rather than only the earlier command-layer preflight. Existing occupied
keychain coverage remains in place.

The existing user-facing commands and their contracts remain:

```bash
asc web auth export --output-path ./web-session.json
asc web auth import --file ./web-session.json
asc web auth status
```

`asc web auth import` validates and stores the local bundle without an Apple
request. `asc web auth status` is the explicit command for resumed-session
validation with Apple. The existing `--overwrite` option keeps its
replacement semantics, for example:

```bash
asc web auth export --output-path ./web-session.json --overwrite --output json
asc web auth import --file ./web-session.json --overwrite
```

## Compatibility and remaining scope

This is proof for the existing no-overwrite behavior. It does not change
session selection, lock ordering, keychain storage, fallback rules, output,
or error handling. The tests use temporary cache directories, an in-memory
array keyring, and an isolated lock root; they do not touch a live Apple
account or network.

The proposed `ASC_WEB_SESSION` environment handoff from #567 is not
implemented here. A future change needs an explicit decision on whether the
value is the existing JSON `SessionBundle`, cookie text, or another format;
whether it is persisted; how Apple ID binding is checked; and how secrets are
kept out of process and CI diagnostics. This PR should therefore be credited
with #2382 acceptance proof only.

## Validation

The focused acceptance command passed:

```bash
ASC_BYPASS_KEYCHAIN=1 GOMAXPROCS=2 go test -p=1 -parallel=1 -count=1 ./internal/web -run 'TestImportSessionBundleNoOverwritePreservesSessionWrittenDuring(FilePreflight|KeychainFallbackPreflight|FileFallbackPreflight)$'
```

Recorded result:

```text
ok github.com/rudrankriyam/App-Store-Connect-CLI/internal/web 0.568s
```

The repository gates and commit hook also passed:

```bash
make build
make format
make check-docs
make lint
ASC_BYPASS_KEYCHAIN=1 make test
```

The full test gate completed successfully in 141.62 seconds. The final
committed review of head `453e6ce8ca276fc43c9ad9df434a699c17184f09` against
`main` at `7d78e32ef7fc3393750ff1573589db8a42bcf438` reported no actionable
defects, with the full gates and hook passing outside the review sandbox.

Refs #2382. See #567 for the separate contract decision.


## Final merge validation

The final committed head `2b666311edaeece79363574f403811a9a54e0d16` was reviewed against `main` at `854ef259751590486c1cf76d574f09184e853f78`. Build, formatting, lint and the full Go suite passed on integration head d51f74c7a874c71dbade91f2aaafb1648dd70953. The subsequent main update changed only 13 guidance/contribution files; Go, build and test inputs were verified unchanged, so those passing results were reused. Documentation checks and the normal merge commit hook, including its short Go suite, passed again after that update. The final full-branch local `/review` reported no actionable findings. This additive update preserves the PR history. GitHub-required checks are verified separately before merge.
