### PR TITLE
apps wall: add Comer en Asturias

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -264,6 +264,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/4a/7f/ae/4a7faef1-a45e-75d7-d90a-066eda390ea4/AppIcon-0-0-1x_U007emarketing-0-8-0-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Comer en Asturias",
+    "link": "https://apps.apple.com/us/app/comer-en-asturias/id6802125809?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/7e/b1/18/7eb118c2-0cfb-c083-839e-cc896b31577c/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Concert Memories 2: Countdown",
     "link": "https://apps.apple.com/us/app/concert-memories-2-countdown/id6744301154?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/6c/ce/a1/6ccea161-6da4-52c7-1260-f44955b0bc70/ConcertMemories2-0-0-1x_U007epad-0-1-0-sRGB-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Comer en Asturias` to the Wall of Apps

## Entry

- App ID: 6802125809
- App: Comer en Asturias
- Link: https://apps.apple.com/us/app/comer-en-asturias/id6802125809?uo=4

## Notes

- Submitted via `asc apps wall submit`
