### PR TITLE
fix(web): protect individual key files from inherited ACLs

### DIFF
--- a/internal/cli/web/web_api_keys_individual.go
+++ b/internal/cli/web/web_api_keys_individual.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -164,7 +165,7 @@ Examples:
 				return fmt.Errorf("prepare individual API key staging path; remote create was not attempted: %w", err)
 			}
 			stagedPath := filepath.Join(outputRoot.Path(), stagedName)
-			if err := outputRoot.CreateNewFile(stagedName, privatePEM, 0o600); err != nil {
+			if err := stageIndividualAPIKey(outputRoot, stagedName, privatePEM); err != nil {
 				return fmt.Errorf("stage individual API key private artifact at %q; remote create was not attempted: %w", stagedPath, err)
 			}
 
@@ -260,6 +261,27 @@ func resolveCreatedIndividualAPIKey(existingIDs map[string]struct{}, keys []webc
 		return nil, fmt.Errorf("created individual API key could not be identified unambiguously: no newly active key was returned")
 	}
 	return candidate, nil
+}
+
+func stageIndividualAPIKey(root rootfs.Root, name string, privatePEM []byte) (err error) {
+	opened, err := root.OpenRoot()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err = errors.Join(err, opened.Close())
+	}()
+	_, err = shared.SafeWriteFileNoSymlinkWithPreparationAndCreatorInRoot(
+		opened, filepath.Join(root.Path(), name), name, 0o600, false,
+		".asc-api-key-private-*.p8", "",
+		func(file *os.File) error { return secureopen.PreparePrivateFile(file, 0o600) },
+		secureopen.OpenNewPrivateFileNoFollowInRoot,
+		func(file *os.File) (int64, error) {
+			written, writeErr := file.Write(privatePEM)
+			return int64(written), writeErr
+		},
+	)
+	return err
 }
 
 func newIndividualAPIKeyStagingName() (string, error) {

--- a/internal/cli/web/web_api_keys_individual_acl_darwin_test.go
+++ b/internal/cli/web/web_api_keys_individual_acl_darwin_test.go
@@ -1,0 +1,29 @@
+//go:build darwin
+
+package web
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWebAPIKeysCreateIndividualDoesNotInheritReadAccess(t *testing.T) {
+	directory := t.TempDir()
+	output, err := exec.Command("/bin/chmod", "+a", "everyone allow read,file_inherit", directory).CombinedOutput()
+	if err != nil {
+		t.Fatalf("apply inheritable ACL: %v (%s)", err, strings.TrimSpace(string(output)))
+	}
+	testWebAPIKeysCreateIndividualGeneratesAndRegistersP8(t, directory)
+	output, err = exec.Command("/bin/ls", "-le", filepath.Join(directory, "ApiKey_IND-1.p8")).CombinedOutput()
+	if err != nil {
+		t.Fatalf("inspect artifact ACL: %v", err)
+	}
+	for _, line := range strings.Split(string(output), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) > 0 && strings.HasSuffix(fields[0], ":") {
+			t.Fatal("private artifact retained an inherited ACL granting read access")
+		}
+	}
+}

--- a/internal/cli/web/web_api_keys_individual_test.go
+++ b/internal/cli/web/web_api_keys_individual_test.go
@@ -128,8 +128,12 @@ func TestWebAPIKeysCreateIndividualUnsupportedPublicationDoesNotCreate(t *testin
 }
 
 func TestWebAPIKeysCreateIndividualGeneratesAndRegistersP8(t *testing.T) {
+	testWebAPIKeysCreateIndividualGeneratesAndRegistersP8(t, t.TempDir())
+}
+
+func testWebAPIKeysCreateIndividualGeneratesAndRegistersP8(t *testing.T, outputDir string) {
+	t.Helper()
 	t.Setenv("ASC_WEB_MIN_REQUEST_INTERVAL", "0")
-	outputDir := t.TempDir()
 	requestCount := 0
 	postCreated := false
 	var registeredPublicKey string


### PR DESCRIPTION
An inherited directory ACL could grant read access to an individual API key's P8 even when its file mode was `0600`. Stage the P8 through the existing private-file creator and permission preparation before writing secret bytes, preserving the pinned output directory, no-replace publication, and recovery artifacts.

The macOS regression runs the full creation command against local HTTP fixtures in a directory with an inherited read ACL, then inspects the generated P8. It fails before the fix and passes afterward.

Validation: focused individual-key tests, `make build`, `make format`, `make check-docs`, `make lint`, and `ASC_BYPASS_KEYCHAIN=1 make test` passed. Both prescribed Codex reviews found no actionable defects, including the final committed branch against current `main`.

Related to #2283. This fixes local private-file protection only. Apple acceptance of individual-key creation remains unverified; no live Apple mutation was performed.
