### PR TITLE
Clarify agent authority and workflow completion

### DIFF
--- a/.agents/skills/review-wall-of-apps-prs/SKILL.md
+++ b/.agents/skills/review-wall-of-apps-prs/SKILL.md
@@ -30,7 +30,7 @@ Use an isolated checkout when needed to validate the exact head or apply authori
 ## Approve and merge
 
 Approval and merge require explicit user intent. That intent may come from the
-current request or from a persisted automation prompt that clearly grants
+current request, preserved session context, or a persisted automation prompt that clearly grants
 approve-and-merge authority. Immediately before approval, or before a merge
 that does not require a new approval, confirm:
 

--- a/.agents/skills/triage-asc-issue/SKILL.md
+++ b/.agents/skills/triage-asc-issue/SKILL.md
@@ -45,7 +45,7 @@ When the issue is actionable, provide:
 5. Safe live verification and cleanup plan.
 6. Compatibility or deprecation requirements.
 
-If the user asks to implement the issue, hand the validated contract to `$develop-asc-change` in an isolated branch or worktree. Do not close the issue or claim completion before the implementation is merged and verified.
+If implementation is requested, continue with `$develop-asc-change` in an isolated branch or worktree. Report the requested implementation and validation as complete when finished, with PR and merge gates separately. Do not close the issue or claim it resolved until merged and verified; closure still requires authority.
 
 ## Automation contract
 

--- a/.agents/skills/watch-asc-pr/SKILL.md
+++ b/.agents/skills/watch-asc-pr/SKILL.md
@@ -5,7 +5,7 @@ description: Recheck an in-progress App-Store-Connect-CLI pull request for new r
 
 # Watch an ASC CLI pull request
 
-Preserve the PR context and authority under `AGENTS.md`: status reads once; watch repeats until a terminal state; fix-and-watch also applies authorized fixes. Watching alone grants no edit, commit, push, or reply authority.
+Preserve the PR context and authority under `AGENTS.md`: status reads once; watch repeats until a terminal state; fix-and-watch also applies authorized fixes. Watching alone grants no edit, commit, push, or reply authority. A one-time check ends after reporting its snapshot; do not start a full readiness audit or heartbeat unless requested or already authorized.
 
 ## Recheck current state
 
@@ -28,6 +28,7 @@ Apply fixes and external writes only when authorized. Otherwise report the verif
 
 ## Return one state
 
+- `observed`: a one-time check completed; report the requested facts and mark readiness unverified unless separately established. An actionable finding does not make a completed read-only check blocked.
 - `changed`: pushed a fix; include commit and validation.
 - `pending`: required checks, required reviews, or actionable reviews are still running; identify exactly what remains. This is an intermediate state during a user-requested loop, not the final handoff.
 - `clean`: the final full-branch local review in `AGENTS.md` is clear for the current head and base, required checks pass, required reviews are satisfied, the latest head is mergeable, and no actionable unresolved thread remains. Report advisory jobs without treating them as blockers.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -13,6 +13,7 @@ fi
 
 needs_code=0
 needs_repo_docs=0
+needs_agent_skills=0
 needs_website_docs=0
 needs_command_docs=0
 needs_wall_of_apps=0
@@ -27,6 +28,14 @@ while IFS= read -r path; do
     needs_wall_of_apps=1
     continue
   fi
+
+  case "$path" in
+    AGENTS.md|.agents/skills/*.md|.agents/skills/*/agents/openai.yaml)
+      needs_repo_docs=1
+      needs_agent_skills=1
+      continue
+      ;;
+  esac
 
   case "$path" in
     docs.json|.mintignore|.mintlify/*|*.mdx|cicd/*|commands/*|concepts/*|configuration/*|guides/*|resources/*)
@@ -70,6 +79,11 @@ fi
 if [ "$needs_repo_docs" -eq 1 ]; then
   echo "Running repository docs checks..."
   make check-repo-docs
+fi
+
+if [ "$needs_agent_skills" -eq 1 ]; then
+  echo "Running agent skill checks..."
+  make check-agent-skills
 fi
 
 if [ "$needs_website_docs" -eq 1 ]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,9 +20,9 @@ Use these skills for their matching workflows instead of expanding this always-l
 
 ## Authority and follow-through
 
-- Audits, reviews, research, triage, status checks, and drafts are read-only. Edits, commits, pushes, PR creation, comments, labels, approval, merge, publication, external sends, and deletion require authority from the request or session context. One request may authorize several actions; do not ask again for granted authority.
+- Audits, reviews, research, triage, status checks, and composing draft text are read-only. Creating or updating a remote draft is an external write. Edits, commits, pushes, PR creation, comments, labels, approval, merge, publication, external sends, and deletion require authority from the request or session context. One request may authorize several actions; do not ask again for granted authority. Creating a PR for agreed changes includes the necessary edits, checks, commit, branch push, and PR creation, but not merge.
 - User instructions override skill guidelines within system and developer constraints; skill selection grants no authority. Make routine choices from repository conventions. Ask only about material scope, compatibility, or authority gaps, after preparing authorized work for review; continue independent work while awaiting answers.
-- If a skill causes a pause or scope change, link its `SKILL.md`, quote the instruction, and explain the unresolved decision. Preserve the objective and authority across follow-ups unless the user changes scope. Inspect state before retrying an interrupted or uncertain write.
+- If a skill causes a pause or scope change, link its `SKILL.md`, quote the instruction, and explain the unresolved decision. Preserve the objective, targets, authority, and verified progress across follow-ups and skill handoffs unless the user changes scope. Switching skills continues the current task; a failing gate blocks dependent actions, not independent authorized work. Inspect state before retrying an interrupted or uncertain write.
 
 ## Core CLI contract
 

--- a/scripts/test_check_docs.py
+++ b/scripts/test_check_docs.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -1332,25 +1334,67 @@ class DocLinksTest(unittest.TestCase):
 
 
 class HookChecksTest(unittest.TestCase):
-    def test_pre_commit_treats_root_level_mdx_and_mintlify_config_as_docs(self) -> None:
-        hook = (
-            Path(__file__).resolve().parents[1] / ".githooks" / "pre-commit"
-        ).read_text()
-        self.assertIn(
-            'docs.json|.mintignore|.mintlify/*|*.mdx|cicd/*|commands/*|concepts/*|configuration/*|guides/*|resources/*)',
-            hook,
-        )
+    def run_hook(self, paths: list[str], fail_target: str = "") -> tuple[int, list[str]]:
+        hook = Path(__file__).resolve().parents[1] / ".githooks" / "pre-commit"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            commands = {
+                "git": '\n'.join([
+                    '#!/usr/bin/env bash',
+                    'if [ "$1" = rev-parse ]; then pwd;',
+                    'elif [ "$2" = --cached ]; then printf "%s\\n" "$HOOK_PATHS"; fi',
+                ]),
+                "go": '#!/usr/bin/env bash\nif [ "$1" = env ]; then pwd; else echo "go $*" >> "$HOOK_LOG"; fi\n',
+                "make": '#!/usr/bin/env bash\necho "make $*" >> "$HOOK_LOG"\n[ "$1" != "$HOOK_FAIL" ]\n',
+            }
+            for name, content in commands.items():
+                command = root / name
+                command.write_text(content)
+                command.chmod(0o755)
+            log = root / "calls"
+            result = subprocess.run(
+                ["bash", str(hook)], cwd=root, capture_output=True, text=True,
+                env={**os.environ, "PATH": f"{root}:{os.environ['PATH']}",
+                     "HOOK_PATHS": "\n".join(paths), "HOOK_LOG": str(log),
+                     "HOOK_FAIL": fail_target},
+            )
+            return result.returncode, log.read_text().splitlines() if log.exists() else []
 
-    def test_pre_commit_treats_docs_go_files_as_code(self) -> None:
-        hook = (
-            Path(__file__).resolve().parents[1] / ".githooks" / "pre-commit"
-        ).read_text()
-        needs_code_case = hook.split('case "$path" in')[4]
-        docs_case = needs_code_case.index(
-            'docs.json|.mintignore|.mintlify/*|*.mdx|cicd/*|commands/*|concepts/*|configuration/*|guides/*|resources/*|README.md|CONTRIBUTING.md|SUPPORT.md|docs/*)'
-        )
-        go_case = needs_code_case.index("*.go|go.mod|go.sum|Makefile)")
-        self.assertLess(go_case, docs_case)
+    def test_instruction_docs_run_validators_without_go_gates(self) -> None:
+        for path in ["AGENTS.md", ".agents/skills/watch-asc-pr/SKILL.md",
+                     ".agents/skills/watch-asc-pr/references/checks.md",
+                     ".agents/skills/watch-asc-pr/agents/openai.yaml"]:
+            with self.subTest(path=path):
+                code, calls = self.run_hook([path])
+                self.assertEqual(code, 0)
+                self.assertEqual(calls, ["make check-repo-docs", "make check-agent-skills"])
+
+    def test_executable_and_mixed_changes_keep_code_gates(self) -> None:
+        for paths in [[".agents/skills/example/scripts/check.py"],
+                      ["AGENTS.md", "internal/cli/main.go"], ["docs/example.go"],
+                      [".githooks/pre-commit"]]:
+            with self.subTest(paths=paths):
+                code, calls = self.run_hook(paths)
+                self.assertEqual(code, 0)
+                self.assertIn("make format", calls)
+                self.assertIn("make lint", calls)
+                self.assertIn("go test -short ./...", calls)
+
+    def test_instruction_validation_failure_blocks_commit(self) -> None:
+        for target in ["check-repo-docs", "check-agent-skills"]:
+            with self.subTest(target=target):
+                code, calls = self.run_hook(["AGENTS.md"], target)
+                self.assertNotEqual(code, 0)
+                self.assertNotIn("make format", calls)
+
+    def test_website_and_wall_fast_paths_remain_separate(self) -> None:
+        for path, expected in [("index.mdx", "make check-website-docs"),
+                               (".mintlify/config.json", "make check-website-docs"),
+                               ("docs/wall-of-apps.json", "make check-wall-of-apps")]:
+            with self.subTest(path=path):
+                code, calls = self.run_hook([path])
+                self.assertEqual(code, 0)
+                self.assertEqual(calls, [expected])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Routine instruction workflows could lose prior authorization, treat a one-time status check as a readiness audit, or keep an implementation open until an unauthorized merge. Clarify bundled PR authority, preserve session context across Wall reviews and skill handoffs, add an observed status result, and distinguish implementation completion from issue resolution. Remote drafts remain explicit external writes.

Instruction Markdown and skill UI metadata now run documentation and skill validators in the commit hook. Executable skill files and mixed code changes retain format, lint, and Go tests. Runtime hook tests cover both paths and ensure validator failures block commits.

Validation: reproduced the hook regression before the fix; all 50 documentation tests and seven skill-validator tests passed; make check-docs passed; the commit hook passed format, lint, and ASC_BYPASS_KEYCHAIN=1 go test -short ./.... Pre-commit and final full-branch local Codex reviews found no actionable issues. No CLI command or CI workflow changed.
