### PR TITLE
feat(web): manage in-app purchase tax categories

### DIFF
--- a/commands/web.mdx
+++ b/commands/web.mdx
@@ -38,6 +38,13 @@ asc web website-push-ids list --output table
 # [experimental] Generate and download a Transaction Tax Report through the web session
 asc web finance transaction-tax download --date 2026-07 --output-path ./transaction-tax-2026-07.zip --output json
 
+# [experimental] Inspect an In-App Purchase tax category
+asc web iap tax-category list --output json
+asc web iap tax-category view --iap "IAP_ID" --output json
+asc web iap tax-category set --iap "IAP_ID" --category "CATEGORY_ID" --confirm
+# Reset an explicit selection so the purchase inherits the parent app
+asc web iap tax-category reset --iap "IAP_ID" --confirm
+
 # Bootstrap app availability where the public API falls short
 asc web apps availability create --app "123456789" --territory "USA,GBR" --available-in-new-territories false
 
@@ -240,6 +247,67 @@ asc web finance transaction-tax download \
   --output-path ./transaction-tax-2026-07.zip \
   --output json
 ```
+
+### `asc web iap`
+
+[experimental] Read and manage an In-App Purchase tax category through an
+authenticated App Store Connect web session. The public App Store Connect API
+does not expose this resource.
+
+Available commands:
+
+* `asc web iap tax-category list` - list the ADDON tax categories and compatible conditions
+* `asc web iap tax-category view` - view one In-App Purchase's explicit tax selection
+* `asc web iap tax-category set` - set a category and complete condition set
+* `asc web iap tax-category reset` - remove the explicit selection and restore parent-app inheritance
+
+`list` reads the In-App Purchase tax picker catalog with
+`filter[productType]=ADDON`. This catalog is separate from the
+`APPLICATION` catalog used by `asc web apps tax-category`; use the opaque IDs
+returned by this command with `set`.
+
+`view --iap IAP_ID` first reads the In-App Purchase and its
+`inAppPurchaseTaxCategoryInfo` relationship. An explicit `null` relationship
+means that the purchase inherits its parent app's selection. Human output
+labels that state `Inherited from parent app`; JSON output preserves Apple's
+raw In-App Purchase discovery envelope and does not guess or add the effective
+category. When the relationship is configured, the command follows the opaque
+tax-info resource ID and returns Apple's raw tax-info detail envelope instead.
+
+`set --iap IAP_ID --category CATEGORY_ID [--condition CONDITION_ID ...]
+--confirm` validates the category and every condition against the ADDON
+catalog. The conditions are a complete desired set: omitting `--condition`
+sends an explicit empty relationship and clears existing conditions. The
+command performs at most one write followed by one readback verification and
+does not retry an ambiguous outcome. It creates a tax-info resource when the
+purchase is inherited and patches the discovered tax-info resource when one
+already exists.
+
+`reset --iap IAP_ID --confirm` reads the current state, deletes only the
+discovered explicit tax-info override when present, and verifies the explicit
+`null` relationship. An already inherited purchase is reported as an
+unchanged verified result without a delete. The In-App Purchase itself is
+retained.
+
+Example:
+
+```bash  theme={null}
+asc web iap tax-category list --output table
+asc web iap tax-category view --iap "IAP_ID" --output json
+asc web iap tax-category set \
+  --iap "IAP_ID" \
+  --category "CATEGORY_ID" \
+  --condition "CONDITION_ID" \
+  --confirm \
+  --output json
+asc web iap tax-category reset --iap "IAP_ID" --confirm --output json
+```
+
+The endpoint is an experimental private web-session contract. A browser
+canary verified catalog discovery, create, update, condition clearing, and
+delete/readback against disposable app `6759231657` and IAP `6760268101` on
+2026-09-06; the disposable IAP was restored and no temporary resources were
+left behind. This canary does not verify final CLI live execution.
 
 ### `asc web api-keys`
 
@@ -840,6 +908,8 @@ asc web agreements --help
 asc web api-keys --help
 asc web finance --help
 asc web finance transaction-tax download --help
+asc web iap --help
+asc web iap tax-category --help
 asc web apps --help
 asc web removed-apps --help
 asc web bundle-ids --help

--- a/docs/API_NOTES.md
+++ b/docs/API_NOTES.md
@@ -72,17 +72,55 @@ the App Store Connect web-client source captured for issue #2299:
   verified explicit application tax configuration and readback. PATCH,
   condition changes, and account-specific errors remain unverified; selecting
   the legally correct classification remains the operator's responsibility.
-- In-App Purchase tax-category read/write is still unavailable because its
-  web-session contract has not been captured. `GET /v1/financeReports` accepts
-  only `FINANCIAL` and `FINANCE_DETAIL` in `filter[reportType]`, and
-  `GET /v1/salesReports` has no tax report type, so Transaction Tax reports
-  cannot be generated or downloaded through the public API. The captured
-  finance workflow is available through the experimental
+- In-App Purchase tax categories are available through the experimental
+  web-session commands `asc web iap tax-category list`,
+  `asc web iap tax-category view --iap IAP_ID`,
+  `asc web iap tax-category set --iap IAP_ID --category CATEGORY_ID
+  [--condition CONDITION_ID ...] --confirm`, and
+  `asc web iap tax-category reset --iap IAP_ID --confirm`. The IAP catalog is
+  distinct from the application catalog: it uses
+  `GET /iris/v1/taxCategories?filter[productType]=ADDON&include=subcategories,conditions&limit[subcategories]=100&limit[conditions]=100`,
+  while App Information uses `filter[productType]=APPLICATION`. `list` keeps
+  the raw JSON:API catalog envelope, including `data`, `included`, `links`,
+  `meta`, and unknown top-level members, for JSON output.
+- `view` first reads
+  `GET /iris/v2/inAppPurchases/{iapId}?include=inAppPurchaseTaxCategoryInfo`.
+  An explicit `inAppPurchaseTaxCategoryInfo.data: null` means that the IAP
+  inherits the parent app's selection; the CLI does not guess the inherited
+  category. Inherited JSON output preserves this raw `inAppPurchases` discovery
+  envelope. For a configured relationship, the CLI follows the returned
+  opaque tax-info ID and reads
+  `GET /iris/v1/inAppPurchaseTaxCategoryInfos/{taxInfoId}?include=category,enabledConditions,inAppPurchaseV2&limit[enabledConditions]=100`;
+  configured JSON output preserves that raw `inAppPurchaseTaxCategoryInfos`
+  detail envelope. The selected IAP is checked against the tax-info owner
+  before the result is accepted.
+- `set` validates the category and every condition against the ADDON catalog,
+  then sends the complete desired category and condition set. Omitting
+  `--condition` sends `enabledConditions.data=[]` and clears stale conditions.
+  It creates the tax-info resource when the IAP is inherited or patches the
+  discovered opaque tax-info ID when configured, performs at most one write and
+  one post-read verification, and does not automatically retry an ambiguous
+  outcome. If the requested state already matches, it reports a verified
+  no-op.
+- `reset` deletes only the discovered
+  `inAppPurchaseTaxCategoryInfos` override and verifies a fresh explicit-null
+  relationship; it never deletes the IAP. When the IAP is already inherited,
+  it skips DELETE and reports a verified no-op. These private endpoints and
+  their request shapes are absent from the public OpenAPI snapshot.
+- A browser canary on 2026-09-06 against disposable app `6759231657` and IAP
+  `6760268101` verified ADDON catalog discovery, create, update, explicit
+  condition clearing, and delete/readback; the disposable IAP was restored and
+  no resources were left behind. This is browser evidence only: final CLI live
+  execution remains unverified.
+- `GET /v1/financeReports` accepts only `FINANCIAL` and `FINANCE_DETAIL` in
+  `filter[reportType]`, and `GET /v1/salesReports` has no tax report type, so
+  Transaction Tax reports cannot be generated or downloaded through the public
+  API. The captured finance workflow is available through the experimental
   `asc web finance transaction-tax download` command; provider and period
   eligibility remain account-specific.
-- `asc capabilities --area monetization` reports the application tax path as
-  partial coverage and keeps In-App Purchase tax selection in the remaining
-  web-only gap.
+- `asc capabilities --area monetization` reports App Information and
+  In-App Purchase tax-category paths as web-session coverage; Transaction Tax
+  reports remain a separate web-session capability.
 
 ## Sandbox Testers
 

--- a/internal/asc/output_registry_init.go
+++ b/internal/asc/output_registry_init.go
@@ -40,6 +40,8 @@ func registerAllOutputRenderers() {
 	registerRows(webAppDistributionSetRows)
 	registerRows(webAppTaxCategoryViewResultRows)
 	registerRows(webAppTaxCategorySetResultRows)
+	registerRows(webIAPTaxCategorySetResultRows)
+	registerRows(webIAPTaxCategoryResetResultRows)
 	registerRows(webReviewReplyResultRows)
 	registerRows(webReviewDraftResultRows)
 	registerRows(webWebsitePushIDMutationRows)

--- a/internal/asc/output_web_iap_tax_category.go
+++ b/internal/asc/output_web_iap_tax_category.go
@@ -1,0 +1,47 @@
+package asc
+
+import "fmt"
+
+// WebIAPTaxCategorySetResult is the receipt for a verified In-App Purchase
+// tax-category selection made through an authenticated web session.
+type WebIAPTaxCategorySetResult struct {
+	IAPID        string   `json:"iapId"`
+	CategoryID   string   `json:"categoryId"`
+	CategoryName string   `json:"categoryName,omitempty"`
+	ConditionIDs []string `json:"conditionIds"`
+	Changed      bool     `json:"changed"`
+	Verified     bool     `json:"verified"`
+}
+
+func webIAPTaxCategorySetResultRows(result *WebIAPTaxCategorySetResult) ([]string, [][]string) {
+	if result == nil {
+		return []string{"Field", "Value"}, nil
+	}
+	return []string{"Field", "Value"}, [][]string{
+		{"IAP ID", result.IAPID},
+		{"Category ID", result.CategoryID},
+		{"Category Name", result.CategoryName},
+		{"Condition IDs", joinOutputStrings(result.ConditionIDs)},
+		{"Changed", fmt.Sprintf("%t", result.Changed)},
+		{"Verified", fmt.Sprintf("%t", result.Verified)},
+	}
+}
+
+// WebIAPTaxCategoryResetResult is the receipt for a verified reset to the
+// inherited In-App Purchase tax-category state.
+type WebIAPTaxCategoryResetResult struct {
+	IAPID    string `json:"iapId"`
+	Changed  bool   `json:"changed"`
+	Verified bool   `json:"verified"`
+}
+
+func webIAPTaxCategoryResetResultRows(result *WebIAPTaxCategoryResetResult) ([]string, [][]string) {
+	if result == nil {
+		return []string{"Field", "Value"}, nil
+	}
+	return []string{"Field", "Value"}, [][]string{
+		{"IAP ID", result.IAPID},
+		{"Changed", fmt.Sprintf("%t", result.Changed)},
+		{"Verified", fmt.Sprintf("%t", result.Verified)},
+	}
+}

--- a/internal/asc/output_web_iap_tax_category_test.go
+++ b/internal/asc/output_web_iap_tax_category_test.go
@@ -1,0 +1,144 @@
+package asc
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestWebIAPTaxCategoryMutationResultsUseCamelCaseJSON(t *testing.T) {
+	tests := []struct {
+		name  string
+		value any
+		wants map[string]string
+	}{
+		{
+			name: "set",
+			value: &WebIAPTaxCategorySetResult{
+				IAPID:        "iap-1",
+				CategoryID:   "category-1",
+				CategoryName: "Digital Goods",
+				ConditionIDs: []string{"condition-1", "condition-2"},
+				Changed:      true,
+				Verified:     true,
+			},
+			wants: map[string]string{
+				"iapId":        `"iap-1"`,
+				"categoryId":   `"category-1"`,
+				"categoryName": `"Digital Goods"`,
+				"conditionIds": `["condition-1","condition-2"]`,
+				"changed":      "true",
+				"verified":     "true",
+			},
+		},
+		{
+			name: "reset",
+			value: &WebIAPTaxCategoryResetResult{
+				IAPID:    "iap-1",
+				Changed:  false,
+				Verified: true,
+			},
+			wants: map[string]string{
+				"iapId":    `"iap-1"`,
+				"changed":  "false",
+				"verified": "true",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded, err := json.Marshal(tc.value)
+			if err != nil {
+				t.Fatalf("json.Marshal() error: %v", err)
+			}
+
+			var fields map[string]json.RawMessage
+			if err := json.Unmarshal(encoded, &fields); err != nil {
+				t.Fatalf("json.Unmarshal() error: %v", err)
+			}
+			for field, want := range tc.wants {
+				got, ok := fields[field]
+				if !ok {
+					t.Fatalf("JSON missing camelCase field %q: %s", field, encoded)
+				}
+				if string(got) != want {
+					t.Fatalf("JSON field %q = %s, want %s", field, got, want)
+				}
+			}
+			for _, field := range []string{"iap_id", "category_id", "category_name", "condition_ids"} {
+				if _, ok := fields[field]; ok {
+					t.Fatalf("JSON contains snake_case field %q: %s", field, encoded)
+				}
+			}
+		})
+	}
+}
+
+func TestWebIAPTaxCategoryMutationResultsUseRegisteredRenderers(t *testing.T) {
+	results := []struct {
+		name string
+		data any
+		want []string
+	}{
+		{
+			name: "set",
+			data: &WebIAPTaxCategorySetResult{
+				IAPID:        "iap-1",
+				CategoryID:   "category-1",
+				CategoryName: "Digital Goods",
+				ConditionIDs: []string{"condition-1", "condition-2"},
+				Changed:      true,
+				Verified:     true,
+			},
+			want: []string{
+				"IAP ID", "Category ID", "Category Name", "Condition IDs", "Changed", "Verified",
+				"iap-1", "category-1", "Digital Goods", "condition-1,condition-2", "true",
+			},
+		},
+		{
+			name: "reset",
+			data: &WebIAPTaxCategoryResetResult{
+				IAPID:    "iap-1",
+				Changed:  false,
+				Verified: true,
+			},
+			want: []string{"IAP ID", "Changed", "Verified", "iap-1", "false", "true"},
+		},
+	}
+
+	ensureOutputRegistryPopulated()
+	if !isRegistryTypeRegistered(typeForPtr[WebIAPTaxCategorySetResult]()) {
+		t.Fatal("WebIAPTaxCategorySetResult is not registered with the output renderer")
+	}
+	if !isRegistryTypeRegistered(typeForPtr[WebIAPTaxCategoryResetResult]()) {
+		t.Fatal("WebIAPTaxCategoryResetResult is not registered with the output renderer")
+	}
+
+	renderers := []struct {
+		name string
+		fn   func(any) error
+	}{
+		{name: "table", fn: PrintTable},
+		{name: "markdown", fn: PrintMarkdown},
+	}
+	for _, result := range results {
+		result := result
+		t.Run(result.name, func(t *testing.T) {
+			for _, renderer := range renderers {
+				renderer := renderer
+				t.Run(renderer.name, func(t *testing.T) {
+					output := captureStdout(t, func() error { return renderer.fn(result.data) })
+					if strings.TrimSpace(output) == "" {
+						t.Fatal("expected rendered output")
+					}
+					for _, want := range result.want {
+						if !strings.Contains(output, want) {
+							t.Fatalf("output missing %q: %q", want, output)
+						}
+					}
+				})
+			}
+		})
+	}
+}

--- a/internal/cli/capabilities/capabilities.go
+++ b/internal/cli/capabilities/capabilities.go
@@ -450,17 +450,21 @@ func capabilityRows() []Capability {
 		{
 			Area:       "monetization",
 			Capability: "App and In-App Purchase tax category",
-			Status:     statusPartial,
+			Status:     statusWebSession,
 			Commands: []string{
 				"asc web apps tax-category list",
 				"asc web apps tax-category view",
 				"asc web apps tax-category set",
+				"asc web iap tax-category list",
+				"asc web iap tax-category view",
+				"asc web iap tax-category set",
+				"asc web iap tax-category reset",
 			},
 			Notes: []string{
-				"App Information tax category is available through web-session commands; the public OpenAPI snapshot has no tax-category resource.",
-				"In-App Purchase tax category remains unimplemented because its web-session read/write contract is not captured. The application setter validates the captured catalog, requires --confirm, clears conditions when --condition is omitted, and does not automatically retry an ambiguous write; a disposable-app canary verified explicit application tax configuration and readback, while PATCH, condition changes, and account-specific errors remain unverified.",
+				"Tax categories use private web-session endpoints; the public OpenAPI snapshot has no tax-category resource. App Information uses the APPLICATION catalog, while In-App Purchases use ADDON.",
+				"IAP reads preserve Apple's response. Explicit null means inheritance from the parent app without identifying its effective category. set requires --confirm, validates the catalog, replaces the complete condition set (omitting --condition clears it), and verifies the result. reset removes only the discovered IAP tax override and verifies explicit null. Neither mutation retries automatically after an uncertain outcome.",
 			},
-			NextAction: "Use asc web apps tax-category list/view/set for App Information; use App Store Connect web UI for In-App Purchase tax category.",
+			NextAction: "Use asc web apps tax-category list/view/set for App Information, or asc web iap tax-category list/view/set/reset for In-App Purchases.",
 		},
 		{
 			Area:       "testflight",

--- a/internal/cli/capabilities/tax_category_unexposed_test.go
+++ b/internal/cli/capabilities/tax_category_unexposed_test.go
@@ -8,15 +8,14 @@ import (
 
 const taxCategoryCapabilityName = "App and In-App Purchase tax category"
 
-// App Information tax category is covered by the experimental web-session
-// command, while In-App Purchase tax category remains outside the CLI.
-func TestTaxCategoryIsReportedAsPartial(t *testing.T) {
+// Both tax-category scopes are available through their web-session commands.
+func TestTaxCategoryIsReportedAsWebSession(t *testing.T) {
 	for _, capability := range capabilityRows() {
 		if capability.Capability != taxCategoryCapabilityName {
 			continue
 		}
-		if capability.Status != statusPartial {
-			t.Fatalf("expected %q status %q, got %q", taxCategoryCapabilityName, statusPartial, capability.Status)
+		if capability.Status != statusWebSession {
+			t.Fatalf("expected %q status %q, got %q", taxCategoryCapabilityName, statusWebSession, capability.Status)
 		}
 		if capability.Area != "monetization" {
 			t.Fatalf("expected %q area %q, got %q", taxCategoryCapabilityName, "monetization", capability.Area)
@@ -25,6 +24,10 @@ func TestTaxCategoryIsReportedAsPartial(t *testing.T) {
 			"asc web apps tax-category list",
 			"asc web apps tax-category view",
 			"asc web apps tax-category set",
+			"asc web iap tax-category list",
+			"asc web iap tax-category view",
+			"asc web iap tax-category set",
+			"asc web iap tax-category reset",
 		}
 		if !slices.Equal(capability.Commands, wantCommands) {
 			t.Fatalf("expected %q commands %v, got %v", taxCategoryCapabilityName, wantCommands, capability.Commands)
@@ -41,14 +44,14 @@ func TestTaxCategoryIsReportedAsPartial(t *testing.T) {
 	t.Fatalf("capability %q not found", taxCategoryCapabilityName)
 }
 
-func TestTaxCategoryCapabilityNotesRemainingIAPGap(t *testing.T) {
+func TestTaxCategoryCapabilityDistinguishesCatalogs(t *testing.T) {
 	for _, capability := range capabilityRows() {
 		if capability.Capability != taxCategoryCapabilityName {
 			continue
 		}
 		joined := strings.ToLower(strings.Join(capability.Notes, " "))
-		if !strings.Contains(joined, "in-app purchase") || !strings.Contains(joined, "unimplemented") {
-			t.Fatalf("expected %q notes to preserve the In-App Purchase gap, got %v", taxCategoryCapabilityName, capability.Notes)
+		if !strings.Contains(joined, "addon") || !strings.Contains(joined, "application") {
+			t.Fatalf("expected %q notes to distinguish the ADDON and APPLICATION catalogs, got %v", taxCategoryCapabilityName, capability.Notes)
 		}
 		return
 	}

--- a/internal/cli/cmdtest/capabilities_tax_category_test.go
+++ b/internal/cli/cmdtest/capabilities_tax_category_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
 )
 
-func TestRun_CapabilitiesReportsTaxCategoryGap(t *testing.T) {
+func TestRun_CapabilitiesReportsTaxCategorySupport(t *testing.T) {
 	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
 
 	stdout, stderr := captureOutput(t, func() {
@@ -27,7 +27,7 @@ func TestRun_CapabilitiesReportsTaxCategoryGap(t *testing.T) {
 		t.Fatalf("expected JSON output, got error %v and stdout %s", err, stdout)
 	}
 
-	assertCapability(t, resp, "App and In-App Purchase tax category", "partial", "asc web apps tax-category list")
+	assertCapability(t, resp, "App and In-App Purchase tax category", "web-session", "asc web apps tax-category list")
 
 	for _, entry := range resp.Capabilities {
 		if entry.Capability != "App and In-App Purchase tax category" {
@@ -37,6 +37,10 @@ func TestRun_CapabilitiesReportsTaxCategoryGap(t *testing.T) {
 			"asc web apps tax-category list",
 			"asc web apps tax-category view",
 			"asc web apps tax-category set",
+			"asc web iap tax-category list",
+			"asc web iap tax-category view",
+			"asc web iap tax-category set",
+			"asc web iap tax-category reset",
 		}
 		if strings.Join(entry.Commands, "\n") != strings.Join(wantCommands, "\n") {
 			t.Fatalf("expected tax category commands %v, got %v", wantCommands, entry.Commands)

--- a/internal/cli/cmdtest/iap_tax_category_test.go
+++ b/internal/cli/cmdtest/iap_tax_category_test.go
@@ -1,0 +1,108 @@
+package cmdtest
+
+import (
+	"path/filepath"
+	"testing"
+
+	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+)
+
+func TestWebIAPTaxCategoryCommandsAreRegistered(t *testing.T) {
+	root := RootCommand("1.2.3")
+	for _, path := range [][]string{
+		{"web", "iap"},
+		{"web", "iap", "tax-category"},
+		{"web", "iap", "tax-category", "list"},
+		{"web", "iap", "tax-category", "view"},
+		{"web", "iap", "tax-category", "set"},
+		{"web", "iap", "tax-category", "reset"},
+	} {
+		if findSubcommand(root, path...) == nil {
+			t.Fatalf("command %v is not registered", path)
+		}
+	}
+}
+
+// TestWebIAPTaxCategoryInputValidationReturnsUsageExitCode locks the
+// pre-session validation contract for each IAP tax-category leaf. Required
+// inputs and positional arguments must produce one concise stderr diagnostic
+// and usage exit code 2 before any web-session lookup can occur.
+func TestWebIAPTaxCategoryInputValidationReturnsUsageExitCode(t *testing.T) {
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.json"))
+	t.Setenv("ASC_APP_ID", "")
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "list rejects positional arguments",
+			args:    []string{"web", "iap", "tax-category", "list", "extra"},
+			wantErr: "unexpected argument(s): extra",
+		},
+		{
+			name:    "view requires iap",
+			args:    []string{"web", "iap", "tax-category", "view"},
+			wantErr: "--iap is required",
+		},
+		{
+			name:    "view rejects positional arguments",
+			args:    []string{"web", "iap", "tax-category", "view", "extra"},
+			wantErr: "unexpected argument(s): extra",
+		},
+		{
+			name:    "set requires iap",
+			args:    []string{"web", "iap", "tax-category", "set"},
+			wantErr: "--iap is required",
+		},
+		{
+			name:    "set requires category",
+			args:    []string{"web", "iap", "tax-category", "set", "--iap", "IAP_ID"},
+			wantErr: "--category is required",
+		},
+		{
+			name:    "set requires confirmation",
+			args:    []string{"web", "iap", "tax-category", "set", "--iap", "IAP_ID", "--category", "CATEGORY_ID"},
+			wantErr: "--confirm is required",
+		},
+		{
+			name:    "set rejects positional arguments",
+			args:    []string{"web", "iap", "tax-category", "set", "extra"},
+			wantErr: "unexpected argument(s): extra",
+		},
+		{
+			name:    "reset requires iap",
+			args:    []string{"web", "iap", "tax-category", "reset"},
+			wantErr: "--iap is required",
+		},
+		{
+			name:    "reset requires confirmation",
+			args:    []string{"web", "iap", "tax-category", "reset", "--iap", "IAP_ID"},
+			wantErr: "--confirm is required",
+		},
+		{
+			name:    "reset rejects positional arguments",
+			args:    []string{"web", "iap", "tax-category", "reset", "extra"},
+			wantErr: "unexpected argument(s): extra",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stdout, stderr, runErr := runCommand(t, test.args)
+
+			if runErr == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if got := rootcmd.ExitCodeFromError(runErr); got != rootcmd.ExitUsage {
+				t.Fatalf("exit code = %d, want %d (err=%v)", got, rootcmd.ExitUsage, runErr)
+			}
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			assertUsageErrorStderr(t, stderr, test.wantErr)
+		})
+	}
+}

--- a/internal/cli/cmdtest/stability_tiers_test.go
+++ b/internal/cli/cmdtest/stability_tiers_test.go
@@ -60,6 +60,12 @@ func TestExperimentalCommandsHaveStabilityLabel(t *testing.T) {
 		{[]string{"web", "finance"}},
 		{[]string{"web", "finance", "transaction-tax"}},
 		{[]string{"web", "finance", "transaction-tax", "download"}},
+		{[]string{"web", "iap"}},
+		{[]string{"web", "iap", "tax-category"}},
+		{[]string{"web", "iap", "tax-category", "list"}},
+		{[]string{"web", "iap", "tax-category", "view"}},
+		{[]string{"web", "iap", "tax-category", "set"}},
+		{[]string{"web", "iap", "tax-category", "reset"}},
 	}
 
 	for _, tc := range cases {
@@ -117,6 +123,12 @@ func TestWebCommandsDoNotHaveExperimentalStabilityLabel(t *testing.T) {
 		"web finance":                          {},
 		"web finance transaction-tax":          {},
 		"web finance transaction-tax download": {},
+		"web iap":                              {},
+		"web iap tax-category":                 {},
+		"web iap tax-category list":            {},
+		"web iap tax-category view":            {},
+		"web iap tax-category set":             {},
+		"web iap tax-category reset":           {},
 	}
 	for _, sub := range webCmd.Subcommands {
 		if sub.Name == "agreements" {

--- a/internal/cli/web/web.go
+++ b/internal/cli/web/web.go
@@ -47,6 +47,7 @@ Examples:
 			WebAuthCommand(),
 			WebAgreementsCommand(),
 			WebFinanceCommand(),
+			WebIAPCommand(),
 			WebAPIKeysCommand(),
 			WebSandboxCommand(),
 			WebAppsCommand(),

--- a/internal/cli/web/web_iap_tax_category.go
+++ b/internal/cli/web/web_iap_tax_category.go
@@ -1,0 +1,510 @@
+package web
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
+)
+
+const iapTaxCategoryInheritedLabel = "Inherited from parent app"
+
+// WebIAPCommand returns the experimental In-App Purchase web-session command
+// group.
+func WebIAPCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("web iap", flag.ExitOnError)
+
+	return &ffcli.Command{
+		Name:       "iap",
+		ShortUsage: "asc web iap <subcommand> [flags]",
+		ShortHelp:  "[experimental] Manage In-App Purchase tax categories via a web session.",
+		LongHelp: `[experimental] WEB SESSION WORKFLOWS
+
+Read and change an In-App Purchase tax category through Apple's internal
+web-session API. The public App Store Connect API does not expose this
+resource. An In-App Purchase without an explicit selection inherits the parent
+app's tax category; the CLI reports that state without guessing the inherited
+category value.
+
+`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			WebIAPTaxCategoryCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+// WebIAPTaxCategoryCommand returns the experimental IAP tax-category command
+// group.
+func WebIAPTaxCategoryCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("web iap tax-category", flag.ExitOnError)
+
+	return &ffcli.Command{
+		Name:       "tax-category",
+		ShortUsage: "asc web iap tax-category <subcommand> [flags]",
+		ShortHelp:  "[experimental] Read or set an In-App Purchase tax category.",
+		LongHelp: `[experimental] WEB SESSION WORKFLOWS
+
+Inspect or change the tax category and compatible conditions assigned to one
+In-App Purchase. ` + "`list`" + ` reads the ADDON tax-category catalog, ` + "`view`" + `
+reads the current explicit selection, ` + "`set`" + ` converges a complete category
+and condition set, and ` + "`reset`" + ` removes the explicit selection so the
+purchase inherits its parent app's tax category.
+
+`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			WebIAPTaxCategoryListCommand(),
+			WebIAPTaxCategoryViewCommand(),
+			WebIAPTaxCategorySetCommand(),
+			WebIAPTaxCategoryResetCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+// WebIAPTaxCategoryListCommand lists the ADDON tax-category catalog.
+func WebIAPTaxCategoryListCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("web iap tax-category list", flag.ExitOnError)
+	authFlags := bindWebSessionFlags(fs)
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "list",
+		ShortUsage: "asc web iap tax-category list [flags]",
+		ShortHelp:  "[experimental] List In-App Purchase tax categories and conditions.",
+		LongHelp: `[experimental] WEB SESSION WORKFLOWS
+
+List the ADDON tax categories and conditions exposed by Apple's In-App Purchase
+tax picker. The opaque IDs returned here are accepted by ` + "`set`" + `.
+
+`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageErrorf("unexpected argument(s): %s", strings.Join(args, " "))
+			}
+			if _, err := shared.ValidateOutputFormat(*output.Output, *output.Pretty); err != nil {
+				return shared.UsageError(err.Error())
+			}
+
+			session, requestCtx, cancel, err := resolveWebSessionForCommand(ctx, authFlags)
+			defer cancel()
+			if err != nil {
+				return err
+			}
+
+			var catalog webcore.TaxCategoryCatalog
+			err = withWebSpinner("Fetching In-App Purchase tax category catalog", func() error {
+				catalog, err = newWebClientFn(session).ListIAPTaxCategories(requestCtx)
+				return err
+			})
+			if err != nil {
+				return withWebAuthHint(err, "web iap tax-category list")
+			}
+			return printWebAppTaxCategoryCatalog(catalog, *output.Output, *output.Pretty)
+		},
+	}
+}
+
+// WebIAPTaxCategoryViewCommand reads an IAP's explicit selection. A missing
+// explicit selection is rendered as an inherited state for human output; the
+// JSON path preserves the raw Apple response and does not infer a category.
+func WebIAPTaxCategoryViewCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("web iap tax-category view", flag.ExitOnError)
+	iapID := fs.String("iap", "", "In-App Purchase ID")
+	authFlags := bindWebSessionFlags(fs)
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "view",
+		ShortUsage: "asc web iap tax-category view --iap IAP_ID [flags]",
+		ShortHelp:  "[experimental] View an In-App Purchase tax category.",
+		LongHelp: `[experimental] WEB SESSION WORKFLOWS
+
+Read the explicit tax category and enabled conditions for one In-App Purchase.
+When the explicit resource is absent, human output labels the selection as
+inherited from the parent app. JSON output preserves Apple's response and does
+not add an inferred effective-category field.
+
+`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageErrorf("unexpected argument(s): %s", strings.Join(args, " "))
+			}
+			if _, err := shared.ValidateOutputFormat(*output.Output, *output.Pretty); err != nil {
+				return shared.UsageError(err.Error())
+			}
+			resolvedIAPID := strings.TrimSpace(*iapID)
+			if resolvedIAPID == "" {
+				return shared.UsageError("--iap is required")
+			}
+
+			session, requestCtx, cancel, err := resolveWebSessionForCommand(ctx, authFlags)
+			defer cancel()
+			if err != nil {
+				return err
+			}
+
+			var current *webcore.IAPTaxCategory
+			err = withWebSpinner("Fetching In-App Purchase tax category", func() error {
+				current, err = newWebClientFn(session).GetIAPTaxCategory(requestCtx, resolvedIAPID)
+				return err
+			})
+			if err != nil {
+				return withWebAuthHint(err, "web iap tax-category view")
+			}
+			if current == nil {
+				return fmt.Errorf("web iap tax-category view failed: missing current selection")
+			}
+			if !iapTaxCategoryIdentityMatches(current, resolvedIAPID) {
+				return fmt.Errorf("web iap tax-category view failed: response did not identify In-App Purchase %q", resolvedIAPID)
+			}
+
+			return shared.PrintOutputWithRenderers(
+				current,
+				*output.Output,
+				*output.Pretty,
+				func() error {
+					asc.RenderTable(webIAPTaxCategoryViewHeaders(), webIAPTaxCategoryViewRows(current))
+					return nil
+				},
+				func() error {
+					asc.RenderMarkdown(webIAPTaxCategoryViewHeaders(), webIAPTaxCategoryViewRows(current))
+					return nil
+				},
+			)
+		},
+	}
+}
+
+// WebIAPTaxCategorySetCommand converges a complete desired IAP category and
+// condition set. It performs one preflight read, writes at most once, and
+// verifies the resulting state without automatic retries.
+func WebIAPTaxCategorySetCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("web iap tax-category set", flag.ExitOnError)
+	iapID := fs.String("iap", "", "In-App Purchase ID")
+	categoryID := fs.String("category", "", "ADDON tax category resource ID from `asc web iap tax-category list`")
+	var conditionIDs shared.MultiStringFlag
+	fs.Var(&conditionIDs, "condition", "Compatible tax condition resource ID (repeatable; omit to clear conditions)")
+	confirm := fs.Bool("confirm", false, "Confirm changing the In-App Purchase tax category and conditions")
+	authFlags := bindWebSessionFlags(fs)
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "set",
+		ShortUsage: "asc web iap tax-category set --iap IAP_ID --category CATEGORY_ID [--condition CONDITION_ID ...] --confirm [flags]",
+		ShortHelp:  "[experimental] Set an In-App Purchase tax category and condition set.",
+		LongHelp: `[experimental] WEB SESSION WORKFLOWS
+
+Set the In-App Purchase tax category through Apple's internal web-session API.
+The selected category and every ` + "`--condition`" + ` value are validated against
+the ADDON catalog before any write. The desired condition set is declarative:
+omitting ` + "`--condition`" + ` sends an explicit empty relationship and clears
+stale conditions. The result is re-read and verified. An ambiguous write is
+reported without an automatic retry.
+
+`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageErrorf("unexpected argument(s): %s", strings.Join(args, " "))
+			}
+			if _, err := shared.ValidateOutputFormat(*output.Output, *output.Pretty); err != nil {
+				return shared.UsageError(err.Error())
+			}
+			resolvedIAPID := strings.TrimSpace(*iapID)
+			if resolvedIAPID == "" {
+				return shared.UsageError("--iap is required")
+			}
+			resolvedCategoryID := strings.TrimSpace(*categoryID)
+			if resolvedCategoryID == "" {
+				return shared.UsageError("--category is required")
+			}
+			if !*confirm {
+				return shared.UsageError("--confirm is required")
+			}
+			desiredConditions, err := normalizeWebTaxConditionIDs([]string(conditionIDs))
+			if err != nil {
+				return shared.UsageError(err.Error())
+			}
+
+			session, requestCtx, cancel, err := resolveWebSessionForCommand(ctx, authFlags)
+			defer cancel()
+			if err != nil {
+				return err
+			}
+			client := newWebClientFn(session)
+
+			var catalog webcore.TaxCategoryCatalog
+			var current *webcore.IAPTaxCategory
+			err = withWebSpinner("Reading In-App Purchase tax category", func() error {
+				catalog, err = client.ListIAPTaxCategories(requestCtx)
+				if err != nil {
+					return err
+				}
+				current, err = client.GetIAPTaxCategory(requestCtx, resolvedIAPID)
+				return err
+			})
+			if err != nil {
+				return withWebAuthHint(err, "web iap tax-category set")
+			}
+			if current == nil {
+				return fmt.Errorf("web iap tax-category set failed: missing preflight selection for In-App Purchase %q", resolvedIAPID)
+			}
+			if !iapTaxCategoryIdentityMatches(current, resolvedIAPID) {
+				return fmt.Errorf("web iap tax-category set failed: preflight response did not identify In-App Purchase %q", resolvedIAPID)
+			}
+
+			selectedCategory := findIAPTaxCategory(catalog.Categories, resolvedCategoryID)
+			if selectedCategory == nil {
+				return shared.UsageErrorf("category %q was not returned by the ADDON tax catalog", resolvedCategoryID)
+			}
+			if err := validateIAPTaxCategorySelection(catalog.Categories, selectedCategory); err != nil {
+				return shared.UsageError(err.Error())
+			}
+			if err := validateIAPTaxConditions(catalog.Categories, selectedCategory, desiredConditions); err != nil {
+				return shared.UsageError(err.Error())
+			}
+
+			changed := current == nil || !current.Configured || strings.TrimSpace(current.CategoryID) != resolvedCategoryID || !sameWebTaxConditionSet(current.EnabledConditionIDs, desiredConditions)
+			if changed {
+				err = withWebSpinner("Saving In-App Purchase tax category", func() error {
+					return client.SaveIAPTaxCategory(requestCtx, resolvedIAPID, resolvedCategoryID, desiredConditions, current)
+				})
+				if err != nil {
+					return fmt.Errorf("web iap tax-category set failed: write outcome may be ambiguous; do not retry automatically: %w", withWebAuthHint(err, "web iap tax-category set"))
+				}
+				current, err = client.GetIAPTaxCategory(requestCtx, resolvedIAPID)
+				if err != nil {
+					return fmt.Errorf("web iap tax-category set failed: write may have succeeded but post-read verification failed; do not retry automatically: %w", withWebAuthHint(err, "web iap tax-category set"))
+				}
+			}
+			if !iapTaxCategoryStateMatches(current, resolvedIAPID, resolvedCategoryID, desiredConditions) {
+				return fmt.Errorf("web iap tax-category set failed: Apple did not confirm In-App Purchase %q category %q and the requested condition set; do not retry automatically", resolvedIAPID, resolvedCategoryID)
+			}
+
+			receipt := &asc.WebIAPTaxCategorySetResult{
+				IAPID:        resolvedIAPID,
+				CategoryID:   resolvedCategoryID,
+				CategoryName: strings.TrimSpace(selectedCategory.Name),
+				ConditionIDs: desiredConditions,
+				Changed:      changed,
+				Verified:     true,
+			}
+			if err := shared.PrintOutput(receipt, *output.Output, *output.Pretty); err != nil {
+				return fmt.Errorf("web iap tax-category set In-App Purchase %q category %q was %s and verified, but receipt output failed; do not retry automatically: %w", receipt.IAPID, receipt.CategoryID, iapTaxCategoryWriteSummary(receipt.Changed), err)
+			}
+			return nil
+		},
+	}
+}
+
+// WebIAPTaxCategoryResetCommand removes an explicit IAP tax-category resource.
+// It never sends DELETE for an already inherited state.
+func WebIAPTaxCategoryResetCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("web iap tax-category reset", flag.ExitOnError)
+	iapID := fs.String("iap", "", "In-App Purchase ID")
+	confirm := fs.Bool("confirm", false, "Confirm removing the In-App Purchase tax category")
+	authFlags := bindWebSessionFlags(fs)
+	output := shared.BindOutputFlags(fs)
+
+	return &ffcli.Command{
+		Name:       "reset",
+		ShortUsage: "asc web iap tax-category reset --iap IAP_ID --confirm [flags]",
+		ShortHelp:  "[experimental] Reset an In-App Purchase tax category to inherited state.",
+		LongHelp: `[experimental] WEB SESSION WORKFLOWS
+
+Remove the explicit In-App Purchase tax-category resource so the purchase
+inherits its parent app's selection. The command reads first, sends DELETE only
+when an explicit resource is configured, and verifies an explicit null result.
+An ambiguous delete is reported without an automatic retry.
+
+`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 {
+				return shared.UsageErrorf("unexpected argument(s): %s", strings.Join(args, " "))
+			}
+			if _, err := shared.ValidateOutputFormat(*output.Output, *output.Pretty); err != nil {
+				return shared.UsageError(err.Error())
+			}
+			resolvedIAPID := strings.TrimSpace(*iapID)
+			if resolvedIAPID == "" {
+				return shared.UsageError("--iap is required")
+			}
+			if !*confirm {
+				return shared.UsageError("--confirm is required")
+			}
+
+			session, requestCtx, cancel, err := resolveWebSessionForCommand(ctx, authFlags)
+			defer cancel()
+			if err != nil {
+				return err
+			}
+			client := newWebClientFn(session)
+
+			var current *webcore.IAPTaxCategory
+			err = withWebSpinner("Reading In-App Purchase tax category", func() error {
+				current, err = client.GetIAPTaxCategory(requestCtx, resolvedIAPID)
+				return err
+			})
+			if err != nil {
+				return withWebAuthHint(err, "web iap tax-category reset")
+			}
+			if current == nil {
+				return fmt.Errorf("web iap tax-category reset failed: missing preflight selection for In-App Purchase %q", resolvedIAPID)
+			}
+			if !iapTaxCategoryIdentityMatches(current, resolvedIAPID) {
+				return fmt.Errorf("web iap tax-category reset failed: preflight response did not identify In-App Purchase %q", resolvedIAPID)
+			}
+
+			changed := current.Configured
+			if changed {
+				err = withWebSpinner("Resetting In-App Purchase tax category", func() error {
+					return client.DeleteIAPTaxCategory(requestCtx, resolvedIAPID, current)
+				})
+				if err != nil {
+					return fmt.Errorf("web iap tax-category reset failed: delete outcome may be ambiguous; do not retry automatically: %w", withWebAuthHint(err, "web iap tax-category reset"))
+				}
+				current, err = client.GetIAPTaxCategory(requestCtx, resolvedIAPID)
+				if err != nil {
+					return fmt.Errorf("web iap tax-category reset failed: delete may have succeeded but post-read verification failed; do not retry automatically: %w", withWebAuthHint(err, "web iap tax-category reset"))
+				}
+			}
+			if !iapTaxCategoryIsExplicitNull(current, resolvedIAPID) {
+				return fmt.Errorf("web iap tax-category reset failed: Apple did not confirm an explicit null tax category for In-App Purchase %q; do not retry automatically", resolvedIAPID)
+			}
+
+			receipt := &asc.WebIAPTaxCategoryResetResult{
+				IAPID:    resolvedIAPID,
+				Changed:  changed,
+				Verified: true,
+			}
+			if err := shared.PrintOutput(receipt, *output.Output, *output.Pretty); err != nil {
+				return fmt.Errorf("web iap tax-category reset In-App Purchase %q was %s and verified, but receipt output failed; do not retry automatically: %w", receipt.IAPID, iapTaxCategoryWriteSummary(receipt.Changed), err)
+			}
+			return nil
+		},
+	}
+}
+
+func findIAPTaxCategory(categories []webcore.TaxCategory, id string) *webcore.TaxCategory {
+	for index := range categories {
+		category := &categories[index]
+		if strings.TrimSpace(category.ID) != id {
+			continue
+		}
+		productType := strings.TrimSpace(category.ProductType)
+		if !strings.EqualFold(productType, "ADDON") {
+			return nil
+		}
+		return category
+	}
+	return nil
+}
+
+func validateIAPTaxCategorySelection(categories []webcore.TaxCategory, selected *webcore.TaxCategory) error {
+	if selected == nil {
+		return fmt.Errorf("selected category is missing from the ADDON tax catalog")
+	}
+	if !selected.SubcategoryRequired {
+		return nil
+	}
+	selectedID := strings.TrimSpace(selected.ID)
+	for _, category := range categories {
+		for _, subcategory := range category.Subcategories {
+			if strings.TrimSpace(subcategory.ID) == selectedID {
+				return nil
+			}
+		}
+	}
+	return fmt.Errorf("category %q requires a subcategory selection; select one of its listed subcategories", selectedID)
+}
+
+func validateIAPTaxConditions(categories []webcore.TaxCategory, category *webcore.TaxCategory, conditionIDs []string) error {
+	if category == nil {
+		return fmt.Errorf("selected category is missing from the ADDON tax catalog")
+	}
+	compatible := make(map[string]struct{}, len(category.Conditions))
+	for _, condition := range effectiveWebTaxConditions(categories, category) {
+		if condition.Type != "taxConditions" {
+			continue
+		}
+		if id := strings.TrimSpace(condition.ID); id != "" {
+			compatible[id] = struct{}{}
+		}
+	}
+	for _, conditionID := range conditionIDs {
+		if _, ok := compatible[conditionID]; !ok {
+			return fmt.Errorf("condition %q is not compatible with ADDON category %q according to the tax catalog", conditionID, strings.TrimSpace(category.ID))
+		}
+	}
+	return nil
+}
+
+func webIAPTaxCategoryViewHeaders() []string {
+	return []string{"Field", "Value"}
+}
+
+func webIAPTaxCategoryViewRows(result *webcore.IAPTaxCategory) [][]string {
+	if result == nil {
+		return nil
+	}
+	categoryName := strings.TrimSpace(result.CategoryName)
+	if !result.Configured {
+		categoryName = iapTaxCategoryInheritedLabel
+	}
+	return [][]string{
+		{"IAP ID", strings.TrimSpace(result.IAPID)},
+		{"ID", strings.TrimSpace(result.ID)},
+		{"Configured", fmt.Sprintf("%t", result.Configured)},
+		{"Category ID", strings.TrimSpace(result.CategoryID)},
+		{"Category Name", categoryName},
+		{"Enabled Condition IDs", strings.Join(result.EnabledConditionIDs, ",")},
+	}
+}
+
+func iapTaxCategoryIdentityMatches(result *webcore.IAPTaxCategory, iapID string) bool {
+	if result == nil {
+		return false
+	}
+	identifier := strings.TrimSpace(result.IAPID)
+	if identifier == "" {
+		return false
+	}
+	return identifier == iapID
+}
+
+func iapTaxCategoryStateMatches(result *webcore.IAPTaxCategory, iapID, categoryID string, conditionIDs []string) bool {
+	return iapTaxCategoryIdentityMatches(result, iapID) && result.Configured && strings.TrimSpace(result.CategoryID) == categoryID && sameWebTaxConditionSet(result.EnabledConditionIDs, conditionIDs)
+}
+
+func iapTaxCategoryIsExplicitNull(result *webcore.IAPTaxCategory, iapID string) bool {
+	return iapTaxCategoryIdentityMatches(result, iapID) && !result.Configured && strings.TrimSpace(result.CategoryID) == "" && len(normalizedWebTaxConditionIDsForComparison(result.EnabledConditionIDs)) == 0
+}
+
+func iapTaxCategoryWriteSummary(changed bool) string {
+	if changed {
+		return "written"
+	}
+	return "already matched"
+}

--- a/internal/cli/web/web_iap_tax_category_lifecycle_test.go
+++ b/internal/cli/web/web_iap_tax_category_lifecycle_test.go
@@ -1,0 +1,513 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
+)
+
+// These tests exercise the command against a real HTTP server through the
+// same web client used in production. The transport only rewrites Apple's
+// host to the local server, leaving paths, query strings, methods, and bodies
+// observable by the fake provider.
+func TestWebIAPTaxCategorySetLifecycleUsesOneWriteAndReadback(t *testing.T) {
+	tests := []struct {
+		name                   string
+		initialConfigured      bool
+		initialConditions      []string
+		args                   []string
+		wantMethod             string
+		wantChanged            bool
+		wantConditions         []string
+		wantPostRead           bool
+		wantCategory           string
+		wantWriteCount         int
+		wantConditionInPayload []string
+	}{
+		{
+			name:                   "inherited create",
+			args:                   []string{"--iap", "iap-1", "--category", "C003", "--condition", "C003-Q01", "--confirm", "--output", "json"},
+			wantMethod:             http.MethodPost,
+			wantChanged:            true,
+			wantConditions:         []string{"C003-Q01"},
+			wantPostRead:           true,
+			wantCategory:           "C003",
+			wantWriteCount:         1,
+			wantConditionInPayload: []string{"C003-Q01"},
+		},
+		{
+			name:              "configured identical no-op",
+			initialConfigured: true,
+			initialConditions: []string{"C003-Q01"},
+			args:              []string{"--iap", "iap-1", "--category", "C003", "--condition", "C003-Q01", "--confirm", "--output", "json"},
+			wantChanged:       false,
+			wantConditions:    []string{"C003-Q01"},
+			wantCategory:      "C003",
+			wantWriteCount:    0,
+		},
+		{
+			name:                   "changed conditions clear explicitly",
+			initialConfigured:      true,
+			initialConditions:      []string{"C003-Q01"},
+			args:                   []string{"--iap", "iap-1", "--category", "C003", "--confirm", "--output", "json"},
+			wantMethod:             http.MethodPatch,
+			wantChanged:            true,
+			wantConditions:         []string{},
+			wantPostRead:           true,
+			wantCategory:           "C003",
+			wantWriteCount:         1,
+			wantConditionInPayload: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := &iapTaxCategoryCLIHTTPFixture{
+				configured:   tt.initialConfigured,
+				categoryID:   "C003",
+				conditionIDs: append([]string(nil), tt.initialConditions...),
+				recordID:     "tax-1",
+			}
+			setupIAPTaxCategoryCLIHTTP(t, fixture)
+
+			command := WebIAPTaxCategorySetCommand()
+			if err := command.FlagSet.Parse(tt.args); err != nil {
+				t.Fatalf("parse command: %v", err)
+			}
+			stdout, stderr := captureWebCommandOutput(t, func() {
+				if err := command.Exec(context.Background(), nil); err != nil {
+					t.Fatalf("execute command: %v", err)
+				}
+			})
+			if stderr != "" {
+				t.Fatalf("stderr = %q, want empty", stderr)
+			}
+
+			var receipt struct {
+				IAPID        string   `json:"iapId"`
+				CategoryID   string   `json:"categoryId"`
+				ConditionIDs []string `json:"conditionIds"`
+				Changed      bool     `json:"changed"`
+				Verified     bool     `json:"verified"`
+			}
+			if err := json.Unmarshal([]byte(stdout), &receipt); err != nil {
+				t.Fatalf("decode receipt %q: %v", stdout, err)
+			}
+			if receipt.IAPID != "iap-1" || receipt.CategoryID != tt.wantCategory || receipt.Changed != tt.wantChanged || !receipt.Verified {
+				t.Fatalf("unexpected receipt: %+v", receipt)
+			}
+			if !sameWebTaxConditionSet(receipt.ConditionIDs, tt.wantConditions) {
+				t.Fatalf("receipt conditions = %v, want %v", receipt.ConditionIDs, tt.wantConditions)
+			}
+			if fixture.writeCount != tt.wantWriteCount {
+				t.Fatalf("write count = %d, want %d; requests = %v", fixture.writeCount, tt.wantWriteCount, fixture.requests)
+			}
+			if tt.wantMethod != "" {
+				if fixture.writeMethods[0] != tt.wantMethod {
+					t.Fatalf("write method = %q, want %q", fixture.writeMethods[0], tt.wantMethod)
+				}
+				if !sameWebTaxConditionSet(fixture.writeConditions[0], tt.wantConditionInPayload) {
+					t.Fatalf("write conditions = %v, want %v", fixture.writeConditions[0], tt.wantConditionInPayload)
+				}
+			}
+			if fixture.postReadCount != boolToInt(tt.wantPostRead) {
+				t.Fatalf("post-read count = %d, want %t", fixture.postReadCount, tt.wantPostRead)
+			}
+			if fixture.configured != true || fixture.categoryID != tt.wantCategory || !sameWebTaxConditionSet(fixture.conditionIDs, tt.wantConditions) {
+				t.Fatalf("fixture final state configured=%t category=%q conditions=%v", fixture.configured, fixture.categoryID, fixture.conditionIDs)
+			}
+		})
+	}
+}
+
+func TestWebIAPTaxCategoryResetLifecycleDeletesConfiguredRecordAndVerifiesNull(t *testing.T) {
+	fixture := &iapTaxCategoryCLIHTTPFixture{
+		configured:   true,
+		categoryID:   "C003",
+		conditionIDs: []string{"C003-Q01"},
+		recordID:     "tax-1",
+	}
+	setupIAPTaxCategoryCLIHTTP(t, fixture)
+
+	command := WebIAPTaxCategoryResetCommand()
+	if err := command.FlagSet.Parse([]string{"--iap", "iap-1", "--confirm", "--output", "json"}); err != nil {
+		t.Fatalf("parse command: %v", err)
+	}
+	stdout, stderr := captureWebCommandOutput(t, func() {
+		if err := command.Exec(context.Background(), nil); err != nil {
+			t.Fatalf("execute command: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	var receipt struct {
+		IAPID    string `json:"iapId"`
+		Changed  bool   `json:"changed"`
+		Verified bool   `json:"verified"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &receipt); err != nil {
+		t.Fatalf("decode receipt %q: %v", stdout, err)
+	}
+	if receipt.IAPID != "iap-1" || !receipt.Changed || !receipt.Verified {
+		t.Fatalf("unexpected receipt: %+v", receipt)
+	}
+	if fixture.writeCount != 1 || fixture.writeMethods[0] != http.MethodDelete {
+		t.Fatalf("writes = %v, want one DELETE", fixture.writeMethods)
+	}
+	if fixture.postReadCount != 1 {
+		t.Fatalf("post-read count = %d, want 1", fixture.postReadCount)
+	}
+	if fixture.configured {
+		t.Fatal("expected reset to leave an explicit null relationship")
+	}
+}
+
+func TestWebIAPTaxCategoryViewRendersInheritedStateWithoutInferringCategory(t *testing.T) {
+	fixture := &iapTaxCategoryCLIHTTPFixture{
+		categoryID: "C003",
+		recordID:   "tax-1",
+	}
+	setupIAPTaxCategoryCLIHTTP(t, fixture)
+
+	for _, output := range []string{"json", "table", "markdown"} {
+		t.Run(output, func(t *testing.T) {
+			command := WebIAPTaxCategoryViewCommand()
+			if err := command.FlagSet.Parse([]string{"--iap", "iap-1", "--output", output}); err != nil {
+				t.Fatalf("parse command: %v", err)
+			}
+			stdout, stderr := captureWebCommandOutput(t, func() {
+				if err := command.Exec(context.Background(), nil); err != nil {
+					t.Fatalf("execute command: %v", err)
+				}
+			})
+			if stderr != "" {
+				t.Fatalf("stderr = %q, want empty", stderr)
+			}
+
+			if output == "json" {
+				var envelope struct {
+					Data struct {
+						Relationships map[string]struct {
+							Data json.RawMessage `json:"data"`
+						} `json:"relationships"`
+					} `json:"data"`
+					Meta map[string]any `json:"meta"`
+				}
+				if err := json.Unmarshal([]byte(stdout), &envelope); err != nil {
+					t.Fatalf("decode raw envelope %q: %v", stdout, err)
+				}
+				linkage := envelope.Data.Relationships["inAppPurchaseTaxCategoryInfo"].Data
+				if string(linkage) != "null" {
+					t.Fatalf("tax-category linkage = %s, want explicit null", linkage)
+				}
+				if envelope.Meta["fixture"] != true {
+					t.Fatalf("raw envelope meta = %#v, want preserved fixture marker", envelope.Meta)
+				}
+				return
+			}
+			if !strings.Contains(stdout, iapTaxCategoryInheritedLabel) {
+				t.Fatalf("%s output = %q, want inherited label", output, stdout)
+			}
+			if strings.Contains(stdout, "C003") {
+				t.Fatalf("%s output = %q, inferred category ID", output, stdout)
+			}
+		})
+	}
+}
+
+func TestWebIAPTaxCategorySetRejectsInvalidCatalogSelectionBeforeMutation(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		productType   string
+		conditionArgs []string
+		wantError     string
+	}{
+		{name: "wrong product type", productType: "APPLICATION", wantError: "ADDON tax catalog"},
+		{name: "incompatible condition", productType: "ADDON", conditionArgs: []string{"--condition", "C003-Q99"}, wantError: "not compatible"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := &iapTaxCategoryCLIHTTPFixture{
+				categoryProductType: tc.productType,
+				categoryID:          "C003",
+				recordID:            "tax-1",
+			}
+			setupIAPTaxCategoryCLIHTTP(t, fixture)
+
+			args := []string{"--iap", "iap-1", "--category", "C003"}
+			args = append(args, tc.conditionArgs...)
+			args = append(args, "--confirm", "--output", "json")
+			command := WebIAPTaxCategorySetCommand()
+			if err := command.FlagSet.Parse(args); err != nil {
+				t.Fatalf("parse command: %v", err)
+			}
+			var commandErr error
+			_, stderr := captureWebCommandOutput(t, func() {
+				commandErr = command.Exec(context.Background(), nil)
+			})
+			if commandErr == nil {
+				t.Fatalf("error = nil, want %q", tc.wantError)
+			}
+			if !strings.Contains(stderr, tc.wantError) {
+				t.Fatalf("stderr = %q, want %q", stderr, tc.wantError)
+			}
+			if fixture.writeCount != 0 {
+				t.Fatalf("write count = %d, want 0; methods = %v", fixture.writeCount, fixture.writeMethods)
+			}
+		})
+	}
+}
+
+func TestWebIAPTaxCategorySetDoesNotRetryMismatchedPostRead(t *testing.T) {
+	fixture := &iapTaxCategoryCLIHTTPFixture{
+		categoryID:          "C003",
+		recordID:            "tax-1",
+		mismatchPostRead:    true,
+		categoryProductType: "ADDON",
+	}
+	setupIAPTaxCategoryCLIHTTP(t, fixture)
+
+	command := WebIAPTaxCategorySetCommand()
+	if err := command.FlagSet.Parse([]string{"--iap", "iap-1", "--category", "C003", "--confirm", "--output", "json"}); err != nil {
+		t.Fatalf("parse command: %v", err)
+	}
+	var commandErr error
+	_, stderr := captureWebCommandOutput(t, func() {
+		commandErr = command.Exec(context.Background(), nil)
+	})
+	if commandErr == nil || !strings.Contains(commandErr.Error(), "do not retry automatically") {
+		t.Fatalf("error = %v, want an explicit non-retry verification error", commandErr)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty for direct command execution", stderr)
+	}
+	if fixture.writeCount != 1 || fixture.writeMethods[0] != http.MethodPost {
+		t.Fatalf("writes = %v, want one POST", fixture.writeMethods)
+	}
+	if fixture.postReadCount != 1 {
+		t.Fatalf("post-read count = %d, want 1", fixture.postReadCount)
+	}
+}
+
+type iapTaxCategoryCLIHTTPFixture struct {
+	configured          bool
+	categoryID          string
+	categoryProductType string
+	conditionIDs        []string
+	recordID            string
+	mismatchPostRead    bool
+	postReadCount       int
+	writeCount          int
+	writeMethods        []string
+	writeConditions     [][]string
+	requests            []string
+}
+
+func setupIAPTaxCategoryCLIHTTP(t *testing.T, fixture *iapTaxCategoryCLIHTTPFixture) {
+	t.Helper()
+	if fixture.categoryID == "" {
+		fixture.categoryID = "C003"
+	}
+	if fixture.categoryProductType == "" {
+		fixture.categoryProductType = "ADDON"
+	}
+	if fixture.recordID == "" {
+		fixture.recordID = "tax-1"
+	}
+
+	server := httptest.NewServer(fixture)
+	t.Cleanup(server.Close)
+	target, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		clone := req.Clone(req.Context())
+		requestURL := *req.URL
+		requestURL.Scheme = target.Scheme
+		requestURL.Host = target.Host
+		clone.URL = &requestURL
+		return server.Client().Transport.RoundTrip(clone)
+	})
+
+	originalResolveSession := resolveSessionFn
+	originalNewWebClient := newWebClientFn
+	resolveSessionFn = func(context.Context, string, string, string) (*webcore.AuthSession, string, error) {
+		return &webcore.AuthSession{Client: &http.Client{Transport: transport}}, "cache", nil
+	}
+	newWebClientFn = webcore.NewClient
+	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
+	t.Setenv("ASC_WEB_MIN_REQUEST_INTERVAL", "0")
+	t.Cleanup(func() {
+		resolveSessionFn = originalResolveSession
+		newWebClientFn = originalNewWebClient
+	})
+}
+
+func (f *iapTaxCategoryCLIHTTPFixture) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	f.requests = append(f.requests, r.Method+" "+r.URL.Path)
+	switch r.URL.Path {
+	case "/iris/v1/taxCategories":
+		if r.Method != http.MethodGet {
+			f.writeFixtureError(w, http.StatusMethodNotAllowed, "catalog method")
+			return
+		}
+		if got := r.URL.Query().Get("filter[productType]"); got != "ADDON" {
+			f.writeFixtureError(w, http.StatusBadRequest, "catalog product type")
+			return
+		}
+		f.writeCatalog(w)
+	case "/iris/v2/inAppPurchases/iap-1":
+		if r.Method != http.MethodGet {
+			f.writeFixtureError(w, http.StatusMethodNotAllowed, "discovery method")
+			return
+		}
+		if f.writeCount > 0 {
+			// Every post-write verification starts with a fresh discovery read.
+			f.postReadCount++
+		}
+		f.writeDiscovery(w)
+	case "/iris/v1/inAppPurchaseTaxCategoryInfos", "/iris/v1/inAppPurchaseTaxCategoryInfos/tax-1":
+		switch r.Method {
+		case http.MethodGet:
+			if r.URL.Path != "/iris/v1/inAppPurchaseTaxCategoryInfos/"+f.recordID {
+				f.writeFixtureError(w, http.StatusNotFound, "record id path")
+				return
+			}
+			f.writeRecord(w)
+		case http.MethodPost, http.MethodPatch:
+			if r.Method == http.MethodPost && r.URL.Path != "/iris/v1/inAppPurchaseTaxCategoryInfos" {
+				f.writeFixtureError(w, http.StatusNotFound, "create path")
+				return
+			}
+			if r.Method == http.MethodPatch && r.URL.Path != "/iris/v1/inAppPurchaseTaxCategoryInfos/"+f.recordID {
+				f.writeFixtureError(w, http.StatusNotFound, "update path")
+				return
+			}
+			if err := f.applyWrite(r); err != nil {
+				f.writeFixtureError(w, http.StatusBadRequest, err.Error())
+				return
+			}
+			f.writeCount++
+			f.writeMethods = append(f.writeMethods, r.Method)
+			status := http.StatusOK
+			if r.Method == http.MethodPost {
+				status = http.StatusCreated
+			}
+			writeJSON(w, status, fmt.Sprintf(`{"data":{"type":"inAppPurchaseTaxCategoryInfos","id":%q}}`, f.recordID))
+		case http.MethodDelete:
+			f.configured = false
+			f.categoryID = ""
+			f.conditionIDs = nil
+			f.writeCount++
+			f.writeMethods = append(f.writeMethods, r.Method)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			f.writeFixtureError(w, http.StatusMethodNotAllowed, "record method")
+		}
+	default:
+		f.writeFixtureError(w, http.StatusNotFound, "unexpected path")
+	}
+}
+
+func (f *iapTaxCategoryCLIHTTPFixture) writeCatalog(w http.ResponseWriter) {
+	conditionID := "C003-Q01"
+	if f.categoryID != "C003" {
+		conditionID = f.categoryID + "-Q01"
+	}
+	writeJSON(w, http.StatusOK, fmt.Sprintf(`{"data":[{"type":"taxCategories","id":%q,"attributes":{"name":"Digital Goods","productType":%q,"subcategoryRequired":false},"relationships":{"conditions":{"data":[{"type":"taxConditions","id":%q}]}}}],"included":[{"type":"taxConditions","id":%q,"attributes":{"name":"Digital goods condition"}}],"meta":{"fixture":true}}`, f.categoryID, f.categoryProductType, conditionID, conditionID))
+}
+
+func (f *iapTaxCategoryCLIHTTPFixture) writeDiscovery(w http.ResponseWriter) {
+	linkage := "null"
+	if f.configured {
+		linkage = fmt.Sprintf(`{"type":"inAppPurchaseTaxCategoryInfos","id":%q}`, f.recordID)
+	}
+	writeJSON(w, http.StatusOK, fmt.Sprintf(`{"data":{"type":"inAppPurchases","id":"iap-1","relationships":{"inAppPurchaseTaxCategoryInfo":{"data":%s}}},"meta":{"fixture":true}}`, linkage))
+}
+
+func (f *iapTaxCategoryCLIHTTPFixture) writeRecord(w http.ResponseWriter) {
+	categoryID := f.categoryID
+	if f.mismatchPostRead && f.writeCount > 0 {
+		categoryID = "C010"
+	}
+	conditionData := make([]string, 0, len(f.conditionIDs))
+	for _, conditionID := range f.conditionIDs {
+		conditionData = append(conditionData, fmt.Sprintf(`{"type":"taxConditions","id":%q}`, conditionID))
+	}
+	writeJSON(w, http.StatusOK, []byte(fmt.Sprintf(`{"data":{"type":"inAppPurchaseTaxCategoryInfos","id":%q,"relationships":{"inAppPurchaseV2":{"data":{"type":"inAppPurchases","id":"iap-1"}},"category":{"data":{"type":"taxCategories","id":%q}},"enabledConditions":{"data":[%s]}}},"included":[{"type":"taxCategories","id":%q,"attributes":{"name":"Digital Goods"}}],"meta":{"fixture":true}}`, f.recordID, categoryID, strings.Join(conditionData, ","), categoryID)))
+}
+
+func (f *iapTaxCategoryCLIHTTPFixture) applyWrite(r *http.Request) error {
+	var envelope struct {
+		Data struct {
+			ID            string `json:"id"`
+			Type          string `json:"type"`
+			Relationships struct {
+				Category struct {
+					Data struct {
+						ID string `json:"id"`
+					} `json:"data"`
+				} `json:"category"`
+				EnabledConditions struct {
+					Data []struct {
+						ID string `json:"id"`
+					} `json:"data"`
+				} `json:"enabledConditions"`
+			} `json:"relationships"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&envelope); err != nil {
+		return fmt.Errorf("decode write: %w", err)
+	}
+	if envelope.Data.Type != "inAppPurchaseTaxCategoryInfos" || envelope.Data.Relationships.Category.Data.ID == "" {
+		return fmt.Errorf("invalid write payload: %+v", envelope.Data)
+	}
+	if r.Method == http.MethodPost && envelope.Data.ID != "" {
+		return fmt.Errorf("create unexpectedly included id %q", envelope.Data.ID)
+	}
+	if r.Method == http.MethodPatch && envelope.Data.ID != f.recordID {
+		return fmt.Errorf("update id = %q, want %q", envelope.Data.ID, f.recordID)
+	}
+	conditions := make([]string, 0, len(envelope.Data.Relationships.EnabledConditions.Data))
+	for _, condition := range envelope.Data.Relationships.EnabledConditions.Data {
+		conditions = append(conditions, condition.ID)
+	}
+	f.writeConditions = append(f.writeConditions, conditions)
+	f.categoryID = envelope.Data.Relationships.Category.Data.ID
+	f.conditionIDs = conditions
+	f.configured = true
+	return nil
+}
+
+func (f *iapTaxCategoryCLIHTTPFixture) writeFixtureError(w http.ResponseWriter, status int, detail string) {
+	writeJSON(w, status, fmt.Sprintf(`{"errors":[{"detail":%q}]}`, detail))
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	switch value := body.(type) {
+	case string:
+		_, _ = io.WriteString(w, value)
+	case []byte:
+		_, _ = w.Write(value)
+	default:
+		_ = json.NewEncoder(w).Encode(value)
+	}
+}
+
+func boolToInt(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
+}

--- a/internal/cli/web/web_iap_tax_category_validation_test.go
+++ b/internal/cli/web/web_iap_tax_category_validation_test.go
@@ -1,0 +1,14 @@
+package web
+
+import (
+	"testing"
+
+	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
+)
+
+func TestWebIAPTaxCategoryRejectsWrongConditionResourceType(t *testing.T) {
+	category := webcore.TaxCategory{ID: "C003", ProductType: "ADDON", Conditions: []webcore.TaxCategoryReference{{ID: "condition-1", Type: "apps"}}}
+	if err := validateIAPTaxConditions([]webcore.TaxCategory{category}, &category, []string{"condition-1"}); err == nil {
+		t.Fatal("accepted a non-taxConditions reference as a compatible condition")
+	}
+}

--- a/internal/web/iap_tax_category.go
+++ b/internal/web/iap_tax_category.go
@@ -1,0 +1,224 @@
+package web
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// IAPTaxCategory preserves Apple's read envelope and summarizes its tax override.
+// Configured is false only after explicit null linkage on the selected IAP.
+type IAPTaxCategory struct {
+	Raw                                 json.RawMessage
+	IAPID, ID, CategoryID, CategoryName string
+	Configured                          bool
+	EnabledConditionIDs                 []string
+}
+
+func (s IAPTaxCategory) MarshalJSON() ([]byte, error) { return s.Raw, nil }
+
+// ListIAPTaxCategories reads the ADDON catalog used by Apple's IAP tax picker.
+func (c *Client) ListIAPTaxCategories(ctx context.Context) (TaxCategoryCatalog, error) {
+	return c.listTaxCategoriesForProduct(ctx, "ADDON")
+}
+
+func iapTaxReference(data json.RawMessage, expectedType string) (resourceRef, error) {
+	var ref resourceRef
+	if err := json.Unmarshal(data, &ref); err != nil {
+		return ref, fmt.Errorf("invalid %s relationship: %w", expectedType, err)
+	}
+	if ref.Type != expectedType || strings.TrimSpace(ref.ID) == "" {
+		return ref, fmt.Errorf("invalid %s relationship identity", expectedType)
+	}
+	return ref, nil
+}
+
+// GetIAPTaxCategory discovers the tax record instead of assuming its ID matches
+// the IAP. An absent relationship or a failed read never means inheritance.
+func (c *Client) GetIAPTaxCategory(ctx context.Context, iapID string) (*IAPTaxCategory, error) {
+	iapID = strings.TrimSpace(iapID)
+	if iapID == "" {
+		return nil, fmt.Errorf("iap id is required")
+	}
+	body, err := c.doJSONAPIRequest(ctx, c.webIrisV2BaseURL(), "/inAppPurchases/"+url.PathEscape(iapID)+"?include=inAppPurchaseTaxCategoryInfo")
+	if err != nil {
+		return nil, err
+	}
+	var payload struct {
+		Data     jsonAPIResource   `json:"data"`
+		Included []jsonAPIResource `json:"included"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, fmt.Errorf("parse IAP tax discovery: %w", err)
+	}
+	if payload.Data.Type != "inAppPurchases" || payload.Data.ID != iapID {
+		return nil, fmt.Errorf("IAP tax discovery does not identify requested IAP %q", iapID)
+	}
+	relation, ok := payload.Data.Relationships["inAppPurchaseTaxCategoryInfo"]
+	if !ok || len(relation.Data) == 0 {
+		return nil, fmt.Errorf("IAP tax discovery omitted tax-category linkage")
+	}
+	result := &IAPTaxCategory{Raw: body, IAPID: iapID, EnabledConditionIDs: []string{}}
+	if bytes.Equal(bytes.TrimSpace(relation.Data), []byte("null")) {
+		return result, nil
+	}
+	ref, err := iapTaxReference(relation.Data, "inAppPurchaseTaxCategoryInfos")
+	if err != nil {
+		return nil, err
+	}
+	query := url.Values{"include": {"category,enabledConditions,inAppPurchaseV2"}, "limit[enabledConditions]": {"100"}}
+	body, err = c.doJSONAPIRequest(ctx, c.baseURL, queryPath("/inAppPurchaseTaxCategoryInfos/"+url.PathEscape(ref.ID), query))
+	if err != nil {
+		return nil, err
+	}
+	// Use a fresh envelope; unmarshalling into the discovery would retain omitted fields.
+	var taxPayload struct {
+		Data     jsonAPIResource   `json:"data"`
+		Included []jsonAPIResource `json:"included"`
+	}
+	if err := json.Unmarshal(body, &taxPayload); err != nil {
+		return nil, fmt.Errorf("parse IAP tax category: %w", err)
+	}
+	resource := taxPayload.Data
+	if resource.Type != ref.Type || resource.ID != ref.ID {
+		return nil, fmt.Errorf("IAP tax response does not identify requested tax record %q", ref.ID)
+	}
+	owner, err := iapTaxReference(resource.Relationships["inAppPurchaseV2"].Data, "inAppPurchases")
+	if err != nil {
+		return nil, err
+	}
+	if owner.ID != iapID {
+		return nil, fmt.Errorf("IAP tax record belongs to a different IAP")
+	}
+	category, err := iapTaxReference(resource.Relationships["category"].Data, "taxCategories")
+	if err != nil {
+		return nil, err
+	}
+	conditions := resource.Relationships["enabledConditions"].Data
+	if !bytes.HasPrefix(bytes.TrimSpace(conditions), []byte("[")) {
+		return nil, fmt.Errorf("IAP tax response omitted explicit condition linkage")
+	}
+	var refs []resourceRef
+	if err := json.Unmarshal(conditions, &refs); err != nil {
+		return nil, fmt.Errorf("parse IAP tax conditions: %w", err)
+	}
+	for _, condition := range refs {
+		if condition.Type != "taxConditions" || strings.TrimSpace(condition.ID) == "" {
+			return nil, fmt.Errorf("invalid IAP tax condition identity")
+		}
+		result.EnabledConditionIDs = append(result.EnabledConditionIDs, condition.ID)
+	}
+	// A partial relationship cannot verify a complete condition replacement.
+	var completeness struct {
+		Data struct {
+			Relationships struct {
+				Conditions struct {
+					Meta struct {
+						Paging struct {
+							Total *int `json:"total"`
+						} `json:"paging"`
+					} `json:"meta"`
+					Links struct {
+						Next json.RawMessage `json:"next"`
+					} `json:"links"`
+				} `json:"enabledConditions"`
+			} `json:"relationships"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &completeness); err != nil {
+		return nil, err
+	}
+	conditionMeta := completeness.Data.Relationships.Conditions
+	if total := conditionMeta.Meta.Paging.Total; total != nil && *total != len(refs) {
+		return nil, fmt.Errorf("IAP tax response contains an incomplete condition relationship")
+	}
+	if next := bytes.TrimSpace(conditionMeta.Links.Next); len(next) > 0 && !bytes.Equal(next, []byte("null")) && !bytes.Equal(next, []byte(`""`)) {
+		return nil, fmt.Errorf("IAP tax response contains additional condition pages")
+	}
+	result.Raw = body
+	result.ID = ref.ID
+	result.Configured = true
+	result.CategoryID = category.ID
+	for _, included := range taxPayload.Included {
+		if included.Type == category.Type && included.ID == category.ID {
+			result.CategoryName = stringAttr(included.Attributes, "name")
+			break
+		}
+	}
+	return result, nil
+}
+
+func validateIAPTaxCurrent(iapID string, current *IAPTaxCategory) error {
+	if iapID == "" {
+		return fmt.Errorf("iap id is required")
+	}
+	if current == nil || current.IAPID != iapID {
+		return fmt.Errorf("verified current tax state for selected IAP is required")
+	}
+	if current.Configured && strings.TrimSpace(current.ID) == "" {
+		return fmt.Errorf("configured IAP tax state is missing its record id")
+	}
+	return nil
+}
+
+// SaveIAPTaxCategory sends one create or update with the complete condition set.
+// Callers must verify the selected IAP again after this request succeeds.
+func (c *Client) SaveIAPTaxCategory(ctx context.Context, iapID, categoryID string, conditions []string, current *IAPTaxCategory) error {
+	iapID = strings.TrimSpace(iapID)
+	categoryID = strings.TrimSpace(categoryID)
+	if err := validateIAPTaxCurrent(iapID, current); err != nil {
+		return err
+	}
+	if categoryID == "" {
+		return fmt.Errorf("category id is required")
+	}
+	normalized, err := normalizeTaxConditionIDs(conditions)
+	if err != nil {
+		return err
+	}
+	refs := make([]resourceRef, 0, len(normalized))
+	for _, id := range normalized {
+		refs = append(refs, resourceRef{Type: "taxConditions", ID: id})
+	}
+	relationships := map[string]any{"category": map[string]any{"data": resourceRef{Type: "taxCategories", ID: categoryID}}, "enabledConditions": map[string]any{"data": refs}}
+	data := map[string]any{"type": "inAppPurchaseTaxCategoryInfos", "relationships": relationships}
+	method, path := http.MethodPost, "/inAppPurchaseTaxCategoryInfos"
+	if current.Configured {
+		method = http.MethodPatch
+		path += "/" + url.PathEscape(current.ID)
+		data["id"] = current.ID
+	} else {
+		relationships["inAppPurchaseV2"] = map[string]any{"data": resourceRef{Type: "inAppPurchases", ID: iapID}}
+	}
+	body, err := c.doRequest(ctx, method, path, map[string]any{"data": data})
+	if err != nil {
+		return err
+	}
+	var response struct {
+		Data resourceRef `json:"data"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return fmt.Errorf("parse IAP tax write response: %w", err)
+	}
+	if response.Data.Type != "inAppPurchaseTaxCategoryInfos" || strings.TrimSpace(response.Data.ID) == "" || (current.Configured && response.Data.ID != current.ID) {
+		return fmt.Errorf("IAP tax write response has unexpected resource identity")
+	}
+	return nil
+}
+
+// DeleteIAPTaxCategory removes only the discovered override. The IAP is retained.
+func (c *Client) DeleteIAPTaxCategory(ctx context.Context, iapID string, current *IAPTaxCategory) error {
+	iapID = strings.TrimSpace(iapID)
+	if err := validateIAPTaxCurrent(iapID, current); err != nil {
+		return err
+	}
+	if !current.Configured {
+		return nil
+	}
+	_, err := c.doRequest(ctx, http.MethodDelete, "/inAppPurchaseTaxCategoryInfos/"+url.PathEscape(current.ID), nil)
+	return err
+}

--- a/internal/web/iap_tax_category_test.go
+++ b/internal/web/iap_tax_category_test.go
@@ -1,0 +1,185 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestIAPTaxCategoryRead(t *testing.T) {
+	for _, tc := range []struct {
+		name, linkage, record string
+		configured, wantErr   bool
+	}{
+		{name: "inherited", linkage: `null`},
+		{name: "configured", linkage: `{"type":"inAppPurchaseTaxCategoryInfos","id":"tax-1"}`, record: `{"data":{"type":"inAppPurchaseTaxCategoryInfos","id":"tax-1","relationships":{"inAppPurchaseV2":{"data":{"type":"inAppPurchases","id":"iap-1"}},"category":{"data":{"type":"taxCategories","id":"C009"}},"enabledConditions":{"data":[{"type":"taxConditions","id":"C009-Q01"}]}}},"meta":{"future":true}}`, configured: true},
+		{name: "missing linkage", linkage: ``, wantErr: true},
+		{name: "wrong reference type", linkage: `{"type":"apps","id":"tax-1"}`, wantErr: true},
+		{name: "wrong IAP", linkage: `{"type":"inAppPurchaseTaxCategoryInfos","id":"tax-1"}`, record: `{"data":{"type":"inAppPurchaseTaxCategoryInfos","id":"tax-1","relationships":{"inAppPurchaseV2":{"data":{"type":"inAppPurchases","id":"another"}}}}}`, wantErr: true},
+		{name: "unknown conditions", linkage: `{"type":"inAppPurchaseTaxCategoryInfos","id":"tax-1"}`, record: `{"data":{"type":"inAppPurchaseTaxCategoryInfos","id":"tax-1","relationships":{"inAppPurchaseV2":{"data":{"type":"inAppPurchases","id":"iap-1"}},"category":{"data":{"type":"taxCategories","id":"C009"}},"enabledConditions":{"links":{}}}}}`, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			discovery := `{"data":{"type":"inAppPurchases","id":"iap-1","relationships":{"inAppPurchaseTaxCategoryInfo":{}}},"meta":{"future":true}}`
+			if tc.linkage != "" {
+				discovery = fmt.Sprintf(`{"data":{"type":"inAppPurchases","id":"iap-1","relationships":{"inAppPurchaseTaxCategoryInfo":{"data":%s}}},"meta":{"future":true}}`, tc.linkage)
+			}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "GET" {
+					t.Errorf("unexpected method %s", r.Method)
+				}
+				switch r.URL.Path {
+				case "/iris/v2/inAppPurchases/iap-1":
+					if r.URL.Query().Get("include") != "inAppPurchaseTaxCategoryInfo" {
+						t.Error(r.URL)
+					}
+					_, _ = io.WriteString(w, discovery)
+				case "/inAppPurchaseTaxCategoryInfos/tax-1":
+					if r.URL.Query().Get("include") != "category,enabledConditions,inAppPurchaseV2" || r.URL.Query().Get("limit[enabledConditions]") != "100" {
+						t.Error(r.URL)
+					}
+					_, _ = io.WriteString(w, tc.record)
+				default:
+					t.Error(r.URL)
+					http.NotFound(w, r)
+				}
+			}))
+			defer server.Close()
+			result, err := testWebClient(server).GetIAPTaxCategory(context.Background(), "iap-1")
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.Configured != tc.configured || result.IAPID != "iap-1" {
+				t.Fatalf("result %+v", result)
+			}
+			raw, err := json.Marshal(result)
+			if err != nil || !strings.Contains(string(raw), `"future":true`) {
+				t.Fatalf("lost envelope: %s %v", raw, err)
+			}
+			if tc.configured && (result.ID != "tax-1" || result.CategoryID != "C009" || len(result.EnabledConditionIDs) != 1) {
+				t.Fatalf("result %+v", result)
+			}
+		})
+	}
+}
+
+func TestIAPTaxCategoryWritesUseCapturedContract(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		var body struct {
+			Data struct {
+				ID, Type      string
+				Relationships map[string]json.RawMessage
+			}
+		}
+		if r.Method == "DELETE" {
+			if r.URL.Path != "/inAppPurchaseTaxCategoryInfos/tax-1" {
+				t.Error(r.URL)
+			}
+			w.WriteHeader(204)
+			return
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Error(err)
+		}
+		if body.Data.Type != "inAppPurchaseTaxCategoryInfos" {
+			t.Errorf("type %s", body.Data.Type)
+		}
+		if string(body.Data.Relationships["enabledConditions"]) != `{"data":[]}` {
+			t.Errorf("conditions %s", body.Data.Relationships["enabledConditions"])
+		}
+		switch r.Method {
+		case "POST":
+			if body.Data.ID != "" || !strings.Contains(string(body.Data.Relationships["inAppPurchaseV2"]), `"iap-1"`) {
+				t.Errorf("body %+v", body)
+			}
+		case "PATCH":
+			if body.Data.ID != "tax-1" || len(body.Data.Relationships["inAppPurchaseV2"]) != 0 {
+				t.Errorf("body %+v", body)
+			}
+		default:
+			t.Error(r.Method)
+		}
+		_, _ = io.WriteString(w, `{"data":{"type":"inAppPurchaseTaxCategoryInfos","id":"tax-1"}}`)
+	}))
+	defer server.Close()
+	client := testWebClient(server)
+	ctx := context.Background()
+	inherited := &IAPTaxCategory{IAPID: "iap-1"}
+	if err := client.SaveIAPTaxCategory(ctx, "iap-1", "C003", nil, inherited); err != nil {
+		t.Fatal(err)
+	}
+	configured := &IAPTaxCategory{IAPID: "iap-1", ID: "tax-1", Configured: true}
+	if err := client.SaveIAPTaxCategory(ctx, "iap-1", "C003", nil, configured); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.DeleteIAPTaxCategory(ctx, "iap-1", configured); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.DeleteIAPTaxCategory(ctx, "other", configured); err == nil {
+		t.Fatal("wrong IAP accepted")
+	}
+	if calls != 3 {
+		t.Fatalf("calls %d", calls)
+	}
+}
+
+func TestListIAPTaxCategoriesUsesAddonCatalog(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/taxCategories" || r.URL.Query().Get("filter[productType]") != "ADDON" {
+			t.Error(r.URL)
+		}
+		_, _ = io.WriteString(w, `{"data":[{"type":"taxCategories","id":"C003","attributes":{"productType":"ADDON"},"relationships":{"conditions":{"data":[{"type":"taxConditions","id":"condition-1"}]}}}],"included":[{"type":"taxConditions","id":"condition-1","attributes":{"description":"A condition from Apple"}}],"meta":{"future":true}}`)
+	}))
+	defer server.Close()
+	result, err := testWebClient(server).ListIAPTaxCategories(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Conditions) != 1 || result.Conditions[0].Name != "A condition from Apple" {
+		t.Fatalf("condition descriptions missing: %+v", result.Conditions)
+	}
+	if len(result.Categories) != 1 || result.Categories[0].ProductType != "ADDON" {
+		t.Fatalf("result %+v", result)
+	}
+}
+
+func TestIAPTaxCategoryWriteFailureIsNotRetried(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = io.WriteString(w, `{"errors":[{"code":"UNAVAILABLE"}]}`)
+	}))
+	defer server.Close()
+	err := testWebClient(server).SaveIAPTaxCategory(context.Background(), "iap-1", "C003", nil, &IAPTaxCategory{IAPID: "iap-1"})
+	if err == nil || calls != 1 {
+		t.Fatalf("err=%v calls=%d", err, calls)
+	}
+}
+
+func TestIAPTaxCategoryRejectsIncompleteConditions(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/inAppPurchases/") {
+			_, _ = io.WriteString(w, `{"data":{"type":"inAppPurchases","id":"iap-1","relationships":{"inAppPurchaseTaxCategoryInfo":{"data":{"type":"inAppPurchaseTaxCategoryInfos","id":"tax-1"}}}}}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"data":{"type":"inAppPurchaseTaxCategoryInfos","id":"tax-1","relationships":{"inAppPurchaseV2":{"data":{"type":"inAppPurchases","id":"iap-1"}},"category":{"data":{"type":"taxCategories","id":"C009"}},"enabledConditions":{"data":[],"meta":{"paging":{"total":1}}}}}}`)
+	}))
+	defer server.Close()
+	_, err := testWebClient(server).GetIAPTaxCategory(context.Background(), "iap-1")
+	if err == nil || !strings.Contains(err.Error(), "incomplete condition") {
+		t.Fatalf("err=%v", err)
+	}
+}

--- a/internal/web/jsonapi_pages.go
+++ b/internal/web/jsonapi_pages.go
@@ -47,7 +47,7 @@ func (c *Client) fetchJSONAPIPagesFromWithOptions(ctx context.Context, baseURL, 
 		visited[nextPath] = struct{}{}
 		currentPath := nextPath
 
-		responseBody, err := c.doJSONAPIRequest(ctx, baseURL, http.MethodGet, nextPath)
+		responseBody, err := c.doJSONAPIRequest(ctx, baseURL, nextPath)
 		if err != nil {
 			return jsonAPIListPayload{}, err
 		}
@@ -107,14 +107,14 @@ func (c *Client) fetchJSONAPIPagesFromWithOptions(ctx context.Context, baseURL, 
 	return combined, nil
 }
 
-func (c *Client) doJSONAPIRequest(ctx context.Context, baseURL, method, path string) ([]byte, error) {
+func (c *Client) doJSONAPIRequest(ctx context.Context, baseURL, path string) ([]byte, error) {
 	headers := make(http.Header)
 	headers.Set("Content-Type", "application/json")
 	headers.Set("Accept", "application/json")
 	headers.Set("X-Requested-With", "XMLHttpRequest")
 	headers.Set("Origin", appStoreBaseURL)
 	headers.Set("Referer", appStoreBaseURL+"/")
-	return c.doRequestBase(ctx, baseURL, method, path, nil, headers)
+	return c.doRequestBase(ctx, baseURL, http.MethodGet, path, nil, headers)
 }
 
 func resolveJSONAPINextPath(nextLink, currentPath, baseURL string) (string, error) {

--- a/internal/web/tax_category.go
+++ b/internal/web/tax_category.go
@@ -117,10 +117,14 @@ func decodeTaxCategoryResource(resource jsonAPIResource, included map[string]jso
 }
 
 func decodeTaxConditionResource(resource jsonAPIResource) TaxCondition {
+	name := stringAttr(resource.Attributes, "description")
+	if name == "" {
+		name = stringAttr(resource.Attributes, "name")
+	}
 	return TaxCondition{
 		ID:   strings.TrimSpace(resource.ID),
 		Type: strings.TrimSpace(resource.Type),
-		Name: stringAttr(resource.Attributes, "name"),
+		Name: name,
 	}
 }
 
@@ -176,13 +180,17 @@ func decodeTaxCategoryCatalog(payload jsonAPIListPayload) TaxCategoryCatalog {
 // App Information tax UI. This is an internal web-session endpoint; it is not
 // part of Apple's public App Store Connect API.
 func (c *Client) ListTaxCategories(ctx context.Context) (TaxCategoryCatalog, error) {
+	return c.listTaxCategoriesForProduct(ctx, "APPLICATION")
+}
+
+func (c *Client) listTaxCategoriesForProduct(ctx context.Context, productType string) (TaxCategoryCatalog, error) {
 	query := url.Values{}
-	query.Set("filter[productType]", "APPLICATION")
+	query.Set("filter[productType]", productType)
 	query.Set("include", taxCategoryCatalogInclude)
 	query.Set("limit[subcategories]", "100")
 	query.Set("limit[conditions]", "100")
 	path := queryPath("/taxCategories", query)
-	responseBody, err := c.doJSONAPIRequest(ctx, c.baseURL, http.MethodGet, path)
+	responseBody, err := c.doJSONAPIRequest(ctx, c.baseURL, path)
 	if err != nil {
 		return TaxCategoryCatalog{}, err
 	}


### PR DESCRIPTION
App Information tax categories and Transaction Tax downloads are already implemented. This change addresses the remaining IAP tax-category scope in #2299 through the private App Store Connect web session.

## Commands

```bash
asc web iap tax-category list --output json
asc web iap tax-category view --iap IAP_ID --output json
asc web iap tax-category set --iap IAP_ID --category CATEGORY_ID --confirm
asc web iap tax-category set --iap IAP_ID --category CATEGORY_ID --condition CONDITION_ID --confirm
asc web iap tax-category reset --iap IAP_ID --confirm
```

## Apple contract and live evidence

The IAP picker requests the tax catalog with `filter[productType]=ADDON`; the existing application picker uses `APPLICATION`. IAP discovery reads `/iris/v2/inAppPurchases/{id}?include=inAppPurchaseTaxCategoryInfo`. An explicit null relationship means the IAP inherits its parent's selection; it does not identify the effective parent category.

The linked `/iris/v1/inAppPurchaseTaxCategoryInfos/{id}` resource is read with `include=category,enabledConditions,inAppPurchaseV2&limit[enabledConditions]=100`. Creating an override POSTs `inAppPurchaseTaxCategoryInfos` with the `inAppPurchaseV2` and `category` relationships. Existing overrides use PATCH; resetting to the parent uses DELETE of the discovered tax record.

On 2026-09-06 the authenticated Apple browser verified these contracts on disposable app `6759231657`, IAP `6760268101`:

- ADDON catalog and minimal IAP discovery returned HTTP 200.
- An override was created with category C003, verified by readback, changed to C010 with HTTP 200, and verified again. Creation and deletion responses in this first canary exceeded the browser tool timeout; independent reads established the resulting state, and neither write was retried.
- A second canary returned POST 201 for C009 with condition C009-Q01. Readback confirmed both. PATCH 200 with explicit `enabledConditions.data: []` cleared the condition, confirmed by another read.
- A separate create canary returned HTTP 201 with explicit `enabledConditions.data: []`; readback confirmed category C003 with no conditions.
- DELETE returned HTTP 204 and an independent IAP read returned explicit null. The original inherited state was restored. No temporary tax record remains and no personal app was changed.

These are browser/provider contract checks. Final-binary live behavior is a separate verification boundary.

## Behavior and compatibility

- `list` uses the IAP-specific ADDON catalog. Existing application tax reads retain their APPLICATION query.
- `view` preserves Apple's original JSON envelope, including unknown fields. Table/Markdown show explicit selection or "Inherited from parent app"; they do not invent the effective inherited category.
- `set` validates the complete category/condition selection, reads the selected IAP, follows its opaque tax-record ID, and writes at most once. Omitting `--condition` explicitly clears conditions. Identical state skips the write.
- `reset` deletes only the discovered override and verifies null linkage. Already inherited state is a verified no-op. The IAP itself is retained.
- Missing or malformed linkage, mismatched resource ownership, and partial condition collections fail closed. A failed or ambiguous mutation is not retried automatically; operators can inspect `view` before deciding what to do next.
- Both mutations require `--confirm` and return registered camelCase receipts with `changed` and `verified`. Required flags, output formats, and unexpected arguments fail before authentication with usage exit code 2.
- The shared tax-catalog renderer now uses Apple's condition `description`, retaining `name` as a compatibility fallback. This fixes blank condition labels in IAP and existing app catalog tables without changing raw JSON.
- The internal JSON:API read helper drops its constant method argument; all callers still send GET. This removes the lint finding exposed by the additional IAP callers without changing request behavior.

## Validation

- Focused client, HTTP-backed CLI lifecycle, root registration/usage, output-renderer, capability, and stability tests passed. Includes application-catalog regression coverage, opaque tax IDs, wrong-type condition references, no-op transitions, condition clearing, and readback mismatch/no-retry cases.
- Built-binary help and invalid-input checks passed, including missing IAP, missing confirmation, empty condition, unsupported output, and unexpected arguments; invalid calls exited 2 with empty stdout.
- `make build`, `make format`, `make check-docs`, `make lint`, and `ASC_BYPASS_KEYCHAIN=1 make test` passed on the final source. Tests used a bounded four-package run (`GOMAXPROCS=1`, `GOFLAGS="-p=4 -parallel=1"`).
- The final pre-commit `/review` reported no actionable correctness defects. Final full-branch `/review` of commit `c5f87bef347b96254271d7f10cd6b47abcd024f7` against freshly fetched main also reported no actionable correctness defects. Normal commit hooks passed on the feature commit. After strict branch protection refused the original merge because main had advanced, main was integrated with a regular merge commit; all five required local gates and the full-branch review passed again on the updated head. The reviewer could not execute tests in its read-only sandbox; the parent-run focused and full gates above supply the test evidence.

## Scope

The commands are experimental. Subscriptions and app-level tax settings are outside this IAP change. The existing app-tax and Transaction Tax report commands are not reimplemented.

Fixes #2299.
