### PR TITLE
fix(web): reject incomplete draft reads during verification

### DIFF
--- a/docs/API_NOTES.md
+++ b/docs/API_NOTES.md
@@ -205,6 +205,9 @@ the App Store Connect web-client source captured for issue #2299:
   upload attachments and never retry an uncertain mutation or post-read
   verification. No disposable live thread/draft fixture was available, so
   Apple provider acceptance of these writes remains unverified.
+- A draft read response without `data` is malformed, not proof of absence.
+  Create refuses it before writing; delete cannot report verified success
+  from it. Only explicit `data: null` or a relationship 404 means no draft.
 
 ## Web-session app distribution method
 

--- a/internal/cli/web/web_review_drafts_test.go
+++ b/internal/cli/web/web_review_drafts_test.go
@@ -241,6 +241,40 @@ func TestWebReviewDraftCreateRefusesAnyExistingDraftBeforeWrite(t *testing.T) {
 	}
 }
 
+func TestWebReviewDraftCreateRefusesMissingPreflightData(t *testing.T) {
+	requested := stubWebReviewDraftSequence(t, []webReviewDraftHTTPResponse{
+		{method: http.MethodGet, path: "/iris/v1/apps/app-1/resolutionCenterThreads", status: http.StatusOK, body: webReviewDraftSingleThreadFixture},
+		{method: http.MethodGet, path: "/iris/v1/resolutionCenterThreads/thread-1/resolutionCenterDraftMessage", status: http.StatusOK, body: `{}`},
+	})
+	command := webReviewDraftCommand(t, "create", "--app", "app-1", "--thread-id", "thread-1", "--message", "new", "--confirm", "--output", "json")
+	var commandErr error
+	stdout, _ := captureOutput(t, func() { commandErr = command.Exec(context.Background(), nil) })
+	if commandErr == nil {
+		t.Fatalf("expected missing data error, got %v", commandErr)
+	}
+	if stdout != "" || len(*requested) != 2 {
+		t.Fatalf("expected no receipt or POST, got stdout=%q requests=%#v", stdout, *requested)
+	}
+}
+
+func TestWebReviewDraftDeleteRejectsMissingVerificationData(t *testing.T) {
+	requested := stubWebReviewDraftSequence(t, []webReviewDraftHTTPResponse{
+		{method: http.MethodGet, path: "/iris/v1/apps/app-1/resolutionCenterThreads", status: http.StatusOK, body: webReviewDraftSingleThreadFixture},
+		{method: http.MethodGet, path: "/iris/v1/resolutionCenterThreads/thread-1/resolutionCenterDraftMessage", status: http.StatusOK, body: webReviewDraftResponse("draft-1", "old")},
+		{method: http.MethodDelete, path: "/iris/v1/resolutionCenterDraftMessages/draft-1", status: http.StatusNoContent},
+		{method: http.MethodGet, path: "/iris/v1/resolutionCenterThreads/thread-1/resolutionCenterDraftMessage", status: http.StatusOK, body: `{}`},
+	})
+	command := webReviewDraftCommand(t, "delete", "--app", "app-1", "--thread-id", "thread-1", "--draft-id", "draft-1", "--confirm", "--output", "json")
+	var commandErr error
+	stdout, _ := captureOutput(t, func() { commandErr = command.Exec(context.Background(), nil) })
+	if commandErr == nil || !strings.Contains(commandErr.Error(), "post-read verification failed; do not retry automatically") {
+		t.Fatalf("expected unverified deletion error, got %v", commandErr)
+	}
+	if stdout != "" || len(*requested) != 4 {
+		t.Fatalf("expected no receipt or retry, got stdout=%q requests=%#v", stdout, *requested)
+	}
+}
+
 func TestWebReviewDraftUpdateRefusesMismatchedExistingDraftBeforeWrite(t *testing.T) {
 	requested := stubWebReviewDraftSequence(t, []webReviewDraftHTTPResponse{
 		{method: http.MethodGet, path: "/iris/v1/apps/app-1/resolutionCenterThreads", status: http.StatusOK, body: webReviewDraftSingleThreadFixture},

--- a/internal/web/review.go
+++ b/internal/web/review.go
@@ -672,8 +672,11 @@ func (c *Client) GetResolutionCenterDraftMessage(ctx context.Context, threadID s
 		return nil, fmt.Errorf("failed to parse resolution center draft message response: %w", err)
 	}
 	trimmedData := bytes.TrimSpace(payload.Data)
-	if len(trimmedData) == 0 || bytes.Equal(trimmedData, []byte("null")) {
+	if bytes.Equal(trimmedData, []byte("null")) {
 		return nil, nil
+	}
+	if len(trimmedData) == 0 {
+		return nil, fmt.Errorf("resolution center draft message response did not include data")
 	}
 	var resource jsonAPIResource
 	if err := json.Unmarshal(trimmedData, &resource); err != nil {

--- a/internal/web/review_app_threads_test.go
+++ b/internal/web/review_app_threads_test.go
@@ -306,7 +306,6 @@ func TestGetResolutionCenterDraftMessageReportsAbsentDraft(t *testing.T) {
 		body   string
 	}{
 		{name: "null data", status: http.StatusOK, body: `{"data": null}`},
-		{name: "missing data", status: http.StatusOK, body: `{}`},
 		{name: "not found", status: http.StatusNotFound, body: `{"errors": [{"code": "NOT_FOUND"}]}`},
 	}
 
@@ -327,6 +326,19 @@ func TestGetResolutionCenterDraftMessageReportsAbsentDraft(t *testing.T) {
 				t.Fatalf("expected no draft message, got %#v", draft)
 			}
 		})
+	}
+}
+
+func TestGetResolutionCenterDraftMessageRejectsMissingData(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	draft, err := testWebClient(server).GetResolutionCenterDraftMessage(context.Background(), "thread-1", false)
+	if err == nil {
+		t.Fatalf("expected missing data error, got draft=%#v err=%v", draft, err)
 	}
 }
 


### PR DESCRIPTION
A successful draft read that omits `data` was treated as an absent draft. This let `drafts create` write after an inconclusive preflight and let `drafts delete` print `verified: true` without evidence that deletion succeeded.

Reject incomplete draft responses while preserving the captured absence contract: explicit `data: null` or a relationship 404. Regression coverage proves that create stops before POST and delete returns an unverified error without a success receipt or retry.

Related to #566. Attachment upload remains blocked on a captured reserve/upload/commit contract and an authorized disposable fixture. No message or draft write was sent to Apple.

Validation: focused RED/GREEN regressions; build, format, documentation checks, lint and full tests; uncommitted and full-branch Codex reviews. A read-only check of the disposable app returned zero review threads, so live draft-write acceptance remains unverified.
