### PR TITLE
fix(web): reject mismatched app tax category resources

### DIFF
--- a/internal/web/tax_category.go
+++ b/internal/web/tax_category.go
@@ -284,6 +284,9 @@ func (c *Client) GetAppTaxCategory(ctx context.Context, appID string) (*AppTaxCa
 	if strings.TrimSpace(resource.ID) == "" {
 		return nil, fmt.Errorf("app tax category response did not include a resource id")
 	}
+	if strings.TrimSpace(resource.ID) != appID || strings.TrimSpace(resource.Type) != "appTaxCategories" {
+		return nil, fmt.Errorf("app tax category response identified resource %q of type %q, want app tax category for %q", resource.ID, resource.Type, appID)
+	}
 	return decodeAppTaxCategoryResource(resource, payload.Included, appID), nil
 }
 

--- a/internal/web/tax_category_test.go
+++ b/internal/web/tax_category_test.go
@@ -251,3 +251,26 @@ func taxCategoryWriteMap(t *testing.T, parent map[string]any, key string) map[st
 	}
 	return value
 }
+
+func TestGetAppTaxCategoryRejectsUnexpectedResourceIdentity(t *testing.T) {
+	for _, resource := range []struct{ name, id, kind string }{{"wrong app", "app-2", "appTaxCategories"}, {"wrong type", "app-1", "apps"}, {"missing type", "app-1", ""}} {
+		t.Run(resource.name, func(t *testing.T) {
+			requests := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests++
+				if r.Method != http.MethodGet || r.URL.Path != "/appTaxCategories/app-1" {
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				if err := json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"id": resource.id, "type": resource.kind, "relationships": map[string]any{"category": map[string]any{"data": map[string]string{"id": "cat-games", "type": "taxCategories"}}}}}); err != nil {
+					t.Error(err)
+				}
+			}))
+			defer server.Close()
+			result, err := testWebClient(server).GetAppTaxCategory(context.Background(), "app-1")
+			if err == nil || result != nil || requests != 1 {
+				t.Fatalf("accepted unexpected tax resource: result=%+v error=%v requests=%d", result, err, requests)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Configured app tax-category reads accepted any nonempty resource ID and then reported the category under the requested app ID. A response for app B could therefore appear as app A's selection and influence the setter's preflight or readback. This change rejects responses unless `data.type` is `appTaxCategories` and `data.id` matches the requested app. Refs #2299.

## Behavior

The check lives in `GetAppTaxCategory`, shared by the existing view and set workflows. It follows the captured `/appTaxCategories/{appId}` resource contract and the identity validation already used when a missing category is checked against `/apps/{appId}`. Malformed configured-resource responses fail before decoding their category and conditions. Valid reads and the existing 404/null default-selection handling remain unchanged.

No commands or flags are added. Existing commands include:

```bash
asc web apps tax-category view --app APP_ID --output json
asc web apps tax-category set --app APP_ID --category CATEGORY_ID --confirm
```

## Regression evidence

The local HTTP regression returned a wrong app ID, wrong resource type, and missing type. Before the fix, each response was accepted and attributed to the requested app; after the fix, all three return an error without a computed category. Existing tax-category client and CLI tests also pass:

```bash
ASC_BYPASS_KEYCHAIN=1 GOMAXPROCS=1 go test -p=1 -parallel=1 ./internal/web ./internal/cli/web -run 'TaxCategory|TaxCategories' -count=1
```

The captured Apple frontend establishes the expected ID/type contract; no mismatched Apple response was observed live. This is deterministic malformed-response verification. No tax classification was changed, and no provider mutation was performed for this fix. It does not add a duplicate tax feature or expand the available category catalog.

## Final validation

The following all passed on the final source tree, followed by normal commit hooks:

```bash
make build
make format
make check-docs
make lint
ASC_BYPASS_KEYCHAIN=1 make test
```

Final committed full-branch `/review` against main `bbbd538cbd1ec3eb7915c92048da0f361938441f` found no actionable defects at head `9d3e0680b816ccb392a21092bb236986159e2ed1`. Review used ChatGPT authentication through the built-in OpenAI provider with app connectors and plugins disabled. The review sandbox could not run Go tests; the independent local gates above did. No command-help generation was needed because the CLI surface is unchanged.
