### PR TITLE
Document verified reverse privacy identity updates

### DIFF
--- a/commands/web.mdx
+++ b/commands/web.mdx
@@ -411,7 +411,7 @@ Available commands:
 * `asc web privacy catalog` - list valid privacy declaration tokens
 * `asc web privacy pull` - fetch the current declaration state
 * `asc web privacy plan` - diff a local declaration file against remote state
-* `asc web privacy apply` - apply declaration changes without publishing
+* `asc web privacy apply` - apply declaration changes without calling Apple's publish endpoint; usage mutations may update published-state metadata
 * `asc web privacy publish` - explicitly publish the declaration
 
 Recommended flow:

--- a/docs/API_NOTES.md
+++ b/docs/API_NOTES.md
@@ -5,10 +5,10 @@ Quirks and tips for specific App Store Connect API endpoints.
 ## Web App Privacy Data Usage Updates
 
 - Live canary on 2026-09-04 using a disposable app and a redacted web session verified the private `PATCH /iris/v1/appDataUsages/{usageID}` contract for a same-category, same-purpose `DATA_LINKED_TO_YOU` to `DATA_NOT_LINKED_TO_YOU` identity flip. The request uses the existing `appDataUsages` JSON:API resource and its `dataProtection` relationship; Apple returned `200`, and a fresh GET showed the same usage ID with the new protection.
-- The reverse `DATA_NOT_LINKED_TO_YOU` to `DATA_LINKED_TO_YOU` transition was not exercised by this canary and remains unverified; do not infer it from this note.
+- A second live canary on 2026-09-05 using the same disposable app verified the reverse `DATA_NOT_LINKED_TO_YOU` to `DATA_LINKED_TO_YOU` transition. The temporary `EMAIL_ADDRESS`/`APP_FUNCTIONALITY` tuple returned `200`, and a fresh GET retained the same usage ID with the new protection. The exact pre-canary `DATA_NOT_COLLECTED` baseline was restored and matched on a fresh GET.
 - The canary seeded the tuple with `POST` (`201`), confirmed it by GET, then restored the semantic baseline by deleting it (`204`) and creating the `DATA_NOT_COLLECTED` declaration (`201`). Direct restore attempts via `POST` or `PATCH` to `DATA_NOT_COLLECTED` returned `409 STATE_ERROR`.
 - The direct mutations advanced the remote `lastPublished` value while `published` remained `true`, despite no publish endpoint being called. Treat this path as a published-state mutation; do not describe the canary or `asc web privacy apply` as unpublished-only.
-- For the verified transition, the planner must pair only the same-category, same-purpose identity flip into a PATCH update. Tracking, `DATA_NOT_COLLECTED`, and scope changes remain delete/create operations; other identity-transition directions are not covered by this live contract.
+- For these verified transitions, the planner must pair only a same-category, same-purpose identity flip in either direction into a PATCH update. Tracking, `DATA_NOT_COLLECTED`, and scope changes remain delete/create operations.
 
 ## Apple Ads Profile Context Isolation
 

--- a/internal/cli/web/web_privacy.go
+++ b/internal/cli/web/web_privacy.go
@@ -1948,7 +1948,8 @@ func WebPrivacyApplyCommand() *ffcli.Command {
 		LongHelp: `WEB SESSION WORKFLOWS
 
 Apply local declaration tuples to remote app data usages.
-This command never publishes automatically.
+This command never calls Apple's publish endpoint automatically, but applying
+usage mutations may still update Apple's published-state metadata.
 
 Declarations that contain UNKNOWN_OR_MISSING (unrepresentable remote data)
 are rejected before any create, update, or delete.

--- a/internal/cli/web/web_privacy.go
+++ b/internal/cli/web/web_privacy.go
@@ -1660,7 +1660,8 @@ Subcommands:
   catalog  List category/purpose/data-protection tokens for declaration authoring
   pull     Fetch current app data usage declarations as canonical JSON
   plan     Diff local declaration file against remote state
-  apply    Apply planned changes (never publishes automatically)
+  apply    Apply planned changes (does not call Apple's publish endpoint;
+          usage mutations may update published-state metadata)
   publish  Explicitly publish app data usage declarations
 
 `,


### PR DESCRIPTION
## What this PR records

This PR closes the evidence gap in issue #2295 for the reverse privacy identity transition. A live canary on disposable app `6759231657` changed a same-category, same-purpose usage from `DATA_NOT_LINKED_TO_YOU` to `DATA_LINKED_TO_YOU`; Apple returned `200`, a fresh read kept the same usage ID, and the new protection was visible. The temporary declaration was then removed and the original `DATA_NOT_COLLECTED` baseline was restored and matched on a fresh read.

The existing privacy planner and PATCH implementation already handle the same-scope identity update. This PR does not add another endpoint or implementation. It updates `docs/API_NOTES.md` with the reverse canary and clarifies the parent `privacy` help, `privacy apply` help and website command summary so operators don't read “no publish call” as “no published-state change.”

## Existing versus new

`asc web privacy pull`, `plan`, `apply`, and `publish` already provide the workflow. The private update request is already:

```text
PATCH /iris/v1/appDataUsages/{USAGE_ID}
```

using an `appDataUsages` JSON:API resource whose `dataProtection` relationship carries the requested token. The planner pairs only a same-category, same-purpose identity flip, in either direction, as an update. Tracking, `DATA_NOT_COLLECTED`, and category, purpose, or scope changes continue to use their existing delete/create operations.

The new evidence covers the direction that had previously remained unverified. It also records that the direct mutations advanced Apple's `lastPublished` value while `published` stayed `true`, even though the explicit publish endpoint was never called.

## Operator commands and flags

The evidence flow uses the existing commands:

```bash
asc web privacy pull \
  --app 6759231657 \
  --out /tmp/privacy-baseline.json \
  --output json \
  --pretty

asc web privacy plan \
  --app 6759231657 \
  --file /tmp/privacy-reverse.json \
  --output json \
  --pretty

asc web privacy apply \
  --app 6759231657 \
  --file /tmp/privacy-reverse.json \
  --output json \
  --pretty

asc web privacy apply \
  --app 6759231657 \
  --file /tmp/privacy-baseline.json \
  --allow-deletes \
  --confirm \
  --output json \
  --pretty
```

`--app` selects an App Store Connect app ID and defaults from `ASC_APP_ID`; `--file` names the canonical declaration JSON; `--out` is available on `pull`. `--allow-deletes` is required when the plan contains deletes, and `--confirm` is required with it. The shared session flags are `--apple-id`, `--provider-id`, `--public-provider-id`, and `--two-factor-code-command`. `--output json|table|markdown` and `--pretty` control the receipt. `asc web privacy publish --app 6759231657 --confirm` remains a separate explicit action and was not called by the canary.

The help now says:

```text
This command never calls Apple's publish endpoint automatically, but applying
usage mutations may still update Apple's published-state metadata.
```

## Output contract

`pull` reports `appId`, the canonical `declaration`, `publishState`, and `unrepresentableCount`; when `--out` is used it also reports the output path. `plan` reports `appId`, `file`, `updates`, `adds`, `deletes`, optional `skippedDeletes`, optional `staleTokens`, and the planned `apiCalls`.

`apply` reports the plan plus `applied`, `changed`, and action buckets. A successful receipt looks like:

```json
{
  "appId": "6759231657",
  "file": "/tmp/privacy-reverse.json",
  "updates": [
    {
      "key": "EMAIL_ADDRESS|APP_FUNCTIONALITY",
      "category": "EMAIL_ADDRESS",
      "purpose": "APP_FUNCTIONALITY",
      "dataProtection": "DATA_LINKED_TO_YOU",
      "usageId": "USAGE_ID"
    }
  ],
  "adds": [],
  "deletes": [],
  "applied": true,
  "changed": true,
  "actions": [
    {
      "action": "update",
      "key": "EMAIL_ADDRESS|APP_FUNCTIONALITY",
      "usageId": "USAGE_ID",
      "dataProtection": "DATA_LINKED_TO_YOU"
    }
  ]
}
```

If a mutation has no confirmed outcome, the receipt separates `unknownActions` from `notAppliedActions`, performs one fresh remote re-read, and includes `recheck`. `changed` is omitted when an attempted action remains unresolved instead of pretending that the invocation was a no-op. A non-zero error still directs the operator to inspect the receipt and current remote state.

## Evidence and limits

The canary started from the exact `DATA_NOT_COLLECTED` baseline, seeded a temporary `EMAIL_ADDRESS`/`APP_FUNCTIONALITY` tuple, confirmed the tuple, applied the reverse identity update, and verified the same usage ID after a fresh read. Restore removed the temporary tuple and recreated the baseline; final semantic comparison matched the original declaration. Restore attempts that tried to write `DATA_NOT_COLLECTED` directly returned `409 STATE_ERROR`, so the documented cleanup uses delete plus create.

No publish endpoint was called. The observed `lastPublished` change means this path must be treated as a published-state mutation, and the help/docs no longer describe it as unpublished-only. The private `/iris` contract is absent from the public OpenAPI snapshot, and the canary proves this state on the disposable app only; it does not remove Apple's account or app eligibility rules.

## Validation

The documentation-only branch passed:

```bash
make generate-command-docs
make check-docs
```

The repository commit hook passed, and local `/review` of the committed diff against the current `origin/main` found no actionable findings. GitHub check status remains separate.


## Final merge validation

The final committed head `cb75fd3cbfd74ea444c16dcd4ba6eae107dee236` was reviewed against `main` at `89c13fa4b85667a369191ee66eef70194d99585f`. The integrated head passed make build, make format, make check-docs, make lint, and ASC_BYPASS_KEYCHAIN=1 make test (full suite). Formatting left the tree unchanged. The original change commit passed its normal staged hook; the additive merge was additionally checked by the complete local gates. No runtime behavior was changed by this help/documentation correction. The final full-branch local `/review` reported no actionable findings. This additive update preserves the PR history. GitHub-required checks are verified separately before merge.
