### PR TITLE
feat(web): read app transfer status

### DIFF
--- a/commands/web.mdx
+++ b/commands/web.mdx
@@ -294,6 +294,7 @@ Available commands:
 * `asc web apps compatibility view|edit` - inspect or change the Mac and Apple Vision Pro App Store opt-in settings
 * `asc web apps distribution view|set` - inspect or update the app distribution method (`APP_STORE` or `CUSTOM`)
 * `asc web apps history` - view App Store version status history, optionally scoped with `--version-id`
+* `asc web apps transfer status` - read the app-attached transfer request without performing transfer actions
 * `asc web apps declarations list` - list the App Store Regulations & Permits declarations tracked for an app
 * `asc web apps medical-device view` - read the stored regulated medical device declaration
 * `asc web apps medical-device set` - manage the regulated medical device declaration
@@ -317,6 +318,32 @@ Notes:
 * `asc web apps distribution view` prints `distributionType` as `APP_STORE` (public) or `CUSTOM` (private distribution through Apple Business Manager or Apple School Manager); attributes Apple omits are reported as `unknown`. `distribution set` covers only the captured app-level public/private transition and paired education value. `DIRECT_URL`/unlisted distribution remains a separate Apple flow with no captured request contract and stays in the App Store Connect web UI
 
 `asc web apps tax-category set` requires `--app`, `--category`, and `--confirm`. Repeat `--condition` for compatible conditions or omit it to clear them. The command validates the catalog before writing and re-reads the result. Transaction Tax reports remain outside this workflow.
+
+### `asc web apps transfer`
+
+Read the transfer request attached to an app through an authenticated web session:
+
+```bash
+asc web apps transfer status --app APP_ID
+asc web apps transfer status --app APP_ID --output json
+```
+
+This experimental command uses `GET /iris/v1/apps/{appId}?include=appTransferRequest`.
+JSON preserves Apple's complete app response, including the relationship, any
+included transfer resource, links, and unknown fields. Table and Markdown output
+show request presence (`none`, `present`, or `unknown`), the transfer ID, and the
+state Apple returned. Explicit `data: null` means no request was returned;
+omitted linkage or state remains unknown. No eligibility or completion is inferred.
+
+A read on the disposable app verified HTTP 200 with an explicit null relationship.
+A nonempty pending transfer has not yet been captured; its state rendering is
+covered by HTTP fixtures using Apple's source-defined `id` and `state` fields.
+
+The manual prerequisite page is
+`https://appstoreconnect.apple.com/WebObjects/iTunesConnect.woa/wa/LCAppPage/transferApp?adamId=APP_ID`.
+The command does not open or scrape it, or list recipient-side transfers.
+Initiate, accept, cancel, and decline are intentionally deferred until the
+maintainer performs those workflows and captures their requests and responses.
 
 ### `asc web sandbox`
 

--- a/docs/API_NOTES.md
+++ b/docs/API_NOTES.md
@@ -181,6 +181,13 @@ the App Store Connect web-client source captured for issue #2299:
 - These writes are based on the captured frontend constructor and local HTTP tests; no live Apple mutation or live eligibility/success proof was performed. Apple-side role and eligibility restrictions can still reject a validly serialized request.
 - Unlisted App Store distribution is a request form reviewed by Apple, not an attribute value on this resource. There is no captured endpoint for it, so no flag is offered.
 
+## App transfer status (web session)
+
+- The captured App Information frontend includes `appTransferRequest` and models its `id` and `state`. The narrowed read is `GET /iris/v1/apps/{appId}?include=appTransferRequest`, with no body. This relationship is absent from the embedded public OpenAPI app schema.
+- On 2026-09-06, an authenticated read of disposable app `6759231657` returned HTTP 200, the expected `apps` resource ID, `relationships.appTransferRequest.data: null`, and an empty `included` array. The related URL `/iris/v1/apps/{appId}/appTransferRequest` returned HTTP 409 with `ENTITY_ERROR.RELATIONSHIP.INVALID` for that fixture. The CLI uses the successful app read and does not follow the related link.
+- `asc web apps transfer status --app APP_ID` preserves the original JSON envelope. Human output distinguishes explicit null (`none`), a resource reference (`present`), and omitted linkage (`unknown`). It matches an included transfer resource by both type and ID, preserves state strings, and leaves missing state unknown. App identity must match before any output. It does not normalize states into eligibility, success, or failure; no pending-transfer response was observed live.
+- The legacy navigation URL `/WebObjects/iTunesConnect.woa/wa/LCAppPage/transferApp?adamId={appId}` leads to a prerequisite page. It is not a captured initiate API. No recipient list, initiate, accept, cancel, or decline action contract has been captured. Those operations are deferred to maintainer-run transfers and subsequent request/response captures.
+
 ## Last-compatible version settings (`downloadable`)
 
 - App Store Connect's Last-Compatible Version Settings screen has no dedicated resource and no `lastCompatibleVersion` attribute. The feature is carried by the boolean `downloadable` attribute on the existing `appStoreVersions` resource; `lastCompatibleVersion` is only a client-side label App Store Connect puts on the `appStoreVersions` collection it reads back.

--- a/internal/cli/capabilities/capabilities.go
+++ b/internal/cli/capabilities/capabilities.go
@@ -282,6 +282,14 @@ func capabilityRows() []Capability {
 		},
 		{
 			Area:       "app-management",
+			Capability: "App transfer status",
+			Status:     statusWebSession,
+			Commands:   []string{"asc web apps transfer status"},
+			Notes:      []string{"Reads the app-attached transfer relationship through a web session and preserves Apple's raw state. It does not check eligibility or list recipient transfers; initiate, accept, cancel, and decline remain manual workflows."},
+			NextAction: "Use asc web apps transfer status --app APP_ID for the app-attached request, or App Store Connect for transfer actions.",
+		},
+		{
+			Area:       "app-management",
 			Capability: "App Store Mac and Vision Pro compatibility opt-ins",
 			Status:     statusWebSession,
 			Commands:   []string{"asc web apps compatibility"},

--- a/internal/cli/cmdtest/stability_tiers_test.go
+++ b/internal/cli/cmdtest/stability_tiers_test.go
@@ -32,6 +32,8 @@ func TestExperimentalCommandsHaveStabilityLabel(t *testing.T) {
 		{[]string{"signing", "reconcile", "plan"}},
 		{[]string{"signing", "reconcile", "apply"}},
 		{[]string{"apps", "rename"}},
+		{[]string{"web", "apps", "transfer"}},
+		{[]string{"web", "apps", "transfer", "status"}},
 		{[]string{"web", "agreements"}},
 		{[]string{"web", "agreements", "status"}},
 		{[]string{"web", "agreements", "accept"}},
@@ -91,6 +93,8 @@ func TestWebCommandsDoNotHaveExperimentalStabilityLabel(t *testing.T) {
 	}
 	assertCommandDoesNotMentionExperimental(t, webCmd, []string{"web"})
 	allowed := map[string]struct{}{
+		"web apps transfer":           {},
+		"web apps transfer status":    {},
 		"web auth export":             {},
 		"web auth import":             {},
 		"web bundle-ids list":         {},

--- a/internal/cli/cmdtest/web_apps_transfer_test.go
+++ b/internal/cli/cmdtest/web_apps_transfer_test.go
@@ -1,0 +1,27 @@
+package cmdtest
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"strings"
+	"testing"
+)
+
+func TestWebAppsTransferStatusRequiresApp(t *testing.T) {
+	t.Setenv("ASC_APP_ID", "")
+	root := RootCommand("test")
+	if findSubcommand(root, "web", "apps", "transfer", "status") == nil {
+		t.Fatal("transfer status is not registered")
+	}
+	var runErr error
+	stdout, stderr := captureOutput(t, func() {
+		if err := root.Parse([]string{"web", "apps", "transfer", "status"}); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		runErr = root.Run(context.Background())
+	})
+	if !errors.Is(runErr, flag.ErrHelp) || !strings.Contains(stderr, "--app is required") || stdout != "" {
+		t.Fatalf("err=%v stdout=%q stderr=%q", runErr, stdout, stderr)
+	}
+}

--- a/internal/cli/web/web_apps.go
+++ b/internal/cli/web/web_apps.go
@@ -37,6 +37,7 @@ Use ` + "`asc web apps create`" + ` as the canonical app-creation command.
 			WebAppsCompatibilityCommand(),
 			WebAppsDistributionCommand(),
 			WebAppsHistoryCommand(),
+			WebAppsTransferCommand(),
 			WebAppsDeclarationsCommand(),
 			WebAppsMedicalDeviceCommand(),
 			WebAppsTaxCategoryCommand(),

--- a/internal/cli/web/web_apps_transfer.go
+++ b/internal/cli/web/web_apps_transfer.go
@@ -1,0 +1,82 @@
+package web
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+// WebAppsTransferCommand exposes read-only app-transfer information.
+func WebAppsTransferCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("web apps transfer", flag.ExitOnError)
+	return &ffcli.Command{
+		Name: "transfer", ShortUsage: "asc web apps transfer <subcommand> [flags]",
+		ShortHelp: "[experimental] Read app-transfer status via a web session.",
+		LongHelp: `Read the transfer request attached to an app in App Store Connect.
+Initiate, accept, cancel, and decline remain manual Apple workflows.`,
+		FlagSet: fs, UsageFunc: shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{WebAppsTransferStatusCommand()},
+		Exec:        func(context.Context, []string) error { return flag.ErrHelp },
+	}
+}
+
+// WebAppsTransferStatusCommand reads Apple's appTransferRequest relationship.
+func WebAppsTransferStatusCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("web apps transfer status", flag.ExitOnError)
+	appID := fs.String("app", "", "App Store Connect app ID (or ASC_APP_ID)")
+	authFlags := bindWebSessionFlags(fs)
+	output := shared.BindOutputFlags(fs)
+	return &ffcli.Command{
+		Name: "status", ShortUsage: "asc web apps transfer status --app APP_ID [flags]",
+		ShortHelp: "[experimental] Read the app-attached transfer request and state.",
+		LongHelp: `Read the app through Apple's web-session API with appTransferRequest included.
+JSON preserves Apple's full response envelope. Table and Markdown report request
+presence as none for explicit null, present for a resource reference, or unknown
+when Apple omits linkage. Missing state stays unknown; returned state values are
+not normalized. A null relationship does not prove the app is eligible to transfer.
+
+This reads one app, not the recipient's transfer list or the legacy prerequisite
+page. It does not initiate, accept, cancel, or decline a transfer.
+
+Examples:
+  asc web apps transfer status --app 6759231657
+  asc web apps transfer status --app 6759231657 --output json`,
+		FlagSet: fs, UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageErrorf("unexpected argument(s): %s", strings.Join(args, " "))
+			}
+			resolved := strings.TrimSpace(shared.ResolveAppID(*appID))
+			if resolved == "" {
+				fmt.Fprintln(os.Stderr, "Error: --app is required (or set ASC_APP_ID)")
+				return shared.MissingRequiredUsageError("--app")
+			}
+			session, requestCtx, cancel, err := resolveWebSessionForCommand(ctx, authFlags)
+			defer cancel()
+			if err != nil {
+				return withWebAuthHint(err, "web apps transfer status")
+			}
+			result, err := newWebClientFn(session).GetAppTransferStatus(requestCtx, resolved)
+			if err != nil {
+				return withWebAuthHint(err, "web apps transfer status")
+			}
+			state := result.State
+			if strings.TrimSpace(state) == "" {
+				state = "unknown"
+			}
+			headers := []string{"App ID", "Request", "Transfer ID", "State"}
+			rows := [][]string{{result.AppID, result.Presence, shared.OrNA(result.RequestID), state}}
+			return shared.PrintOutputWithRenderers(
+				result, *output.Output, *output.Pretty,
+				func() error { asc.RenderTable(headers, rows); return nil },
+				func() error { asc.RenderMarkdown(headers, rows); return nil },
+			)
+		},
+	}
+}

--- a/internal/cli/web/web_apps_transfer_test.go
+++ b/internal/cli/web/web_apps_transfer_test.go
@@ -1,0 +1,58 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
+)
+
+func TestWebAppsTransferStatusOutputs(t *testing.T) {
+	t.Setenv("ASC_WEB_MIN_REQUEST_INTERVAL", "0")
+	t.Setenv("ASC_APP_ID", "app-1")
+	originalClient := newWebClientFn
+	t.Cleanup(func() { newWebClientFn = originalClient })
+	restore := SetResolveWebSession(func(context.Context, string, string, string) (*webcore.AuthSession, string, error) {
+		return &webcore.AuthSession{}, "cache", nil
+	})
+	t.Cleanup(restore)
+	body := `{"data":{"type":"apps","id":"app-1","relationships":{"appTransferRequest":{"data":null}}},"included":[],"meta":{"future":"preserved"}}`
+	newWebClientFn = func(*webcore.AuthSession) *webcore.Client {
+		return newCLIAPIKeyHTTPTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != "GET" || r.URL.Path != "/iris/v1/apps/app-1" || r.URL.Query().Get("include") != "appTransferRequest" {
+				t.Errorf("request %s %s", r.Method, r.URL)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(body))
+		}))
+	}
+	for _, format := range []string{"json", "table", "markdown"} {
+		t.Run(format, func(t *testing.T) {
+			cmd := WebAppsTransferStatusCommand()
+			if err := cmd.FlagSet.Parse([]string{"--output", format}); err != nil {
+				t.Fatal(err)
+			}
+			var runErr error
+			stdout, stderr := captureOutput(t, func() { runErr = cmd.Exec(context.Background(), nil) })
+			if runErr != nil || stderr != "" {
+				t.Fatalf("err=%v stderr=%s", runErr, stderr)
+			}
+			if format == "json" {
+				var got, want any
+				if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+					t.Fatal(err)
+				}
+				_ = json.Unmarshal([]byte(body), &want)
+				if !reflect.DeepEqual(got, want) {
+					t.Fatalf("changed JSON: %s", stdout)
+				}
+			} else if !strings.Contains(stdout, "app-1") || !strings.Contains(stdout, "none") || !strings.Contains(stdout, "unknown") {
+				t.Fatalf("summary: %s", stdout)
+			}
+		})
+	}
+}

--- a/internal/web/app_transfer.go
+++ b/internal/web/app_transfer.go
@@ -1,0 +1,80 @@
+package web
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// AppTransferStatus preserves the app response, with a summary for human output.
+// Presence is unknown when Apple omits linkage, none for explicit null, and
+// present when Apple returns a transfer reference. It does not imply eligibility.
+type AppTransferStatus struct {
+	Raw       json.RawMessage
+	AppID     string
+	Presence  string
+	RequestID string
+	State     string
+}
+
+// MarshalJSON returns Apple's envelope without flattening or dropping fields.
+func (s AppTransferStatus) MarshalJSON() ([]byte, error) { return s.Raw, nil }
+
+// GetAppTransferStatus reads the app-attached transfer request through the
+// private web API. It never follows the legacy transfer page or action links.
+func (c *Client) GetAppTransferStatus(ctx context.Context, appID string) (*AppTransferStatus, error) {
+	appID = strings.TrimSpace(appID)
+	if appID == "" {
+		return nil, fmt.Errorf("app id is required")
+	}
+	body, err := c.doRequest(ctx, http.MethodGet, "/apps/"+url.PathEscape(appID)+"?include=appTransferRequest", nil)
+	if err != nil {
+		return nil, err
+	}
+	var payload struct {
+		Data     jsonAPIResource   `json:"data"`
+		Included []jsonAPIResource `json:"included"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, fmt.Errorf("parse app transfer status: %w", err)
+	}
+	if payload.Data.Type != "apps" || payload.Data.ID != appID {
+		return nil, fmt.Errorf("app transfer status response does not identify requested app %q", appID)
+	}
+	result := &AppTransferStatus{Raw: body, AppID: appID, Presence: "unknown"}
+	relation, ok := payload.Data.Relationships["appTransferRequest"]
+	if !ok || len(relation.Data) == 0 {
+		return result, nil
+	}
+	if bytes.Equal(bytes.TrimSpace(relation.Data), []byte("null")) {
+		result.Presence = "none"
+		return result, nil
+	}
+	var ref resourceRef
+	if err := json.Unmarshal(relation.Data, &ref); err != nil {
+		return nil, fmt.Errorf("parse app transfer relationship: %w", err)
+	}
+	if strings.TrimSpace(ref.ID) == "" || strings.TrimSpace(ref.Type) == "" {
+		return nil, fmt.Errorf("app transfer relationship is missing resource identity")
+	}
+	result.Presence = "present"
+	result.RequestID = ref.ID
+	found := false
+	for _, resource := range payload.Included {
+		if resource.ID != ref.ID || resource.Type != ref.Type {
+			continue
+		}
+		if found {
+			return nil, fmt.Errorf("app transfer response contains duplicate referenced resources")
+		}
+		found = true
+		if state, ok := resource.Attributes["state"].(string); ok {
+			result.State = state
+		}
+	}
+	return result, nil
+}

--- a/internal/web/app_transfer_test.go
+++ b/internal/web/app_transfer_test.go
@@ -1,0 +1,89 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestGetAppTransferStatus(t *testing.T) {
+	for _, tc := range []struct{ name, relationship, included, presence, id, state string }{
+		{"no request", `"appTransferRequest":{"data":null}`, `[]`, "none", "", ""},
+		{"omitted", ``, `[]`, "unknown", "", ""},
+		{"link only", `"appTransferRequest":{"links":{"related":"/example"}}`, `[]`, "unknown", "", ""},
+		{"future state", `"appTransferRequest":{"data":{"type":"appTransferRequests","id":"transfer-1"}}`, `[{"type":"unrelated","id":"transfer-1","attributes":{"state":"WRONG"}},{"type":"appTransferRequests","id":"transfer-1","attributes":{"state":"FUTURE_APPLE_STATE","newField":123}}]`, "present", "transfer-1", "FUTURE_APPLE_STATE"},
+		{"missing included", `"appTransferRequest":{"data":{"type":"appTransferRequests","id":"transfer-1"}}`, `[]`, "present", "transfer-1", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body := `{"data":{"type":"apps","id":"app-1","relationships":{` + tc.relationship + `}},"included":` + tc.included + `,"meta":{"future":"preserved"}}`
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "GET" || r.URL.Path != "/apps/app-1" || r.URL.Query().Get("include") != "appTransferRequest" || len(r.URL.Query()) != 1 || r.ContentLength > 0 {
+					t.Errorf("unexpected request %s %s", r.Method, r.URL)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(body))
+			}))
+			defer server.Close()
+			got, err := testWebClient(server).GetAppTransferStatus(context.Background(), "app-1")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.AppID != "app-1" || got.Presence != tc.presence || got.RequestID != tc.id || got.State != tc.state {
+				t.Fatalf("unexpected summary %+v", got)
+			}
+			encoded, err := json.Marshal(got)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var wantJSON, gotJSON any
+			_ = json.Unmarshal([]byte(body), &wantJSON)
+			_ = json.Unmarshal(encoded, &gotJSON)
+			if !reflect.DeepEqual(wantJSON, gotJSON) {
+				t.Fatalf("envelope changed: %s", encoded)
+			}
+		})
+	}
+}
+
+func TestGetAppTransferStatusRejectsInvalidResponse(t *testing.T) {
+	for _, body := range []string{
+		`{"data":{"type":"apps","id":"other"}}`,
+		`{"data":{"type":"other","id":"app-1"}}`,
+		`{"data":null}`,
+		`{"data":{"type":"apps","id":"app-1","relationships":{"appTransferRequest":{"data":[]}}}}`,
+		`{"data":{"type":"apps","id":"app-1","relationships":{"appTransferRequest":{"data":{}}}}}`,
+		`not-json`,
+	} {
+		t.Run(body, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte(body)) }))
+			defer server.Close()
+			if _, err := testWebClient(server).GetAppTransferStatus(context.Background(), "app-1"); err == nil {
+				t.Fatal("expected invalid response error")
+			}
+		})
+	}
+}
+
+func TestGetAppTransferStatusRequiresAppAndPropagatesError(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"errors":[{"status":"403","code":"FORBIDDEN","title":"Forbidden"}]}`))
+	}))
+	defer server.Close()
+	client := testWebClient(server)
+	if _, err := client.GetAppTransferStatus(context.Background(), " "); err == nil || !strings.Contains(err.Error(), "app id is required") {
+		t.Fatalf("err=%v", err)
+	}
+	if requests != 0 {
+		t.Fatal("empty app made a request")
+	}
+	if _, err := client.GetAppTransferStatus(context.Background(), "app-1"); err == nil {
+		t.Fatal("expected HTTP error")
+	}
+}


### PR DESCRIPTION
App transfer status was missing from the CLI even though App Store Connect exposes an app-attached transfer request. This adds an experimental, read-only command using the authenticated app endpoint verified on the disposable test app.

## Commands and behavior

```bash
asc web apps transfer status --app APP_ID
asc web apps transfer status --app APP_ID --output json
asc web apps transfer status --app APP_ID --output table
asc web apps transfer status --app APP_ID --output markdown
```

`ASC_APP_ID` may supply the app. Existing web-session and provider-selection flags apply. The command makes one `GET /iris/v1/apps/{appId}?include=appTransferRequest`, validates the selected app's resource identity, and preserves Apple's entire response envelope in JSON, including unknown fields, relationship links, and included resources.

Human output shows App ID, Request, Transfer ID, and State. Request is `none` only for explicit null linkage, `present` for a resource reference, or `unknown` when Apple omits linkage. The included resource must match both relationship type and ID. Missing state stays unknown; new Apple state strings pass through unchanged. No transfer eligibility, expiry, recipient direction, or completion is inferred.

This adds no interactive prompts or writes. Missing app, unexpected arguments, and unsupported options fail before authentication. The new command is additive and experimental; existing app commands are unchanged.

## Endpoint evidence and scope

A read-only authenticated browser request on 2026-09-06 returned HTTP 200 for disposable app `6759231657`, matching `type: apps` and app ID, with `relationships.appTransferRequest.data: null` and `included: []`. This verifies Apple's acceptance of the narrowed include query. Apple's related `/iris/v1/apps/{id}/appTransferRequest` URL returned HTTP 409 `ENTITY_ERROR.RELATIONSHIP.INVALID` for that fixture, so the command uses the app read instead.

The captured frontend defines transfer `id` and `state`; no nonempty transfer was available for a live capture. Nonempty, unknown-state, omitted-linkage, and malformed-response behavior is covered by local HTTP fixtures, not claimed as live transfer evidence. The live check used the authenticated browser, not a new transfer or recipient account.

The manual legacy prerequisite page is documented, but not opened or scraped by the CLI. Initiate, accept, cancel, decline, and recipient-side listing are intentionally deferred. The maintainer will perform those workflows and provide the missing action requests, response shapes, and post-state captures. This PR does not claim the full lifecycle is complete.

## Verification

- RED: root command test failed because transfer status was not registered.
- GREEN: focused web-client, CLI output, root command, and capabilities tests passed. The first full run caught a missing experimental-command allowlist entry; both the explicit label expectations and that allowlist now include the new commands, and the focused failing test passed.
- HTTP fixtures cover exact GET/query, null and omitted linkage, matched resource identity, unknown state, raw-envelope preservation, malformed responses, and provider errors.
- CLI coverage checks JSON/table/Markdown output and `ASC_APP_ID`; built-binary checks verify help and exit 2 for missing app, unsupported action, and invalid output.
- `make generate-command-docs` ran; the generated top-level command index was unchanged.

- `ASC_BYPASS_KEYCHAIN=1 GOMAXPROCS=4 GOFLAGS=-p=4 make build`, `make format`, `make check-docs`, `make lint`, and `make test` all passed on the final source tree. Normal commit hooks also passed, including their short test suite.
- Safe local Codex `/review` ran before commit. Its output-validation finding was verified as non-actionable: root command construction recursively wraps this leaf with `shared.WrapCommandOutputValidation`; the built binary rejects `--output yaml` before authentication with exit 2 and empty stdout.
- Final committed full-branch `/review --base origin/main` completed without actionable findings on `f8e7899c58fd5fc299aaa27fcdf7abee5774e7fe` against freshly fetched main `3a2318a756f78ef6d2d9101f68124ce26cbb056c`. The review sandbox could not execute Go tests; the parent workspace's focused tests, full suite, and normal hook tests independently passed. Review used ChatGPT authentication with API-key overrides absent and app/plugin connectors disabled.
- GitHub-required `format-and-lint`, `unit-tests`, and `build` checks passed on the reviewed head. GitHub reports the PR mergeable with no review threads or required-review blocker. A nonempty live transfer and final CLI execution against Apple remain unverified; no transfer or account mutation was performed.

Related to #2287. Per maintainer instruction, the umbrella issue may be closed for now with the write operations explicitly deferred; this read-only PR remains separately reviewable.
