### PR TITLE
apps wall: add Pomodoro Timer: Tempo Focus

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1241,6 +1241,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/ec/c6/43/ecc6438f-9c3e-2b6e-34d7-c27e82104512/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Pomodoro Timer: Tempo Focus",
+    "link": "https://apps.apple.com/us/app/pomodoro-timer-tempo-focus/id6758786811?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/3a/3f/ff/3a3fff6a-e780-4867-ed3f-7445137a4be6/TempoDefault-0-0-1x_U007ephone-0-1-0-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Pool, the screenshot app",
     "link": "https://apps.apple.com/us/app/pool-the-screenshot-app/id6752956163?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/e4/af/3d/e4af3d29-eedd-8746-8c2d-f81d233c7fff/AppIcon-0-0-1x_U007ephone-0-1-sRGB-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Pomodoro Timer: Tempo Focus` to the Wall of Apps

## Entry

- App ID: 6758786811
- App: Pomodoro Timer: Tempo Focus
- Link: https://apps.apple.com/us/app/pomodoro-timer-tempo-focus/id6758786811?uo=4

## Notes

- Submitted via `asc apps wall submit`
