### PR TITLE
docs: clarify agent authorization and completion rules

### DIFF
--- a/.agents/skills/audit-asc-pr/SKILL.md
+++ b/.agents/skills/audit-asc-pr/SKILL.md
@@ -5,7 +5,7 @@ description: Audit App-Store-Connect-CLI pull requests end to end and fix concre
 
 # Audit an ASC CLI pull request
 
-Perform an evidence-first review of the entire pull request. An audit is read-only unless the user also authorizes fixes; follow the authority and review requirements in `AGENTS.md`.
+Audit the entire PR under the authority and review rules in `AGENTS.md`.
 
 ## Establish the contract
 
@@ -13,9 +13,6 @@ Perform an evidence-first review of the entire pull request. An audit is read-on
 2. Read the PR body, every commit, linked issues, current checks, reviews, and comments.
 3. Fetch thread-aware review state with GitHub GraphQL. Do not treat a flat comment list as proof that all review threads are resolved.
 4. State the behavior the PR claims to change and the evidence needed to prove it.
-5. Resolve authorization for fixes, commits, pushes, review communication, approval, and merge from the request and session context. Do not ask again for authority already granted or infer it from skill selection.
-
-Fetch independent read-only metadata, diff, check, schema, and review-thread evidence in parallel or with isolated subagents when available. Keep one coordinated owner for edits, pushes, review replies and resolutions, approvals, and merges.
 
 ## Isolate and inspect
 
@@ -36,11 +33,11 @@ Fetch independent read-only metadata, diff, check, schema, and review-thread evi
 
 ## Fix forward
 
-Use this section only for authorized fixes. Commit, push, and communicate review results only within the established authority; otherwise report findings and the proposed correction.
+For authorized fixes:
 
 1. Reproduce each defect before changing code.
 2. Add or adjust a failing regression test, confirm the failure, implement the smallest coherent fix, and rerun the focused test.
-3. Keep commits logical and traceable to findings or review threads. Add fixes as new commits; do not squash, rebase, force-push, or otherwise rewrite the PR history unless the user explicitly requests it.
+3. Add fixes as logical commits traceable to findings or review threads.
 4. Push to the PR head when permitted. If the contributor branch cannot accept maintainer pushes, report the exact limitation and prepare a separate fix PR only when authorized.
 5. When review communication is authorized, reply to and resolve only threads fully addressed by the pushed change.
 6. Re-fetch the head SHA, checks, reviews, and GraphQL threads after every push.
@@ -51,7 +48,7 @@ Do not post a generic top-level audit summary unless the user asks. Put actionab
 
 Do not call the PR ready until all of the following are true:
 
-- The latest head was audited and compared read-only with current `main`; GitHub reports no merge conflict. Do not update, rebase, or merge `main` into a clean PR merely because `main` advanced.
+- The latest head was audited against current `main` under the branch-update rules in `AGENTS.md`.
 - The final committed head passed the full-branch local review loop required by `AGENTS.md` against the current authoritative base, with no subsequent diff change.
 - Relevant focused and GitHub-required checks pass. Non-required checks may still be pending.
 - No actionable unresolved review thread remains.
@@ -59,10 +56,8 @@ Do not call the PR ready until all of the following are true:
 - GitHub reports the PR mergeable without conflicts. Interpret `BLOCKED` or `UNSTABLE` through the required-check, required-review, and thread gates above; do not require a `CLEAN` merge state when only advisory jobs remain.
 - Live or deterministic verification supports the claimed behavior.
 
-Use `$watch-asc-pr` after the first push when required checks, required reviews, or actionable reviewers are still pending. When the user asked to loop until green, keep running watch passes after each push and fresh review result until the latest head is clean or materially blocked; do not hand off merely because required checks or reviews are pending. Do not start or continue a watch loop only for advisory jobs.
-
-Approve or merge only when the user asked for that action. When merge is authorized, preserve the PR commits with a regular merge commit such as `gh pr merge --merge --match-head-commit <sha>`. Do not squash unless the user explicitly requests squash for that PR.
+For requested follow-up monitoring, use `$watch-asc-pr`. Approve and merge only under the authority, history, and exact-head rules in `AGENTS.md`.
 
 ## Hand off
 
-Lead with findings and the merge recommendation, then decisive evidence and remaining gates. Include fixes, commits, pushes, live mutations, and cleanup when performed. An audit may finish with unresolved findings without calling the PR ready.
+Report findings, evidence, remaining gates, and the merge recommendation. Include any fixes, pushes, live mutations, and cleanup.

--- a/.agents/skills/audit-asc-pr/SKILL.md
+++ b/.agents/skills/audit-asc-pr/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: audit-asc-pr
-description: Audit App-Store-Connect-CLI pull requests end to end and fix concrete defects. Use when the user asks to audit or review a PR, decide whether a PR is valuable or slop, verify that a PR truly solves its issue, assess blast radius, or make a PR code-ready before merge.
+description: Audit App-Store-Connect-CLI pull requests end to end and fix concrete defects when authorized. Use for PR review, value and blast-radius assessment, issue verification, or requested fixes before merge.
 ---
 
 # Audit an ASC CLI pull request
 
-Perform an evidence-first review of the entire pull request. Default to fix-forward work unless the user explicitly requests review-only.
+Perform an evidence-first review of the entire pull request. An audit is read-only unless the user also authorizes fixes; follow the authority and review requirements in `AGENTS.md`.
 
 ## Establish the contract
 
@@ -13,7 +13,7 @@ Perform an evidence-first review of the entire pull request. Default to fix-forw
 2. Read the PR body, every commit, linked issues, current checks, reviews, and comments.
 3. Fetch thread-aware review state with GitHub GraphQL. Do not treat a flat comment list as proof that all review threads are resolved.
 4. State the behavior the PR claims to change and the evidence needed to prove it.
-5. Confirm whether the user authorized fixes, pushes, approval, or merge. An audit authorizes fix-forward changes in this repository, but approval and merge still require explicit user intent.
+5. Resolve authorization for fixes, commits, pushes, review communication, approval, and merge from the request and session context. Do not ask again for authority already granted or infer it from skill selection.
 
 Fetch independent read-only metadata, diff, check, schema, and review-thread evidence in parallel or with isolated subagents when available. Keep one coordinated owner for edits, pushes, review replies and resolutions, approvals, and merges.
 
@@ -31,16 +31,18 @@ Fetch independent read-only metadata, diff, check, schema, and review-thread evi
 2. Build a binary when CLI behavior, flags, output, or exit codes changed. Exercise realistic invocations against the built binary.
 3. For API-facing changes, verify the exact endpoint and method in `docs/openapi/latest.json`, including create-versus-update attributes and endpoint-specific query parameters.
 4. Run focused tests first, then checks required by repository policy or proportional to the diff. Pending or unrelated advisory CI does not block the audit once required checks pass; report relevant advisory failures.
-5. Prefer read-only live App Store Connect verification. When mutation is necessary, use the disposable app `6759231657`, clean up temporary resources, and record anything that could not be removed. Never mutate another app without explicit approval.
+5. Prefer read-only live App Store Connect verification. If live mutations and their cleanup are authorized, use the disposable app `6759231657` and record anything that could not be removed. Never mutate another app without explicit approval.
 6. Preserve uncertainty when live state cannot reproduce an edge case; use deterministic fixtures or tests instead of claiming success.
 
 ## Fix forward
+
+Use this section only for authorized fixes. Commit, push, and communicate review results only within the established authority; otherwise report findings and the proposed correction.
 
 1. Reproduce each defect before changing code.
 2. Add or adjust a failing regression test, confirm the failure, implement the smallest coherent fix, and rerun the focused test.
 3. Keep commits logical and traceable to findings or review threads. Add fixes as new commits; do not squash, rebase, force-push, or otherwise rewrite the PR history unless the user explicitly requests it.
 4. Push to the PR head when permitted. If the contributor branch cannot accept maintainer pushes, report the exact limitation and prepare a separate fix PR only when authorized.
-5. Reply to and resolve only threads fully addressed by the pushed change.
+5. When review communication is authorized, reply to and resolve only threads fully addressed by the pushed change.
 6. Re-fetch the head SHA, checks, reviews, and GraphQL threads after every push.
 
 Do not post a generic top-level audit summary unless the user asks. Put actionable findings in review threads when review communication is authorized.
@@ -50,6 +52,7 @@ Do not post a generic top-level audit summary unless the user asks. Put actionab
 Do not call the PR ready until all of the following are true:
 
 - The latest head was audited and compared read-only with current `main`; GitHub reports no merge conflict. Do not update, rebase, or merge `main` into a clean PR merely because `main` advanced.
+- The final committed head passed the full-branch local review loop required by `AGENTS.md` against the current authoritative base, with no subsequent diff change.
 - Relevant focused and GitHub-required checks pass. Non-required checks may still be pending.
 - No actionable unresolved review thread remains.
 - Required reviews are satisfied.
@@ -62,4 +65,4 @@ Approve or merge only when the user asked for that action. When merge is authori
 
 ## Hand off
 
-Report findings, fixes, commits, pushes, commands and tests run, live ASC mutations and cleanup, unresolved risks, check state, thread state, and the final merge recommendation.
+Lead with findings and the merge recommendation, then decisive evidence and remaining gates. Include fixes, commits, pushes, live mutations, and cleanup when performed. An audit may finish with unresolved findings without calling the PR ready.

--- a/.agents/skills/audit-asc-pr/agents/openai.yaml
+++ b/.agents/skills/audit-asc-pr/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Audit ASC Pull Request"
-  short_description: "Audit and fix-forward an ASC CLI pull request"
+  short_description: "Review ASC CLI PRs and identify concrete defects"
   default_prompt: "Use $audit-asc-pr to audit this ASC CLI pull request end to end."

--- a/.agents/skills/develop-asc-change/SKILL.md
+++ b/.agents/skills/develop-asc-change/SKILL.md
@@ -5,11 +5,11 @@ description: Design, implement, and verify behavior changes in App-Store-Connect
 
 # Develop an ASC CLI change
 
-Deliver one complete, reviewable behavior change through architecture, RED-GREEN implementation, realistic CLI verification, and PR-ready validation.
+Follow `AGENTS.md` for authority, CLI contracts, implementation invariants, validation, and review gates.
 
 ## Write the design note
 
-Before implementation, record the relevant contract below. For a small fix, a brief note with the reproduced failure, intended behavior, and focused check is enough; expand the design for new public behavior or compatibility decisions.
+For a small fix, record the reproduced failure, intended behavior, and focused check. For new public behavior or compatibility decisions, also record:
 
 1. Placement in the existing command taxonomy and registry.
 2. Current `--help` behavior and expected invocation shape.
@@ -18,10 +18,6 @@ Before implementation, record the relevant contract below. For a small fix, a br
 5. Compatibility, lifecycle, migration, and deprecation impact.
 6. RED-GREEN tests, black-box checks, live verification, edge cases, and failure modes.
 7. Credible alternatives when a material design trade-off exists.
-
-Use established conventions for routine choices. Ask only when unresolved public command shape or compatibility decisions materially change the result, and continue independent authorized work while awaiting an answer.
-
-Parallelize independent read-only help, schema, architecture, and test discovery with isolated subagents when available. Keep implementation, shared-file edits, commits, and pushes under one coordinated owner.
 
 ## Establish RED
 
@@ -35,22 +31,12 @@ Read [references/test-matrix.md](references/test-matrix.md) for applicable CLI, 
 ## Validate API support
 
 1. Search `docs/openapi/paths.txt`, then inspect the exact operation in `docs/openapi/latest.json`.
-2. Validate attributes against the correct create or update request schema.
-3. Validate filters and includes against the specific endpoint, not a related top-level or relationship endpoint.
-4. If the API does not support the proposed behavior, do not ship a misleading flag. Use explicit client-side behavior or document the limitation.
-5. Prefer the `sosumi.ai` mirror when explanatory App Store Connect API documentation is required.
+2. Apply the endpoint-specific schema checks in `AGENTS.md`.
+3. If the API cannot support the behavior, implement explicit client-side behavior or document the limitation; do not ship a misleading flag.
 
 ## Implement narrowly
 
-- Extend the correct `internal/cli/<domain>` package and register new top-level commands in `internal/cli/registry/registry.go`.
-- Set `UsageFunc: shared.DefaultUsageFunc` for command groups and subcommands.
-- Use `shared.ContextWithTimeout` or `shared.ContextWithUploadTimeout` for outbound HTTP.
-- Validate required flags before side effects and return usage errors with exit code `2`.
-- Write data to stdout and diagnostics to stderr. Never silently ignore accepted flags.
-- Use long-form flags in documentation, tests, and examples.
-- Require `--confirm` for destructive operations; do not add interactive prompts.
-- Keep one logical change per commit and remove helpers made obsolete by the change. Add review fixes as new commits; do not squash, rebase, force-push, or otherwise rewrite PR history unless the user explicitly requests it.
-- Deprecate stable commands or flags before removal, with warning text, transition tests, and an upgrade path.
+Apply `AGENTS.md`'s implementation invariants. Return usage errors with exit code `2`.
 
 ## Reach GREEN and verify
 
@@ -58,20 +44,10 @@ Read [references/test-matrix.md](references/test-matrix.md) for applicable CLI, 
 2. Run adjacent package and command tests.
 3. Build a binary at a worktree-specific path and verify realistic invocations, output streams, and exit codes. Do not share a fixed `/tmp/asc` path with concurrent tasks.
 4. Run a minimal live smoke test when behavior depends on App Store Connect quirks. Prefer read-only calls; live mutations and cleanup require authority under `AGENTS.md`.
-5. Run focused and affected checks before opening or updating a PR. Run the full repository gate for public CLI behavior, shared code, release surfaces, meaningful defect or security fixes, or when repository policy or the user requires it:
-
-```bash
-make build
-make format
-make check-docs
-make lint
-ASC_BYPASS_KEYCHAIN=1 make test
-```
-
-If command help changed, run `make generate-command-docs` and commit the resulting `docs/COMMANDS.md` update before the gate.
+5. Apply `AGENTS.md`'s validation gate, including command-doc generation when help changes. Public CLI behavior, shared code, release surfaces, and meaningful defect or security fixes require the full gate.
 
 Before handoff, compare the exact branch head with current `main` read-only. Follow the branch-update rules in `AGENTS.md`; a newer base alone does not justify changing the branch.
 
 ## Hand off
 
-Use the review gates and concise handoff contract in `AGENTS.md`. Include expected invocations and compatibility trade-offs when the public contract changed; report pre-existing failures and anything not reproduced.
+Use `AGENTS.md`'s handoff contract; include invocation and compatibility details for public-contract changes.

--- a/.agents/skills/develop-asc-change/SKILL.md
+++ b/.agents/skills/develop-asc-change/SKILL.md
@@ -9,7 +9,7 @@ Deliver one complete, reviewable behavior change through architecture, RED-GREEN
 
 ## Write the design note
 
-Before implementation, record:
+Before implementation, record the relevant contract below. For a small fix, a brief note with the reproduced failure, intended behavior, and focused check is enough; expand the design for new public behavior or compatibility decisions.
 
 1. Placement in the existing command taxonomy and registry.
 2. Current `--help` behavior and expected invocation shape.
@@ -17,20 +17,20 @@ Before implementation, record:
 4. Flags, output formats, stdout/stderr behavior, and exit codes.
 5. Compatibility, lifecycle, migration, and deprecation impact.
 6. RED-GREEN tests, black-box checks, live verification, edge cases, and failure modes.
-7. One or two credible alternatives and why this shape is preferable.
+7. Credible alternatives when a material design trade-off exists.
 
-Stop and align before coding if the public command shape or compatibility decision remains materially ambiguous.
+Use established conventions for routine choices. Ask only when unresolved public command shape or compatibility decisions materially change the result, and continue independent authorized work while awaiting an answer.
 
 Parallelize independent read-only help, schema, architecture, and test discovery with isolated subagents when available. Keep implementation, shared-file edits, commits, and pushes under one coordinated owner.
 
 ## Establish RED
 
 - For a bug, reproduce it first and add the smallest regression test that fails for the expected reason.
-- For a feature, start with CLI-level tests for flags, output, errors, and exit behavior, then add unit or HTTP tests for core logic.
-- For a behavior-changing refactor, add characterization coverage before moving code.
+- For a feature, start with CLI-level coverage of the changed observable contract; add unit or HTTP tests for distinct behavior that those tests do not cover.
+- For a behavior-changing refactor, use existing characterization coverage where sufficient and add coverage for missing behavior before moving code.
 - Run the focused test and record the expected failure before implementation.
 
-Read [references/test-matrix.md](references/test-matrix.md) for mandatory CLI, output, artifact, and auth cases.
+Read [references/test-matrix.md](references/test-matrix.md) for applicable CLI, output, artifact, and auth cases. Reuse sufficient existing coverage; do not duplicate shared parser or renderer tests for every command.
 
 ## Validate API support
 
@@ -56,8 +56,8 @@ Read [references/test-matrix.md](references/test-matrix.md) for mandatory CLI, o
 
 1. Rerun the focused failing test after each small fix.
 2. Run adjacent package and command tests.
-3. Build `/tmp/asc` and verify realistic invocations, output streams, and exit codes against the built binary.
-4. Run a minimal live smoke test when behavior depends on App Store Connect quirks. Prefer read-only calls; use disposable resources and clean them up for mutations.
+3. Build a binary at a worktree-specific path and verify realistic invocations, output streams, and exit codes. Do not share a fixed `/tmp/asc` path with concurrent tasks.
+4. Run a minimal live smoke test when behavior depends on App Store Connect quirks. Prefer read-only calls; live mutations and cleanup require authority under `AGENTS.md`.
 5. Run focused and affected checks before opening or updating a PR. Run the full repository gate for public CLI behavior, shared code, release surfaces, meaningful defect or security fixes, or when repository policy or the user requires it:
 
 ```bash
@@ -70,8 +70,8 @@ ASC_BYPASS_KEYCHAIN=1 make test
 
 If command help changed, run `make generate-command-docs` and commit the resulting `docs/COMMANDS.md` update before the gate.
 
-Before handoff, compare the exact branch head with current `main` read-only. Do not update, rebase, or merge `main` into a clean branch merely because `main` advanced; update only when an actual merge conflict prevents the merge.
+Before handoff, compare the exact branch head with current `main` read-only. Follow the branch-update rules in `AGENTS.md`; a newer base alone does not justify changing the branch.
 
 ## Hand off
 
-Explain the chosen approach, alternatives, expected invocations and outputs, compatibility impact, tests and live checks, commands run, and remaining limitations. Be explicit about pre-existing failures and anything not reproduced.
+Use the review gates and concise handoff contract in `AGENTS.md`. Include expected invocations and compatibility trade-offs when the public contract changed; report pre-existing failures and anything not reproduced.

--- a/.agents/skills/develop-asc-change/references/test-matrix.md
+++ b/.agents/skills/develop-asc-change/references/test-matrix.md
@@ -1,12 +1,12 @@
 # ASC CLI behavior test matrix
 
-Apply the sections relevant to the changed behavior. Prefer a small number of high-signal tests over broad repetitive matrices.
+Apply the cases relevant to the changed behavior, using existing coverage when it proves the contract. Add tests for distinct observable behavior or demonstrated regressions; shared parser and renderer coverage need not be repeated for each command.
 
 ## Flags and parsing
 
 - Add one valid-path test for every new or changed flag.
 - Add one invalid-value test that asserts stderr and exit code `2`.
-- Test flags before subcommands, mixed flag ordering, multiple flags with values, and values that look like subcommand names.
+- When parsing or dispatch changes, cover affected flag ordering and values that look like subcommand names.
 - Assert required-flag errors on stderr; do not test only for `flag.ErrHelp`.
 - Never accept and silently ignore an unsupported flag or value.
 
@@ -36,6 +36,6 @@ Apply the sections relevant to the changed behavior. Prefer a small number of hi
 ## Live verification
 
 - Prefer read-only calls first.
-- For mutations, use a disposable resource, record its ID, and delete or cancel it afterward.
+- For authorized mutations and cleanup, use a disposable resource, record its ID, and delete or cancel it afterward.
 - Assert the externally visible result, not only a successful HTTP status.
 - Report any state that could not be cleaned up.

--- a/.agents/skills/release-asc-cli/SKILL.md
+++ b/.agents/skills/release-asc-cli/SKILL.md
@@ -10,14 +10,14 @@ Treat a release request as an end-to-end publishing operation, not merely a tag 
 ## Prove the release target
 
 1. Resolve the requested plain semantic version without a `v` prefix.
-2. Fetch `origin`, verify the tag does not already exist locally or remotely, and inspect the release-worthy delta since the previous tag.
+2. Fetch `origin` and inspect the requested tag locally and remotely, any release, and its workflow runs before acting. For a new release, require the tag to be absent and inspect the release-worthy delta since the previous tag. When resuming, verify that the existing tag points to the previously approved release commit and resume only unfinished work; stop on a target mismatch.
 3. Query open PRs and confirm the intended changes are already merged.
-4. Create a clean detached worktree from the exact current `origin/main` commit. Do not release from a dirty user checkout or an unmerged branch.
+4. For a new release, create a clean detached worktree from the exact current `origin/main` commit. When resuming, use the tag's previously approved, verified release commit. Do not release from a dirty user checkout or an unmerged branch.
 5. Inspect `.github/workflows/release.yml` and current repository guidance instead of assuming an older release procedure still applies.
 
 ## Run the release gate
 
-Run and record:
+For a new release, run and record the following checks. On resume, reuse completed checks only while their inputs remain valid under `AGENTS.md`; verify consumer-visible state freshly.
 
 ```bash
 make format
@@ -29,12 +29,12 @@ make build
 ./asc version
 ```
 
-If formatting changes files, inspect and commit only intentional release-related changes before continuing. Stop on unexplained failures; do not tag around a broken gate.
+If formatting changes files, inspect the diff and stop the release gate. Prepare necessary corrections on a branch only when authorized; they must pass repository review and validation and merge through the normal PR process before restarting from the updated `origin/main`. Never tag a correction committed only in the detached release worktree. Stop on unexplained failures; do not tag around a broken gate.
 
 ## Publish
 
-1. Reconfirm the worktree HEAD equals the intended `origin/main` commit.
-2. Create an annotated tag using the exact requested version and push that tag explicitly.
+1. For a new release, refresh `origin/main` and reconfirm the worktree HEAD equals the intended current `origin/main` commit. If `origin/main` advanced, inspect the delta and restart target selection and the release gate in a clean detached worktree at the newly selected commit before tagging. Checks run in the old worktree do not validate the new commit.
+2. Create an annotated tag using the exact requested version and push that tag explicitly. On resume, reuse the verified existing tag: skip the push if the remote tag already matches; if only the local tag exists, push it only within the established release authority. Never replace a mismatched remote tag.
 3. Locate the tag-triggered GitHub Actions run and watch it through completion.
 4. Do not retry by silently moving or recreating a published tag. Diagnose failures and preserve the immutable release history.
 
@@ -50,16 +50,16 @@ Do not declare success from CI alone. Verify:
 - The expected WinGet submission or PR exists and references the new version.
 - Any notarization step required by the current workflow succeeded.
 
-If the `winget` job failed, read its rate-limit preflight and retry log lines first. The step retries GitHub throttles on its own and is idempotent, so re-run that job (or dispatch the release workflow for the same version) before repairing the `microsoft/winget-pkgs` submission by hand. Wait for the logged reset time only when the preflight showed a primary quota bucket at zero; for secondary throttles, 5xx responses, or transport failures re-run after a few minutes. See `docs/WINGET.md`.
+If the `winget` job failed, inspect its rate-limit preflight, retry history, and current submission state first. For a transient failure, prefer one rerun of the failed job before manual repair; dispatch the full workflow only after confirming it will safely reuse the existing release. Wait for the logged reset time only when the primary quota bucket is zero; back off a few minutes for secondary throttles, 5xx responses, or transport failures. After a failed retry or a non-transient error, report the exact blocker instead of looping. See `docs/WINGET.md`.
 
 ## Draft the announcement
 
-Read [references/release-announcement.md](references/release-announcement.md). Create the Typefully draft only after the release is visibly published. Never schedule or publish the post unless the user explicitly asks.
+Read [references/release-announcement.md](references/release-announcement.md) and prepare the announcement copy after the release is visibly published. Create an external Typefully draft only when the request or established context authorizes that write; otherwise return the copy locally. Never schedule or publish the post unless the user explicitly asks.
 
 ## Clean up and hand off
 
-Remove only the temporary release worktree created by this run. Report the released commit and tag, workflow run, release URL, artifact verification, Homebrew state, WinGet state, Typefully review URL or connector blocker, commands run, and any residual state.
+Remove only a clean temporary release worktree created by this run as part of its authorized cleanup; preserve unexpected changes. Report the released commit and tag, release URL, artifact verification, Homebrew and WinGet state, remaining blockers, and announcement status separately. An optional external draft does not prevent reporting a verified binary release.
 
 ## Automation boundary
 
-Do not schedule unattended releases. After an explicitly initiated tag push, a thread heartbeat may reuse this skill to watch the release run and finish downstream verification.
+Do not schedule unattended releases. After an explicitly initiated tag push, a thread heartbeat may watch the release run and finish authorized downstream verification. Save the version, immutable commit and tag, run IDs, completed checks, authority, next step, and retry history; create or reuse one heartbeat and end the turn. On wake, reconcile current state once, stay quiet and back off when unchanged, and disable the heartbeat on completion or a blocker requiring user action. Never use a heartbeat to recreate or move the tag.

--- a/.agents/skills/release-asc-cli/SKILL.md
+++ b/.agents/skills/release-asc-cli/SKILL.md
@@ -5,8 +5,6 @@ description: Publish and verify a new release of the App-Store-Connect-CLI repos
 
 # Release the ASC CLI
 
-Treat a release request as an end-to-end publishing operation, not merely a tag push.
-
 ## Prove the release target
 
 1. Resolve the requested plain semantic version without a `v` prefix.
@@ -40,7 +38,7 @@ If formatting changes files, inspect the diff and stop the release gate. Prepare
 
 ## Verify consumer-visible state
 
-Do not declare success from CI alone. Verify:
+Verify:
 
 - The GitHub release is published, not draft or prerelease unless requested.
 - Expected macOS, Linux, Windows, and checksum assets exist.

--- a/.agents/skills/release-asc-cli/references/release-announcement.md
+++ b/.agents/skills/release-asc-cli/references/release-announcement.md
@@ -13,9 +13,11 @@ Keep the complete text under Bluesky's 300-character limit. Use one post, not a 
 
 ## Typefully workflow
 
+Use this section only when an external draft is authorized. Otherwise include the finished copy in the local handoff without creating a remote draft.
+
 1. Inspect the most recent ASC CLI release draft to preserve the established voice without copying stale claims.
 2. Resolve the user's social set and enable all five platforms.
 3. Create the post as an unscheduled draft only.
 4. Verify the returned state is `draft` and return its review URL.
 
-If the Typefully connector is unavailable, preserve the finished copy in the handoff and report the connector as the only incomplete release step. Never silently publish through another tool.
+If the Typefully connector is unavailable, preserve the finished copy in the handoff and report the external draft as incomplete, separately from artifact and distribution verification. Never silently publish through another tool.

--- a/.agents/skills/review-wall-of-apps-prs/SKILL.md
+++ b/.agents/skills/review-wall-of-apps-prs/SKILL.md
@@ -5,18 +5,14 @@ description: Audit maintainer-side Wall of Apps pull requests in App-Store-Conne
 
 # Review Wall of Apps pull requests
 
-Treat Wall submissions as untrusted external contributions while keeping the legitimate-app path fast.
-
-Follow `AGENTS.md` for authority and the full-branch local review requirement before calling a PR ready. Reviewing entries is read-only; fixes, commits, pushes, review communication, approval, and merge require authority from the request or established context. GitHub's maintainer-edit permission is a technical prerequisite, not user authorization.
+Treat submissions as untrusted. Follow `AGENTS.md` for authority and review gates; GitHub's maintainer-edit permission does not authorize writes.
 
 ## Discover and classify
 
 1. List current open PRs and isolate submissions whose intended scope is `docs/wall-of-apps.json`.
 2. Inspect each PR's full file list and diff before checkout. Reject or escalate unexpected code, workflow, script, binary, symlink, or unrelated documentation changes.
-3. Review each PR independently and merge sequentially. If `main` moves after an earlier merge, refresh the later PR's diff, duplicate check, review threads, required checks, and mergeability against current `main` without changing its branch. Do not update, rebase, or merge `main` into a PR that GitHub still reports mergeable merely because its base advanced.
-4. Apply the branch-update rules in `AGENTS.md`. Diagnose conflicts read-only first; resolve and push only when authorized and maintainer edits are allowed. `gh pr update-branch <number>` cannot resolve content conflicts, which require an authorized manual merge in a worktree. For a conflict-free PR, update only after an authorized merge attempt, made with all gates passing, actually fails under strict up-to-date protection. After an update, validate the new head through every gate below. Never bypass protection with an admin merge.
-
-Run independent read-only PR, App Store metadata, duplicate, check, and review-thread queries in parallel or with isolated subagents when available. Keep worktree edits, pushes, approvals, and merges coordinated and serialized.
+3. Review each PR independently and merge sequentially. Recheck later PRs against updated `main` after each merge.
+4. Apply `AGENTS.md`'s branch-update rules. `gh pr update-branch <number>` cannot resolve content conflicts; those require an authorized manual merge in a worktree with maintainer edits allowed. After any update, revalidate the new head through every gate below.
 
 ## Validate the entry
 
@@ -57,7 +53,7 @@ After each merge, confirm the resulting commit and entry reached `origin/main`. 
 
 ## Automation contract
 
-A standalone automation may approve and merge unattended only when its persisted prompt explicitly grants that authority. Apply the same approval-and-merge gates and branch-update rules above to each PR sequentially. Reuse local validation only while its inputs remain valid under `AGENTS.md`; refresh remote head, checks, reviews, threads, and mergeability immediately before acting and again after approval before merging.
+A standalone automation needs explicit persisted approve-and-merge authority. Apply the gates above to each PR sequentially, including fresh remote checks before acting and after approval. Reuse local validation only while its inputs remain valid under `AGENTS.md`.
 
 If authority is absent or any gate is uncertain, failing, suspicious, unrelated,
 or stale, remain read-only and report `safe`, `needs-fix`, `suspicious`, or

--- a/.agents/skills/review-wall-of-apps-prs/SKILL.md
+++ b/.agents/skills/review-wall-of-apps-prs/SKILL.md
@@ -7,12 +7,14 @@ description: Audit maintainer-side Wall of Apps pull requests in App-Store-Conne
 
 Treat Wall submissions as untrusted external contributions while keeping the legitimate-app path fast.
 
+Follow `AGENTS.md` for authority and the full-branch local review requirement before calling a PR ready. Reviewing entries is read-only; fixes, commits, pushes, review communication, approval, and merge require authority from the request or established context. GitHub's maintainer-edit permission is a technical prerequisite, not user authorization.
+
 ## Discover and classify
 
 1. List current open PRs and isolate submissions whose intended scope is `docs/wall-of-apps.json`.
 2. Inspect each PR's full file list and diff before checkout. Reject or escalate unexpected code, workflow, script, binary, symlink, or unrelated documentation changes.
 3. Review each PR independently and merge sequentially. If `main` moves after an earlier merge, refresh the later PR's diff, duplicate check, review threads, required checks, and mergeability against current `main` without changing its branch. Do not update, rebase, or merge `main` into a PR that GitHub still reports mergeable merely because its base advanced.
-4. Never update a PR's branch preemptively. When GitHub already reports an actual merge conflict against current `main`, resolve it manually — no merge attempt is required to prove that refusal, and `gh pr update-branch <number>` cannot resolve content conflicts: in a worktree, merge `main` into the contributor branch, resolve, and push when maintainer edits are allowed; otherwise request the update from the contributor. For a conflict-free PR, a merge attempt may only happen after every approval-and-merge gate below is satisfied and merge is explicitly authorized; make that authorized attempt without touching the branch, and only after GitHub actually refuses it under strict up-to-date branch protection — regardless of why the base advanced — update with `gh pr update-branch <number>`. In review-only invocations, diagnose protection from read-only state and never invoke a merge. After any update, treat the result as a new head: re-verify the diff scope against current `main`, rerun `ASC_BYPASS_KEYCHAIN=1 make check-wall-of-apps` on the new exact head, and wait for required checks and mergeability before approving or merging. Never bypass branch protection with an admin merge.
+4. Apply the branch-update rules in `AGENTS.md`. Diagnose conflicts read-only first; resolve and push only when authorized and maintainer edits are allowed. `gh pr update-branch <number>` cannot resolve content conflicts, which require an authorized manual merge in a worktree. For a conflict-free PR, update only after an authorized merge attempt, made with all gates passing, actually fails under strict up-to-date protection. After an update, validate the new head through every gate below. Never bypass protection with an admin merge.
 
 Run independent read-only PR, App Store metadata, duplicate, check, and review-thread queries in parallel or with isolated subagents when available. Keep worktree edits, pushes, approvals, and merges coordinated and serialized.
 
@@ -25,9 +27,9 @@ For every added or changed app:
 3. Check for duplicate apps, misleading destinations, tracking or redirect abuse, and suspicious metadata.
 4. Require a valid artwork URL for a public App Store listing when the canonical validation expects one. Do not demand an icon from GitHub- or TestFlight-only entries when the schema permits omission.
 5. Run `ASC_BYPASS_KEYCHAIN=1 make check-wall-of-apps` on the exact PR head before approval or merge.
-6. Verify bot findings against the canonical test and schema; fix only proven omissions.
+6. Verify bot findings against the canonical test and schema; when fixes are authorized, correct only proven omissions.
 
-Use a worktree only when a fix is required. Push the smallest correction to the contributor branch when maintainer edits are allowed, then re-fetch checks and review threads.
+Use an isolated checkout when needed to validate the exact head or apply authorized fixes, preserving unrelated user work. Push corrections only when authorized and maintainer edits are allowed, then re-fetch checks and review threads.
 
 ## Approve and merge
 
@@ -37,6 +39,7 @@ approve-and-merge authority. Immediately before approval, or before a merge
 that does not require a new approval, confirm:
 
 - The latest head contains only the legitimate Wall change.
+- The final full-branch local review required by `AGENTS.md` is clear for the current head and authoritative base.
 - `ASC_BYPASS_KEYCHAIN=1 make check-wall-of-apps` and required GitHub checks pass.
 - No actionable unresolved review thread remains.
 - The PR is mergeable against current `main`.
@@ -54,24 +57,11 @@ After each merge, confirm the resulting commit and entry reached `origin/main`. 
 
 ## Automation contract
 
-A standalone automation may approve and merge unattended only when its
-persisted prompt explicitly grants that authority and every approval-and-merge
-gate above passes on the latest head. Immediately before acting, run
-`ASC_BYPASS_KEYCHAIN=1 make check-wall-of-apps` locally on that exact head and verify required GitHub
-checks, review threads, and mergeability again. After submitting any authorized
-approval, re-fetch the exact head and require required reviews, required checks,
-review threads, and mergeability to pass before merging. Do not wait for
-non-required CI jobs. Approve and merge one PR at a time with a regular merge
-commit pinned to the audited head; use a different strategy only when the
-persisted prompt explicitly requests it. If branch protection refuses the merge
-because the base advanced, update the branch, revalidate the new exact head
-through every gate above, and merge only when all gates pass again; never use
-an admin bypass.
+A standalone automation may approve and merge unattended only when its persisted prompt explicitly grants that authority. Apply the same approval-and-merge gates and branch-update rules above to each PR sequentially. Reuse local validation only while its inputs remain valid under `AGENTS.md`; refresh remote head, checks, reviews, threads, and mergeability immediately before acting and again after approval before merging.
 
 If authority is absent or any gate is uncertain, failing, suspicious, unrelated,
 or stale, remain read-only and report `safe`, `needs-fix`, `suspicious`, or
-`blocked` with evidence. Never infer approval from a prior run or from a
-different head SHA.
+`blocked` with evidence. Persisted task authority may cover later passes, but a changed head requires fresh validation; an earlier approval is not proof that the new head passes the gates.
 
 ## Hand off
 

--- a/.agents/skills/sync-asc-skills/SKILL.md
+++ b/.agents/skills/sync-asc-skills/SKILL.md
@@ -5,7 +5,7 @@ description: Check rorkai/app-store-connect-cli-skills against the current ASC C
 
 # Synchronize ASC workflow skills
 
-Compare the external workflow-skill repository with live CLI behavior. Questions about drift produce a read-only report; requests to update skills authorize proven, minimal corrections. Resolve commit, push, and PR-creation authority separately from the request and session context under `AGENTS.md`.
+Drift questions produce a read-only report; update requests authorize proven corrections. Follow `AGENTS.md` for commit, push, and PR-creation authority.
 
 ## Establish both sources
 
@@ -14,7 +14,7 @@ Compare the external workflow-skill repository with live CLI behavior. Questions
 3. Inventory every skill and identify which commands, flags, environment variables, outputs, or workflows it claims to use.
 4. Run the current CLI's `--help` at each relevant command path. Use `asc search`, `asc schema`, or `asc capabilities` only when their own current help confirms they are appropriate.
 
-Split substantive, independent read-only or verified side-effect-free dry-run skill inventory, help, and example checks across isolated subagents when useful. Validate mutation-capable examples with help and schemas first; executing them requires authority for their side effects and cleanup. Keep authorized edits, commits, pushes, and PR creation under one coordinated owner.
+Follow `AGENTS.md` for parallel reads and serialized writes. Validate mutation-capable examples with help and schemas first; execution and cleanup require authority, and dry runs must be side-effect-free.
 
 ## Prove drift
 
@@ -30,8 +30,6 @@ Check for:
 Do not update skills merely because a newer CLI version exists. Record exact help or runtime evidence for every edit.
 
 ## Update minimally
-
-Use this section only when corrections are authorized; otherwise report the exact drift and proposed edits.
 
 1. Change only affected skills and examples; avoid release-number churn and speculative prose.
 2. Keep each `SKILL.md` concise and move lengthy reference material behind progressive disclosure.

--- a/.agents/skills/sync-asc-skills/SKILL.md
+++ b/.agents/skills/sync-asc-skills/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: sync-asc-skills
-description: Audit and update rorkai/app-store-connect-cli-skills against the current ASC CLI surface. Use when the user asks whether ASC agent skills need updates, requests a post-release skills sync, or wants command, flag, output, auth, or workflow examples checked for drift.
+description: Check rorkai/app-store-connect-cli-skills against the current ASC CLI surface and correct proven drift when authorized. Use for skill-drift questions, post-release syncs, or checks of command, flag, output, auth, and workflow examples.
 ---
 
 # Synchronize ASC workflow skills
 
-Compare the external workflow-skill repository with live CLI behavior and make only proven, minimal corrections.
+Compare the external workflow-skill repository with live CLI behavior. Questions about drift produce a read-only report; requests to update skills authorize proven, minimal corrections. Resolve commit, push, and PR-creation authority separately from the request and session context under `AGENTS.md`.
 
 ## Establish both sources
 
@@ -14,7 +14,7 @@ Compare the external workflow-skill repository with live CLI behavior and make o
 3. Inventory every skill and identify which commands, flags, environment variables, outputs, or workflows it claims to use.
 4. Run the current CLI's `--help` at each relevant command path. Use `asc search`, `asc schema`, or `asc capabilities` only when their own current help confirms they are appropriate.
 
-Split independent read-only or dry-run skill inventory, help, and example checks across isolated subagents when available. Serialize live mutation-capable examples, use disposable resources with cleanup, and keep shared skill edits, commits, pushes, and PR creation under one coordinated owner.
+Split substantive, independent read-only or verified side-effect-free dry-run skill inventory, help, and example checks across isolated subagents when useful. Validate mutation-capable examples with help and schemas first; executing them requires authority for their side effects and cleanup. Keep authorized edits, commits, pushes, and PR creation under one coordinated owner.
 
 ## Prove drift
 
@@ -31,12 +31,14 @@ Do not update skills merely because a newer CLI version exists. Record exact hel
 
 ## Update minimally
 
+Use this section only when corrections are authorized; otherwise report the exact drift and proposed edits.
+
 1. Change only affected skills and examples; avoid release-number churn and speculative prose.
 2. Keep each `SKILL.md` concise and move lengthy reference material behind progressive disclosure.
 3. Preserve the skills repository's naming, metadata, validation, and style conventions.
-4. Validate every changed command example against a current built or released `asc` binary.
+4. Validate every changed command example against current built or released `asc` help and the relevant schema. Exercise runtime behavior when safe and authorized; report any path not executed.
 5. Run the skills repository's validators and the current skill-creator validator when available.
-6. Open a separate draft PR in the skills repository with the CLI commit or release used as evidence and a command-by-command validation summary.
+6. When PR creation is authorized, open a separate draft PR in the skills repository with the CLI commit or release used as evidence and a summary of validation and unexecuted paths.
 
 Never modify the CLI merely to make stale skill documentation pass.
 

--- a/.agents/skills/sync-asc-skills/agents/openai.yaml
+++ b/.agents/skills/sync-asc-skills/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Sync ASC Skills"
   short_description: "Audit ASC workflow skills for CLI surface drift"
-  default_prompt: "Use $sync-asc-skills to compare ASC workflow skills with the current CLI and fix proven drift."
+  default_prompt: "Use $sync-asc-skills to compare ASC workflow skills with the current CLI and report proven drift."

--- a/.agents/skills/triage-asc-issue/SKILL.md
+++ b/.agents/skills/triage-asc-issue/SKILL.md
@@ -5,7 +5,7 @@ description: Triage App-Store-Connect-CLI GitHub issues against current code, CL
 
 # Triage an ASC CLI issue
 
-Produce a current, evidence-backed verdict and leave the issue with complete repository labels.
+Produce a current, evidence-backed verdict and proposed repository labels. Apply label changes only when authorized under `AGENTS.md`; a read-only triage ends with recommendations.
 
 ## Read current evidence
 
@@ -15,7 +15,7 @@ Produce a current, evidence-backed verdict and leave the issue with complete rep
 4. For API claims, verify the exact method and endpoint in `docs/openapi/latest.json`; use the `sosumi.ai` documentation mirror for explanatory context.
 5. Check whether the report is already fixed on current `origin/main`, duplicated, unsupported by the public API, or blocked by Apple/platform behavior.
 
-Run independent read-only or dry-run issue, source, help, API, duplicate, and linked-PR checks in parallel or with isolated subagents when available. Serialize mutation-capable reproductions, use disposable resources with cleanup, and keep labels, issue comments, and implementation handoffs coordinated and serialized.
+Run independent read-only or verified side-effect-free dry-run issue, source, help, API, duplicate, and linked-PR checks in parallel or with isolated subagents when useful. Live reproductions require authority for mutations and cleanup, even on disposable resources. Keep authorized labels, issue comments, and implementation handoffs coordinated and serialized.
 
 ## Classify the outcome
 
@@ -28,15 +28,15 @@ Choose one primary verdict:
 
 Separate urgency from implementation size. Explain user impact, blast radius, workaround, compatibility risk, and the smallest proof needed for completion.
 
-## Apply labels
+## Recommend or apply labels
 
-Follow `CONTRIBUTING.md` and leave exactly one label from each bucket:
+Follow `CONTRIBUTING.md` and recommend exactly one label from each bucket, applying them when authorized:
 
 - Type: `bug`, `enhancement`, or `question`.
 - Priority: `p0`, `p1`, `p2`, or `p3`.
 - Difficulty: `easy`, `medium`, or `hard`.
 
-Remove conflicting labels before adding replacements. If evidence is ambiguous, choose the lower priority or difficulty and state the assumption.
+For authorized label updates, remove conflicting labels and add the selected replacements, then verify the resulting buckets. If evidence is incomplete, mark the recommendation provisional and identify the missing evidence; uncertainty alone does not establish low urgency or easy implementation.
 
 ## Define implementation readiness
 
@@ -53,4 +53,4 @@ If the user asks to implement the issue, hand the validated contract to `$develo
 
 ## Automation contract
 
-A recurring issue-triage automation may classify new or incompletely labeled issues and report actionable findings. It must not implement code, close issues, or make speculative high-priority labels without explicit authorization.
+A recurring issue-triage automation may classify new or incompletely labeled issues and report actionable findings. Apply labels or post comments only within its persisted write authority. It must not implement code or close issues without explicit authorization, and labels must follow evidence.

--- a/.agents/skills/triage-asc-issue/SKILL.md
+++ b/.agents/skills/triage-asc-issue/SKILL.md
@@ -15,7 +15,7 @@ Produce a current, evidence-backed verdict and proposed repository labels. Apply
 4. For API claims, verify the exact method and endpoint in `docs/openapi/latest.json`; use the `sosumi.ai` documentation mirror for explanatory context.
 5. Check whether the report is already fixed on current `origin/main`, duplicated, unsupported by the public API, or blocked by Apple/platform behavior.
 
-Run independent read-only or verified side-effect-free dry-run issue, source, help, API, duplicate, and linked-PR checks in parallel or with isolated subagents when useful. Live reproductions require authority for mutations and cleanup, even on disposable resources. Keep authorized labels, issue comments, and implementation handoffs coordinated and serialized.
+Follow `AGENTS.md` for parallel reads and serialized writes. Live reproductions require authority for mutations and cleanup, even on disposable resources; confirm dry runs are side-effect-free.
 
 ## Classify the outcome
 
@@ -30,11 +30,7 @@ Separate urgency from implementation size. Explain user impact, blast radius, wo
 
 ## Recommend or apply labels
 
-Follow `CONTRIBUTING.md` and recommend exactly one label from each bucket, applying them when authorized:
-
-- Type: `bug`, `enhancement`, or `question`.
-- Priority: `p0`, `p1`, `p2`, or `p3`.
-- Difficulty: `easy`, `medium`, or `hard`.
+Recommend one type, priority, and difficulty from `AGENTS.md`'s buckets using the meanings in `CONTRIBUTING.md`. Apply them only when authorized.
 
 For authorized label updates, remove conflicting labels and add the selected replacements, then verify the resulting buckets. If evidence is incomplete, mark the recommendation provisional and identify the missing evidence; uncertainty alone does not establish low urgency or easy implementation.
 

--- a/.agents/skills/watch-asc-pr/SKILL.md
+++ b/.agents/skills/watch-asc-pr/SKILL.md
@@ -5,9 +5,7 @@ description: Recheck an in-progress App-Store-Connect-CLI pull request for new r
 
 # Watch an ASC CLI pull request
 
-Run idempotent follow-up passes while preserving the existing PR context instead of restarting the full audit. A single pass is enough for a status check; a request to loop, babysit, or continue until green requires repeated passes until a terminal state below.
-
-Resolve the mode from the request and established authority: status reads once; watch follows external state; fix-and-watch also applies authorized fixes. Watching alone does not authorize edits, commits, pushes, or review replies. Follow `AGENTS.md` for authority and validation reuse.
+Preserve the PR context and authority under `AGENTS.md`: status reads once; watch repeats until a terminal state; fix-and-watch also applies authorized fixes. Watching alone grants no edit, commit, push, or reply authority.
 
 ## Recheck current state
 
@@ -15,20 +13,18 @@ Resolve the mode from the request and established authority: status reads once; 
 2. Fetch checks, reviews, top-level comments, and GraphQL review threads in parallel where possible. Separate required checks from advisory jobs.
 3. Separate new actionable feedback from resolved, outdated, informational, duplicate, or bot-noise comments.
 4. If the head changed outside this workflow, inspect the new diff before relying on prior conclusions.
-5. If `main` advanced, refresh the merge-base diff and mergeability read-only. Follow the branch-update rules in `AGENTS.md`, including the exception for an authorized merge refused under strict up-to-date protection; a newer base alone does not justify changing the branch.
+5. If `main` advanced, refresh the merge-base diff and mergeability; follow the branch-update rules in `AGENTS.md`.
 
 ## Address actionable feedback
 
 Apply fixes and external writes only when authorized. Otherwise report the verified finding and proposed fix; if it prevents progress, return `blocked` with the exact missing authority.
 
-1. Verify every new claim against the codebase, API schema, and existing behavior. Do not follow automated feedback blindly.
+1. Verify new claims against code, API schemas, and existing behavior.
 2. Reproduce a valid defect and add or update a focused test before changing behavior.
 3. Implement the smallest coherent fix, run the affected checks and required local review, then commit and push when authorized. Complete the final full-branch review loop in `AGENTS.md` before returning `clean`.
 4. When review communication is authorized, reply to and resolve only the threads fully addressed by that push.
 5. Re-fetch the PR after pushing and confirm the live head, checks, and thread state.
-6. If required checks, required reviews, or an actionable reviewer are still pending, continue from the fresh exact-head state. When new valuable feedback arrives, fix it in another additive commit and repeat.
-
-Keep fixes, pushes, review replies and resolutions, approvals, and merges serialized even when read-only checks run in parallel.
+6. Continue from the fresh head while required checks or reviews remain pending; apply new authorized fixes in additive commits.
 
 ## Return one state
 
@@ -37,7 +33,7 @@ Keep fixes, pushes, review replies and resolutions, approvals, and merges serial
 - `clean`: the final full-branch local review in `AGENTS.md` is clear for the current head and base, required checks pass, required reviews are satisfied, the latest head is mergeable, and no actionable unresolved thread remains. Report advisory jobs without treating them as blockers.
 - `blocked`: user input, permissions, an external outage, or an unsafe product decision prevents progress.
 
-Do not approve or merge unless the user explicitly requested it. If merge was requested, reapply the complete merge gate from `$audit-asc-pr` immediately before merging, then use a regular merge commit that preserves the PR commits. Do not squash unless the user explicitly requested squash.
+For an authorized merge, reapply `$audit-asc-pr`'s complete gate immediately before merging and follow the history rules in `AGENTS.md`.
 
 ## Automation contract
 

--- a/.agents/skills/watch-asc-pr/SKILL.md
+++ b/.agents/skills/watch-asc-pr/SKILL.md
@@ -7,20 +7,24 @@ description: Recheck an in-progress App-Store-Connect-CLI pull request for new r
 
 Run idempotent follow-up passes while preserving the existing PR context instead of restarting the full audit. A single pass is enough for a status check; a request to loop, babysit, or continue until green requires repeated passes until a terminal state below.
 
+Resolve the mode from the request and established authority: status reads once; watch follows external state; fix-and-watch also applies authorized fixes. Watching alone does not authorize edits, commits, pushes, or review replies. Follow `AGENTS.md` for authority and validation reuse.
+
 ## Recheck current state
 
 1. Resolve the exact PR and compare its current head SHA with the last audited or pushed SHA.
 2. Fetch checks, reviews, top-level comments, and GraphQL review threads in parallel where possible. Separate required checks from advisory jobs.
 3. Separate new actionable feedback from resolved, outdated, informational, duplicate, or bot-noise comments.
 4. If the head changed outside this workflow, inspect the new diff before relying on prior conclusions.
-5. If `main` advanced, refresh the merge-base diff and mergeability read-only. Do not update, rebase, or merge `main` into a clean PR merely because its base advanced; update only when an actual merge conflict prevents the merge.
+5. If `main` advanced, refresh the merge-base diff and mergeability read-only. Follow the branch-update rules in `AGENTS.md`, including the exception for an authorized merge refused under strict up-to-date protection; a newer base alone does not justify changing the branch.
 
 ## Address actionable feedback
 
+Apply fixes and external writes only when authorized. Otherwise report the verified finding and proposed fix; if it prevents progress, return `blocked` with the exact missing authority.
+
 1. Verify every new claim against the codebase, API schema, and existing behavior. Do not follow automated feedback blindly.
 2. Reproduce a valid defect and add or update a focused test before changing behavior.
-3. Implement the smallest coherent fix, run the focused check, commit, and push.
-4. Reply to and resolve only the threads fully addressed by that push.
+3. Implement the smallest coherent fix, run the affected checks and required local review, then commit and push when authorized. Complete the final full-branch review loop in `AGENTS.md` before returning `clean`.
+4. When review communication is authorized, reply to and resolve only the threads fully addressed by that push.
 5. Re-fetch the PR after pushing and confirm the live head, checks, and thread state.
 6. If required checks, required reviews, or an actionable reviewer are still pending, continue from the fresh exact-head state. When new valuable feedback arrives, fix it in another additive commit and repeat.
 
@@ -30,11 +34,13 @@ Keep fixes, pushes, review replies and resolutions, approvals, and merges serial
 
 - `changed`: pushed a fix; include commit and validation.
 - `pending`: required checks, required reviews, or actionable reviews are still running; identify exactly what remains. This is an intermediate state during a user-requested loop, not the final handoff.
-- `clean`: required checks pass, required reviews are satisfied, the latest head is mergeable, and no actionable unresolved thread remains. Report advisory jobs without treating them as blockers.
+- `clean`: the final full-branch local review in `AGENTS.md` is clear for the current head and base, required checks pass, required reviews are satisfied, the latest head is mergeable, and no actionable unresolved thread remains. Report advisory jobs without treating them as blockers.
 - `blocked`: user input, permissions, an external outage, or an unsafe product decision prevents progress.
 
 Do not approve or merge unless the user explicitly requested it. If merge was requested, reapply the complete merge gate from `$audit-asc-pr` immediately before merging, then use a regular merge commit that preserves the PR commits. Do not squash unless the user explicitly requested squash.
 
 ## Automation contract
 
-Use this skill from a thread heartbeat when the same PR conversation should continue every few minutes. Each wake-up must run one pass, report only changes or blockers, and schedule or await the next pass while required checks, required reviews, or actionable reviewers remain pending. After every fix, re-fetch the pushed exact head and continue. Stop the loop only when the PR is clean, blocked, merged, closed, superseded, or awaiting a material user decision. Advisory jobs may remain pending after the clean gate passes. Do not create an unattended auto-merge loop.
+When only an expected external state change remains in an authorized watch, save a checkpoint with the objective, PR, head and base SHAs, authority, validation results and inputs, unresolved feedback, last checked time, next step, stop condition, and retry history. Create or reuse one thread heartbeat, verify it, and end the turn. If scheduling is unavailable, report the pending state and checkpoint without implying that monitoring continues.
+
+On each wake, inspect decisive state once. Reuse still-valid evidence, stay quiet when unchanged, and back off the next check. Resume work on completion, failure, or a stall. After an uncertain write, reconcile remote state before a bounded retry. Disable the heartbeat when the PR is clean, blocked, merged, closed, superseded, or awaiting a material user decision. Advisory jobs may remain pending after the clean gate passes. Do not create an unattended auto-merge loop.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,10 +20,9 @@ Use these skills for their matching workflows instead of expanding this always-l
 
 ## Authority and follow-through
 
-- Treat audits, reviews, research, triage, status checks, and drafts as read-only. Edits, commits, pushes, PR creation or comments, labels, approval, merge, publication, external sends, and deletion require authority from the user's request or established session context. A clear request can authorize several actions at once; do not ask again for authority already granted.
-- Skill selection does not grant additional authority. Explicit user instructions take precedence over skill guidelines within system and developer constraints. Complete authorized work, make routine choices from repository conventions, and ask only when missing information materially changes scope, public compatibility, or authorization. Continue independent work while awaiting an answer.
-- If a skill causes a pause or departure from the requested scope, link the exact `SKILL.md`, quote the relevant instruction, and explain the unresolved decision. Prepare the authorized work needed for a concrete, reviewable result before asking for any remaining approval.
-- After an interruption or uncertain write, inspect current state before retrying. Keep the original objective and authorization when responding to follow-up questions or corrections unless the user changes the scope.
+- Audits, reviews, research, triage, status checks, and drafts are read-only. Edits, commits, pushes, PR creation, comments, labels, approval, merge, publication, external sends, and deletion require authority from the request or session context. One request may authorize several actions; do not ask again for granted authority.
+- User instructions override skill guidelines within system and developer constraints; skill selection grants no authority. Make routine choices from repository conventions. Ask only about material scope, compatibility, or authority gaps, after preparing authorized work for review; continue independent work while awaiting answers.
+- If a skill causes a pause or scope change, link its `SKILL.md`, quote the instruction, and explain the unresolved decision. Preserve the objective and authority across follow-ups unless the user changes scope. Inspect state before retrying an interrupted or uncertain write.
 
 ## Core CLI contract
 
@@ -61,15 +60,13 @@ Validate attributes against the exact create or update request schema. Validate 
 - Do not push directly to `main`, bypass hooks, use `--no-verify`, or skip checks to force a result.
 - Use TDD for behavior changes: reproduce or establish RED, implement the smallest coherent change, then reach GREEN.
 - **IMPORTANT:** Before ending every implementation session, run `/review`. In a non-interactive environment, use the stable local Codex CLI command `codex exec --ignore-user-config review --disable apps --disable plugins --disable remote_plugin -c 'model_provider="openai"' -c 'model="gpt-5.6-sol"' -c 'review_model="gpt-5.6-sol"' --uncommitted` as a pre-commit review of working-tree changes.
-- Run the review directly from the local Git worktree, with user configuration ignored and app connectors and plugins disabled as shown. Force the built-in `openai` provider and ChatGPT-supported model so custom provider, endpoint, or review-model settings cannot supply another API key, route code to another service, or select an incompatible model. Immediately before every review, confirm `codex login status` shows ChatGPT authentication and verify both `CODEX_API_KEY` and `OPENAI_API_KEY` are unset or empty because either can supply usage-billed API-key authentication to non-interactive reviews. Treat any API-key login or override as a separate authorization gate and stop unless it was explicitly approved.
+- Run reviews from the local worktree with the exact provider, model, config-isolation, and connector-disable flags shown. Immediately before each review, confirm `codex login status` shows ChatGPT authentication and both `CODEX_API_KEY` and `OPENAI_API_KEY` are unset or empty. Stop on API-key authentication or overrides unless explicitly authorized; these can incur separate usage charges.
 - Before calling a PR ready, refresh its authoritative base with `git fetch origin +refs/heads/<base-branch>:refs/remotes/origin/<base-branch>` and run `codex exec --ignore-user-config review --disable apps --disable plugins --disable remote_plugin -c 'model_provider="openai"' -c 'model="gpt-5.6-sol"' -c 'review_model="gpt-5.6-sol"' --base origin/<base-branch>` on the final committed head so the complete branch or PR diff is reviewed against the current base. If the applicable review mechanism is unavailable, report the review gate as blocked and do not call the PR ready. Fix and verify every valid finding, and explicitly verify and disposition any false positive or non-actionable finding. After any change, rerun the applicable review command and repeat until it reports no actionable findings.
-- Do not call a PR clean, ready, complete, or express satisfaction with it until the final full-branch `/review` loop is clear. Any subsequent change invalidates the clear result and requires another full-branch `/review`.
-- An investigation can finish with findings or a blocked gate; report that outcome without implying the PR is ready. Skills must use this full-branch review requirement together with the GitHub readiness gates below.
-- Keep one logical change per commit. Do not mix unrelated refactors, fixes, and test rewrites.
+- PR readiness requires a clear final full-branch `/review` and the GitHub gates below. Any subsequent diff change invalidates the review. An investigation may finish with findings or blocked gates without implying PR readiness.
+- Keep one logical change per commit.
 - Preserve additive PR history. Do not squash, rebase, force-push, or otherwise rewrite commits unless the user explicitly requests that strategy.
 - Re-run the focused failing test after each fix before broad validation.
-- Preserve and report pre-existing failures honestly.
-- Delegate substantive, independent read-only investigations or lightweight focused validation when parallel work can improve time or coverage. Give each subagent distinct ownership and an evidence-based output; verify its conclusions centrally. Handle small or dependent tasks locally. Do not let agents concurrently edit the same branch, files, or command group. Keep edits, pushes, review replies and resolutions, approvals, merges, releases, and cleanup coordinated and serialized.
+- Delegate substantive independent reads or focused validation with distinct ownership; verify conclusions centrally. Handle small or dependent work locally. Serialize edits, commits, pushes, review communication, approvals, merges, releases, and cleanup; agents must not concurrently edit shared branches or files.
 - Treat repository-wide commands that compile, lint, or test broad package sets—including `make build`, `make lint`, `make test`, `go test ./...`, race tests over `./...`, and `golangci-lint run ./...`—as host-intensive gates. Coordinate them through one agent and run only one host-intensive gate at a time on the same host. Before starting one, check whether another task is already running a host-intensive gate; if so, wait instead of competing for the same CPUs. Never terminate another task's process without explicit authorization.
 - Within a worktree, wait for each focused test to finish before starting a broad gate. Record the checked commit, relevant working-tree state, command, and environment. Reuse passing checks while their inputs remain unchanged, including during status-only follow-ups. Rerun affected checks when source, test inputs, commands, environment, toolchain, or requested verification changes; unrelated temporary files do not invalidate results. Complete every required gate for the final change, and preserve the separate full-branch review requirement after any diff change.
 - Run host-intensive gates concurrently only when explicitly required. Assign each gate a CPU budget and keep the sum of concurrent gate budgets within the host's logical CPU count; tool flags are limits within a gate, not values to add together. Avoid multiplying Go package and in-binary concurrency: for a budget of `B`, use `GOMAXPROCS=1 go test -p=B -parallel=1 ./...` for package fan-out or `GOMAXPROCS=B go test -p=1 -parallel=B ./...` for one package at a time. Use `golangci-lint run --concurrency=B ./...` for a linter gate.
@@ -88,20 +85,11 @@ User-facing commands and flags follow `experimental` -> `stable` -> `deprecated`
 
 ## Build and validation
 
-```bash
-make build
-make format
-make check-docs
-make lint
-ASC_BYPASS_KEYCHAIN=1 make test
-make install-hooks
-```
-
 Every manual test command must use `ASC_BYPASS_KEYCHAIN=1` to prevent host keychain prompts and profile bleed-through. The `make test` target enforces the same environment internally.
 
 Before opening or merging a substantive behavior PR, run `make build`, `make format`, `make check-docs`, `make lint`, and `ASC_BYPASS_KEYCHAIN=1 make test`. If command help changed, run `make generate-command-docs` and commit `docs/COMMANDS.md` before those checks. For a narrowly scoped documentation or skill change, run `make check-docs`, which includes the repository and skill validators, instead of the full Go suite unless the changed surface or repository policy requires more. For a Wall-only PR, run `make check-wall-of-apps` on the exact head.
 
-Require GitHub-required checks before merge, but do not wait for advisory or otherwise non-required CI jobs. Inspect and report relevant advisory failures without treating pending or unrelated jobs as blockers.
+Require GitHub-required checks before merge. Report relevant advisory failures, but do not wait for non-required jobs.
 
 Do not weaken CI: formatting, documentation, lint, and tests must run on PR and `main` workflows.
 
@@ -110,9 +98,8 @@ Do not weaken CI: formatting, documentation, lint, and tests must run on PR and 
 - Inspect thread-aware GitHub review state before declaring a PR clean; flat comments do not prove every thread is resolved.
 - A PR is ready only when the latest head was reviewed, required checks pass, required reviews are satisfied, actionable threads are resolved, and GitHub reports it mergeable.
 - If `main` advances, recheck the exact PR head, merge-base diff, duplicate or overlap risk, review threads, required checks, and mergeability against current `main` without changing the branch. Do not update, rebase, or merge `main` into a clean PR merely to refresh its base. Update a branch only when GitHub already reports an actual merge conflict, or when an explicitly authorized merge attempt made with every readiness gate passing is refused under strict up-to-date branch protection. Never bypass branch protection with an admin merge.
-- When the user says to loop, babysit, or continue until green, preserve the authorized mode: watch state, and fix, commit, push, or reply only when those actions are authorized. Recheck the exact head's required checks, required reviews, thread-aware review state, and mergeability until the PR is clean or materially blocked. Pending required CI or reviews are intermediate states; use the checkpoint and heartbeat procedure in `$watch-asc-pr` when only waiting remains. Advisory CI may remain pending only after every other clean-state gate passes.
+- For loop or babysit requests, follow `$watch-asc-pr` until ready or materially blocked, preserving the authorized actions. Use its checkpoint and heartbeat procedure when only waiting remains.
 - When merge is explicitly authorized, preserve the PR commits with a regular merge commit, for example `gh pr merge <number> --merge --match-head-commit <sha>`. Do not squash unless the user explicitly requests squash for that PR.
-- An audit reports findings; implement fixes when requested. Approval and merge require explicit user intent.
 - For read-only triage, recommend exactly one type (`bug`, `enhancement`, `question`), one priority (`p0`-`p3`), and one difficulty (`easy`, `medium`, `hard`). When issue creation or label changes are authorized, apply exactly one label from each bucket and remove conflicting labels.
 
 ## Authentication and live testing
@@ -123,7 +110,7 @@ Tests touching auth must isolate relevant environment and config state. For live
 
 ## Handoff contract
 
-Lead with the outcome, decisive validation evidence, material risks or unknowns, and next action. Use concise prose or a short list; include design alternatives, invocation examples, compatibility details, and individual commands when they help assess the change. Separate source review, tests, remote checks, merge, release artifacts, and provider state; one does not prove the next. Report pre-existing failures and unverified acceptance criteria explicitly.
+Report the outcome, decisive evidence, material unknowns, and next action concisely. Include design or command details only when useful. Distinguish source review, tests, remote checks, merge, release artifacts, and provider state. Report pre-existing failures and unverified acceptance criteria.
 
 ## References
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Skills for using `asc` in app workflows live at https://github.com/rorkai/app-st
 Repository-maintainer workflows live under `.agents/skills/`:
 
 - `$develop-asc-change`: design, implement, and verify commands, flags, endpoints, bug fixes, and behavior-changing refactors.
-- `$audit-asc-pr`: audit a complete PR and fix proven defects.
+- `$audit-asc-pr`: audit a complete PR and, when authorized, fix proven defects.
 - `$watch-asc-pr`: recheck PR comments, checks, head changes, and merge readiness.
 - `$triage-asc-issue`: reproduce, classify, label, and scope an issue.
 - `$review-wall-of-apps-prs`: validate, approve, and merge Wall of Apps submissions safely.
@@ -17,6 +17,13 @@ Repository-maintainer workflows live under `.agents/skills/`:
 - `$sync-asc-skills`: check the external ASC workflow skills for CLI-surface drift.
 
 Use these skills for their matching workflows instead of expanding this always-loaded file with task-specific procedures.
+
+## Authority and follow-through
+
+- Treat audits, reviews, research, triage, status checks, and drafts as read-only. Edits, commits, pushes, PR creation or comments, labels, approval, merge, publication, external sends, and deletion require authority from the user's request or established session context. A clear request can authorize several actions at once; do not ask again for authority already granted.
+- Skill selection does not grant additional authority. Explicit user instructions take precedence over skill guidelines within system and developer constraints. Complete authorized work, make routine choices from repository conventions, and ask only when missing information materially changes scope, public compatibility, or authorization. Continue independent work while awaiting an answer.
+- If a skill causes a pause or departure from the requested scope, link the exact `SKILL.md`, quote the relevant instruction, and explain the unresolved decision. Prepare the authorized work needed for a concrete, reviewable result before asking for any remaining approval.
+- After an interruption or uncertain write, inspect current state before retrying. Keep the original objective and authorization when responding to follow-up questions or corrections unless the user changes the scope.
 
 ## Core CLI contract
 
@@ -57,13 +64,14 @@ Validate attributes against the exact create or update request schema. Validate 
 - Run the review directly from the local Git worktree, with user configuration ignored and app connectors and plugins disabled as shown. Force the built-in `openai` provider and ChatGPT-supported model so custom provider, endpoint, or review-model settings cannot supply another API key, route code to another service, or select an incompatible model. Immediately before every review, confirm `codex login status` shows ChatGPT authentication and verify both `CODEX_API_KEY` and `OPENAI_API_KEY` are unset or empty because either can supply usage-billed API-key authentication to non-interactive reviews. Treat any API-key login or override as a separate authorization gate and stop unless it was explicitly approved.
 - Before calling a PR ready, refresh its authoritative base with `git fetch origin +refs/heads/<base-branch>:refs/remotes/origin/<base-branch>` and run `codex exec --ignore-user-config review --disable apps --disable plugins --disable remote_plugin -c 'model_provider="openai"' -c 'model="gpt-5.6-sol"' -c 'review_model="gpt-5.6-sol"' --base origin/<base-branch>` on the final committed head so the complete branch or PR diff is reviewed against the current base. If the applicable review mechanism is unavailable, report the review gate as blocked and do not call the PR ready. Fix and verify every valid finding, and explicitly verify and disposition any false positive or non-actionable finding. After any change, rerun the applicable review command and repeat until it reports no actionable findings.
 - Do not call a PR clean, ready, complete, or express satisfaction with it until the final full-branch `/review` loop is clear. Any subsequent change invalidates the clear result and requires another full-branch `/review`.
+- An investigation can finish with findings or a blocked gate; report that outcome without implying the PR is ready. Skills must use this full-branch review requirement together with the GitHub readiness gates below.
 - Keep one logical change per commit. Do not mix unrelated refactors, fixes, and test rewrites.
 - Preserve additive PR history. Do not squash, rebase, force-push, or otherwise rewrite commits unless the user explicitly requests that strategy.
 - Re-run the focused failing test after each fix before broad validation.
 - Preserve and report pre-existing failures honestly.
-- Parallelize independent read-only investigation and lightweight focused validation, using isolated subagents when available. Do not let agents concurrently edit the same branch, files, or command group. Keep edits, pushes, review replies and resolutions, approvals, merges, releases, and cleanup coordinated and serialized.
+- Delegate substantive, independent read-only investigations or lightweight focused validation when parallel work can improve time or coverage. Give each subagent distinct ownership and an evidence-based output; verify its conclusions centrally. Handle small or dependent tasks locally. Do not let agents concurrently edit the same branch, files, or command group. Keep edits, pushes, review replies and resolutions, approvals, merges, releases, and cleanup coordinated and serialized.
 - Treat repository-wide commands that compile, lint, or test broad package sets—including `make build`, `make lint`, `make test`, `go test ./...`, race tests over `./...`, and `golangci-lint run ./...`—as host-intensive gates. Coordinate them through one agent and run only one host-intensive gate at a time on the same host. Before starting one, check whether another task is already running a host-intensive gate; if so, wait instead of competing for the same CPUs. Never terminate another task's process without explicit authorization.
-- Within a worktree, wait for each focused test to finish before starting a broad gate. Do not overlap focused and broad tests against the same worktree or have multiple agents repeat a successful full gate for the same commit and unchanged worktree. A tracked or untracked worktree change, gate command or input change, relevant environment or toolchain change, or newly requested verification invalidates the affected results; rerun the relevant focused checks and full gate before claiming readiness.
+- Within a worktree, wait for each focused test to finish before starting a broad gate. Record the checked commit, relevant working-tree state, command, and environment. Reuse passing checks while their inputs remain unchanged, including during status-only follow-ups. Rerun affected checks when source, test inputs, commands, environment, toolchain, or requested verification changes; unrelated temporary files do not invalidate results. Complete every required gate for the final change, and preserve the separate full-branch review requirement after any diff change.
 - Run host-intensive gates concurrently only when explicitly required. Assign each gate a CPU budget and keep the sum of concurrent gate budgets within the host's logical CPU count; tool flags are limits within a gate, not values to add together. Avoid multiplying Go package and in-binary concurrency: for a budget of `B`, use `GOMAXPROCS=1 go test -p=B -parallel=1 ./...` for package fan-out or `GOMAXPROCS=B go test -p=1 -parallel=B ./...` for one package at a time. Use `golangci-lint run --concurrency=B ./...` for a linter gate.
 
 User-facing commands and flags follow `experimental` -> `stable` -> `deprecated` -> `removed`. Do not delete stable behavior directly. Deprecations require warning text, transition tests, migration guidance, and a release-note entry.
@@ -102,20 +110,20 @@ Do not weaken CI: formatting, documentation, lint, and tests must run on PR and 
 - Inspect thread-aware GitHub review state before declaring a PR clean; flat comments do not prove every thread is resolved.
 - A PR is ready only when the latest head was reviewed, required checks pass, required reviews are satisfied, actionable threads are resolved, and GitHub reports it mergeable.
 - If `main` advances, recheck the exact PR head, merge-base diff, duplicate or overlap risk, review threads, required checks, and mergeability against current `main` without changing the branch. Do not update, rebase, or merge `main` into a clean PR merely to refresh its base. Update a branch only when GitHub already reports an actual merge conflict, or when an explicitly authorized merge attempt made with every readiness gate passing is refused under strict up-to-date branch protection. Never bypass branch protection with an admin merge.
-- When the user says to loop, babysit, or continue until green, keep re-fetching the exact head's required checks, required reviews, thread-aware review state, and mergeability. Fix valuable new feedback in additive commits, push, and repeat until the PR is clean or a material blocker requires user input; pending required CI or reviews are intermediate states. Advisory CI may remain pending only after every other clean-state gate passes.
+- When the user says to loop, babysit, or continue until green, preserve the authorized mode: watch state, and fix, commit, push, or reply only when those actions are authorized. Recheck the exact head's required checks, required reviews, thread-aware review state, and mergeability until the PR is clean or materially blocked. Pending required CI or reviews are intermediate states; use the checkpoint and heartbeat procedure in `$watch-asc-pr` when only waiting remains. Advisory CI may remain pending only after every other clean-state gate passes.
 - When merge is explicitly authorized, preserve the PR commits with a regular merge commit, for example `gh pr merge <number> --merge --match-head-commit <sha>`. Do not squash unless the user explicitly requests squash for that PR.
-- Fix-forward is the default for `$audit-asc-pr`; approval and merge still require explicit user intent.
-- Every newly created or triaged issue must end with exactly one type (`bug`, `enhancement`, `question`), one priority (`p0`-`p3`), and one difficulty (`easy`, `medium`, `hard`) label.
+- An audit reports findings; implement fixes when requested. Approval and merge require explicit user intent.
+- For read-only triage, recommend exactly one type (`bug`, `enhancement`, `question`), one priority (`p0`-`p3`), and one difficulty (`easy`, `medium`, `hard`). When issue creation or label changes are authorized, apply exactly one label from each bucket and remove conflicting labels.
 
 ## Authentication and live testing
 
 App Store Connect API keys come from https://appstoreconnect.apple.com/access/integrations/api and must never be committed.
 
-Tests touching auth must isolate relevant environment and config state. For live verification, prefer read-only calls. When mutation is necessary during PR audits, prefer disposable app `6759231657`, clean up temporary resources, and record anything left behind. Never mutate a non-disposable app without explicit approval.
+Tests touching auth must isolate relevant environment and config state. For live verification, prefer read-only calls. Live mutations require authorization, including on disposable app `6759231657`; a disposable target does not itself grant permission. Include temporary-resource cleanup in the authorized verification plan and record anything left behind. Never mutate a non-disposable app without explicit approval.
 
 ## Handoff contract
 
-For substantial changes, explain the chosen approach, alternatives and trade-offs, expected invocations and outputs, compatibility impact, edge cases, failure modes, commands run, tests, live verification, commits or pushes, and unresolved risks.
+Lead with the outcome, decisive validation evidence, material risks or unknowns, and next action. Use concise prose or a short list; include design alternatives, invocation examples, compatibility details, and individual commands when they help assess the change. Separate source review, tests, remote checks, merge, release artifacts, and provider state; one does not prove the next. Report pre-existing failures and unverified acceptance criteria explicitly.
 
 ## References
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,9 +122,10 @@ Label meanings:
 - `medium`: moderate cross-file change or some product/UX/design work
 - `hard`: large, high-risk, or architecture-heavy change
 
-External contributors may not have permission to label issues directly. Maintainers and
-agents should add any missing labels during first triage, and new issues should not be left
-without a type, priority, and difficulty label set.
+External contributors may not have permission to label issues directly. During read-only
+agent triage, recommend one label from each bucket. When issue creation or label updates
+are authorized, apply missing labels and remove conflicting labels so the issue has
+exactly one type, priority, and difficulty. Follow the authority rules in `AGENTS.md`.
 
 ## Security
 


### PR DESCRIPTION
Audit, status, and skill-drift requests could trigger edits or external writes, while skills defined inconsistent PR-readiness rules. Define authority and shared validation rules in `AGENTS.md`, with workflow-specific checks in the seven maintainer skills.

Preserve granted authority across follow-ups, reuse still-valid checks, and require the full-branch review gate. Release resumes reconcile immutable tags; new releases whose base advances restart validation in a worktree at the selected commit. External announcement drafts require established write authority.

Apply the [GPT-6 Astra prompting guidance](https://developers.openai.com/api/docs/guides/latest-model?model=gpt-6-astra), retaining reviewer billing isolation, exact-head merge checks, and artifact verification.

Validation:

- `ASC_BYPASS_KEYCHAIN=1 make check-docs` and `make check-agent-skills`
- Skill-creator validation for all seven skills
- Commit-hook formatting, lint, and short Go tests
- Connector-free pre-commit and final full-branch reviews
