### PR TITLE
feat(web): run selected reads with ephemeral sessions

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,6 +43,7 @@ func RootCommand(version string) *ffcli.Command {
 	catalog := registry.NewCatalog(version)
 	root := newRootCommand(version, catalog.All())
 	catalog.SetCompletionRootFlagSet(root.FlagSet)
+	wrapEphemeralSessionCommands(root)
 	return root
 }
 
@@ -66,6 +67,7 @@ func rootCommandForArgs(version string, args []string) *ffcli.Command {
 			break
 		}
 	}
+	wrapEphemeralSessionCommands(root)
 	return root
 }
 
@@ -86,6 +88,7 @@ func newRootCommand(version string, subcommands []*ffcli.Command) *ffcli.Command
 	}
 
 	root.FlagSet.BoolVar(&versionRequested, "version", false, "Print version and exit")
+	root.FlagSet.Bool("experimental-web-session", false, "[experimental] Use ASC_WEB_SESSION in memory for web removed-apps list and web api-keys list/view")
 	shared.BindRootFlags(root.FlagSet)
 
 	var (

--- a/cmd/web_ephemeral_session.go
+++ b/cmd/web_ephemeral_session.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"context"
+	"flag"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	webcli "github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/web"
+)
+
+func wrapEphemeralSessionCommands(root *ffcli.Command) {
+	mode := root.FlagSet.Lookup("experimental-web-session").Value.(flag.Getter)
+	var wrap func(*ffcli.Command, string)
+	wrap = func(command *ffcli.Command, path string) {
+		for _, child := range command.Subcommands {
+			wrap(child, path+" "+child.Name)
+		}
+		if command.Exec == nil {
+			return
+		}
+		exec := command.Exec
+		command.Exec = func(ctx context.Context, args []string) error {
+			if mode.Get().(bool) {
+				var err error
+				ctx, err = webcli.ContextWithEphemeralSession(ctx, path, command.FlagSet)
+				if err != nil {
+					return err
+				}
+			}
+			return exec(ctx, args)
+		}
+	}
+	for _, command := range root.Subcommands {
+		wrap(command, root.Name+" "+command.Name)
+	}
+}

--- a/commands/web.mdx
+++ b/commands/web.mdx
@@ -148,9 +148,10 @@ account. The imported session becomes the last cached session.
 Use `--from-env` to read the same versioned `asc-web-session` JSON bundle from
 the fixed `ASC_WEB_SESSION` variable when a CI secret store provides
 environment input. The flag is explicit and mutually exclusive with `--file`;
-an environment value is ignored by other commands and by import unless the
-flag is present. Raw cookie headers, opaque tokens, provider values, CSRF
-values, and other environment variables are not accepted. The import receipt's
+an environment value is ignored unless `--from-env` or the explicitly scoped
+`--experimental-web-session` mode below is present. Raw cookie headers, opaque
+tokens, provider values, CSRF values, and other environment variables are not
+accepted. The import receipt's
 `path` is the fixed `ASC_WEB_SESSION` source marker in this mode. Environment
 values use the same versioned bundle schema and 1 MiB parser ceiling. Process
 launchers and operating systems can impose lower per-value or total-environment
@@ -172,6 +173,48 @@ belongs to the named account or remains accepted by Apple.
 Isolate tests and automation with `ASC_WEB_SESSION_CACHE_DIR` and
 `ASC_WEB_SESSION_CACHE_BACKEND=file`. An unset or `auto` backend still falls
 back to the keychain when the file cache is empty.
+
+### Temporary environment sessions [experimental]
+
+For a read that must not persist credentials, supply the canonical bundle through
+`ASC_WEB_SESSION` and place `--experimental-web-session` before the command:
+
+```bash
+asc --experimental-web-session web removed-apps list --output json
+asc --experimental-web-session web api-keys list --output json
+asc --experimental-web-session web api-keys view --key-id KEY_ID --output json
+```
+
+These are the complete supported command set. Other commands, including command
+groups, reject the mode with exit code `2` before reading credentials or contacting
+Apple. Explicit `--help` and the root `--version` flag remain local actions. This
+flag never substitutes cookies for public API-key authentication. Without the
+flag, existing cached-session behavior and explicit import remain unchanged.
+
+The value must be the same versioned `asc-web-session` JSON bundle accepted by
+`web auth import --from-env`, with the same 1 MiB ceiling and operating-system
+environment limits. It is not a raw cookie header or an opaque token. The CLI
+validates a temporary cookie jar with Apple's session endpoint and requires the
+returned Apple Account to match the bundle before making the requested read.
+`--apple-id`, when supplied, must also match the bundle. Invalid input returns
+exit code `2`; failed live validation returns a runtime error without executing
+the read. There is no web-session cache or keychain access, login, 2FA, automatic
+reauthentication, or session persistence in this mode. Supply a fresh canonical
+bundle if validation fails.
+
+The read uses the provider already selected in Apple's session response. Provider
+switching is unsupported: `--provider-id` and `--public-provider-id` are rejected,
+even when explicitly passed an empty or zero value. `--two-factor-code-command`
+is also rejected. Nonempty `ASC_WEB_SESSION_PROVIDER` and `ASC_WEB_SESSION_CSRF`
+values are rejected without echoing their contents. Required Iris headers remain
+owned by the existing endpoint clients; this mode does not accept or inject CSRF
+tokens and does not support Developer Portal commands.
+
+Treat the environment bundle as a password: use your CI secret store, mask the
+value, and disable shell tracing. Session material is not printed, including in
+`--api-debug` output. Command output retains its existing format and may contain
+private app or API-key metadata; key material is never printed. For the full
+cached web workflow, use the existing explicit import commands instead.
 
 ### `asc web agreements`
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -25,6 +25,7 @@ asc <subcommand> [flags]
 
 - `--api-debug` - Enable HTTP debug logging to stderr (redacts sensitive values)
 - `--debug` - Enable debug logging to stderr
+- `--experimental-web-session` - [experimental] Use ASC_WEB_SESSION in memory for web removed-apps list and web api-keys list/view (default: false)
 - `--profile` - Use named authentication profile
 - `--report` - Report format for CI output (e.g., junit)
 - `--report-file` - Path to write CI report file

--- a/internal/cli/cmdtest/web_ephemeral_session_test.go
+++ b/internal/cli/cmdtest/web_ephemeral_session_test.go
@@ -1,0 +1,231 @@
+package cmdtest
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	cmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+)
+
+type ephemeralSessionTransport func(*http.Request) (*http.Response, error)
+
+func (f ephemeralSessionTransport) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func ephemeralSessionFixture(t *testing.T, status int, email string) (*[]string, string) {
+	t.Helper()
+	cache := isolateWebSessionCache(t)
+	t.Setenv("ASC_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
+	t.Setenv("ASC_WEB_SESSION", webSessionBundleFixture)
+	t.Setenv("ASC_WEB_SESSION_PROVIDER", "")
+	t.Setenv("ASC_WEB_SESSION_CSRF", "")
+	for _, name := range []string{"ASC_PROFILE", "ASC_KEY_ID", "ASC_ISSUER_ID", "ASC_PRIVATE_KEY_PATH", "ASC_PRIVATE_KEY", "ASC_PRIVATE_KEY_B64", "ASC_STRICT_AUTH"} {
+		t.Setenv(name, "")
+	}
+	requests := []string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Method+" "+r.URL.Path)
+		if r.Method != http.MethodGet {
+			t.Errorf("unexpected mutation: %s", r.Method)
+		}
+		cookie, err := r.Cookie("myacinfo")
+		if err != nil || cookie.Value != "super-secret-token" {
+			t.Error("request missing supplied session cookie")
+		}
+		if r.Header.Get("Authorization") != "" {
+			t.Error("unexpected JWT authentication")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/olympus/v1/session":
+			w.WriteHeader(status)
+			_, _ = fmt.Fprintf(w, `{"provider":{"providerId":42,"publicProviderId":"team-42"},"user":{"emailAddress":%q}}`, email)
+		case "/iris/v1/apps":
+			if r.URL.Query().Get("filter[removed]") != "true" {
+				t.Error("missing removed filter")
+			}
+			_, _ = fmt.Fprint(w, `{"data":[{"id":"app-1","type":"apps","attributes":{"name":"Removed app","bundleId":"com.example.app"}}]}`)
+		case "/iris/v1/apiKeys/key-1":
+			_, _ = fmt.Fprint(w, `{"data":{"id":"key-1","type":"apiKeys","attributes":{"nickname":"Automation","isActive":true}}}`)
+		case "/iris/v1/apiKeys", "/iris/v2/apiKeys":
+			_, _ = fmt.Fprint(w, `{"data":[]}`)
+		default:
+			t.Errorf("unexpected route: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+	target, _ := url.Parse(server.URL)
+	transport := http.DefaultTransport
+	installDefaultTransport(t, ephemeralSessionTransport(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Scheme != "https" || r.URL.Host != "appstoreconnect.apple.com" {
+			t.Fatalf("unexpected origin: %s", r.URL.Host)
+		}
+		clone := r.Clone(r.Context())
+		clone.URL.Scheme, clone.URL.Host = target.Scheme, target.Host
+		return transport.RoundTrip(clone)
+	}))
+	return &requests, cache
+}
+
+func TestExperimentalWebSessionReadAllowlist(t *testing.T) {
+	for _, tc := range []struct {
+		args, paths []string
+		result      string
+	}{
+		{[]string{"web", "removed-apps", "list"}, []string{"GET /olympus/v1/session", "GET /iris/v1/apps"}, "app-1"},
+		{[]string{"web", "api-keys", "list"}, []string{"GET /olympus/v1/session", "GET /iris/v1/apiKeys", "GET /iris/v2/apiKeys"}, "[]"},
+		{[]string{"web", "api-keys", "view", "--key-id", "key-1"}, []string{"GET /olympus/v1/session", "GET /iris/v1/apiKeys/key-1"}, "key-1"},
+	} {
+		t.Run(strings.Join(tc.args, " "), func(t *testing.T) {
+			requests, cache := ephemeralSessionFixture(t, http.StatusOK, "user@example.com")
+			debugFlag := cmd.RootCommand("test").FlagSet.Lookup("api-debug").Value.(*shared.OptionalBool)
+			previousDebugFlag := *debugFlag
+			t.Cleanup(func() {
+				*debugFlag = previousDebugFlag
+				shared.ApplyRootLoggingOverrides()
+			})
+			// An unusable cache backend must not prevent ephemeral execution.
+			t.Setenv("ASC_WEB_SESSION_CACHE_BACKEND", "off")
+			args := append([]string{"--experimental-web-session", "--api-debug"}, tc.args...)
+			args = append(args, "--output", "json")
+			var code int
+			stdout, stderr := captureOutput(t, func() { code = cmd.Run(args, "test") })
+			if code != 0 {
+				t.Fatalf("exit=%d stdout=%q stderr=%q", code, stdout, stderr)
+			}
+			if !json.Valid([]byte(stdout)) || !strings.Contains(stdout, tc.result) {
+				t.Fatalf("unexpected output %q", stdout)
+			}
+			if !reflect.DeepEqual(*requests, tc.paths) {
+				t.Fatalf("requests=%v, want %v", *requests, tc.paths)
+			}
+			assertEphemeralSessionUnchanged(t, cache, stdout+stderr)
+		})
+	}
+}
+
+func assertEphemeralSessionUnchanged(t *testing.T, cache, output string) {
+	t.Helper()
+	if strings.Contains(output, "super-secret-token") || strings.Contains(output, "override-secret") {
+		t.Fatal("session secret appeared in output")
+	}
+	entries, err := os.ReadDir(cache)
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("cache changed: entries=%v err=%v", entries, err)
+	}
+}
+
+func TestExperimentalWebSessionRejectsBeforeRequests(t *testing.T) {
+	for _, tc := range []struct {
+		name                   string
+		args                   []string
+		env, value, diagnostic string
+	}{
+		{"public", []string{"apps", "list"}, "", "", "does not support --experimental-web-session"},
+		{"executable group", []string{"validate", "--app", "app-1", "--version", "1.0"}, "", "", "does not support --experimental-web-session"},
+		{"group", []string{"web", "api-keys"}, "", "", "does not support --experimental-web-session"},
+		{"mutation", []string{"web", "api-keys", "create", "--name", "test"}, "", "", "does not support --experimental-web-session"},
+		{"import", []string{"web", "auth", "import", "--from-env"}, "", "", "does not support --experimental-web-session"},
+		{"missing", []string{"web", "removed-apps", "list"}, "ASC_WEB_SESSION", "", "ASC_WEB_SESSION is unset or empty"},
+		{"invalid", []string{"web", "removed-apps", "list"}, "ASC_WEB_SESSION", "override-secret", "invalid session bundle"},
+		{"unknown credential field", []string{"web", "removed-apps", "list"}, "ASC_WEB_SESSION", strings.Replace(webSessionBundleFixture, `"version": 1,`, `"version": 1, "override-secret": true,`, 1), "invalid session bundle"},
+		{"oversize", []string{"web", "removed-apps", "list"}, "ASC_WEB_SESSION", strings.Repeat("x", (1<<20)+1), "exceeds"},
+		{"provider env", []string{"web", "removed-apps", "list"}, "ASC_WEB_SESSION_PROVIDER", "override-secret", "ASC_WEB_SESSION_PROVIDER is unsupported"},
+		{"csrf env", []string{"web", "removed-apps", "list"}, "ASC_WEB_SESSION_CSRF", "override-secret", "ASC_WEB_SESSION_CSRF is unsupported"},
+		{"provider flag", []string{"web", "removed-apps", "list", "--provider-id", "42"}, "", "", "--provider-id is unsupported"},
+		{"zero provider flag", []string{"web", "removed-apps", "list", "--provider-id", "0"}, "", "", "--provider-id is unsupported"},
+		{"public provider flag", []string{"web", "removed-apps", "list", "--public-provider-id", "team-42"}, "", "", "--public-provider-id is unsupported"},
+		{"2fa command", []string{"web", "removed-apps", "list", "--two-factor-code-command", "echo override-secret"}, "", "", "--two-factor-code-command is unsupported"},
+		{"apple id", []string{"web", "removed-apps", "list", "--apple-id", "other@example.com"}, "", "", "does not match --apple-id"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			requests, cache := ephemeralSessionFixture(t, 200, "user@example.com")
+			if tc.env != "" {
+				t.Setenv(tc.env, tc.value)
+			}
+			var code int
+			stdout, stderr := captureOutput(t, func() { code = cmd.Run(append([]string{"--experimental-web-session"}, tc.args...), "test") })
+			if code != 2 || !strings.Contains(stderr, tc.diagnostic) {
+				t.Fatalf("exit=%d stderr=%q", code, stderr)
+			}
+			if len(*requests) != 0 {
+				t.Fatalf("unexpected requests: %v", *requests)
+			}
+			assertEphemeralSessionUnchanged(t, cache, stdout+stderr)
+		})
+	}
+}
+
+func TestExperimentalWebSessionValidationFailure(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status int
+		email  string
+	}{
+		{"expired", 401, "user@example.com"}, {"mismatch", 200, "other@example.com"}, {"identity missing", 200, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			requests, cache := ephemeralSessionFixture(t, tc.status, tc.email)
+			var code int
+			stdout, stderr := captureOutput(t, func() { code = cmd.Run([]string{"--experimental-web-session", "web", "removed-apps", "list"}, "test") })
+			if code == 0 || !strings.Contains(stderr, "session validation failed") {
+				t.Fatalf("exit=%d stderr=%q", code, stderr)
+			}
+			if !reflect.DeepEqual(*requests, []string{"GET /olympus/v1/session"}) {
+				t.Fatalf("requests=%v", *requests)
+			}
+			assertEphemeralSessionUnchanged(t, cache, stdout+stderr)
+		})
+	}
+}
+
+func TestExperimentalWebSessionRequiresExplicitOptIn(t *testing.T) {
+	for _, prefix := range [][]string{nil, {"--experimental-web-session=false"}, {"--experimental-web-session", "false"}} {
+		t.Run(strings.Join(prefix, " "), func(t *testing.T) {
+			requests, cache := ephemeralSessionFixture(t, 200, "user@example.com")
+			t.Setenv("ASC_WEB_SESSION_CACHE_BACKEND", "off")
+			var code int
+			stdout, stderr := captureOutput(t, func() {
+				code = cmd.Run(append(prefix, "web", "removed-apps", "list"), "test")
+			})
+			if code == 0 || strings.Contains(stderr, "ephemeral") {
+				t.Fatalf("implicit session mode: exit=%d stderr=%q", code, stderr)
+			}
+			if len(*requests) != 0 {
+				t.Fatalf("implicit session requests: %v", *requests)
+			}
+			assertEphemeralSessionUnchanged(t, cache, stdout+stderr)
+		})
+	}
+}
+
+func TestExperimentalWebSessionHelpDoesNotReadCredentials(t *testing.T) {
+	for _, args := range [][]string{
+		{"--help"}, {"--version"}, {"apps", "list", "--help"}, {"web", "api-keys", "--help"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			requests, cache := ephemeralSessionFixture(t, 200, "user@example.com")
+			t.Setenv("ASC_WEB_SESSION", "override-secret")
+			var code int
+			stdout, stderr := captureOutput(t, func() {
+				code = cmd.Run(append([]string{"--experimental-web-session"}, args...), "test")
+			})
+			if code != 0 || stdout == "" {
+				t.Fatalf("exit=%d stdout=%q stderr=%q", code, stdout, stderr)
+			}
+			if len(*requests) != 0 {
+				t.Fatalf("help requests: %v", *requests)
+			}
+			assertEphemeralSessionUnchanged(t, cache, stdout+stderr)
+		})
+	}
+}

--- a/internal/cli/docs/templates/ASC.md
+++ b/internal/cli/docs/templates/ASC.md
@@ -209,6 +209,7 @@ Use `asc <command> --help` for subcommands and flags.
 
 - `--api-debug` - HTTP request/response logging (redacted)
 - `--debug` - Debug logging
+- `--experimental-web-session` - Use canonical ASC_WEB_SESSION in memory for web removed-apps list and web api-keys list/view only
 - `--profile` - Use a named authentication profile
 - `--report` - Report format for CI output
 - `--report-file` - Path to write CI report file

--- a/internal/cli/web/web_ephemeral_session.go
+++ b/internal/cli/web/web_ephemeral_session.go
@@ -1,0 +1,68 @@
+package web
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	webcore "github.com/rudrankriyam/App-Store-Connect-CLI/internal/web"
+)
+
+type ephemeralSessionContextKey struct{}
+
+// ContextWithEphemeralSession gates the exact read-only command surface before
+// credential access. The marker selects a resolver that cannot persist or log in.
+func ContextWithEphemeralSession(ctx context.Context, command string, fs *flag.FlagSet) (context.Context, error) {
+	switch command {
+	case "asc web removed-apps list", "asc web api-keys list", "asc web api-keys view":
+	default:
+		return nil, shared.UsageError(command + " does not support --experimental-web-session")
+	}
+	var unsupported string
+	fs.Visit(func(f *flag.Flag) {
+		switch f.Name {
+		case "provider-id", "public-provider-id", "two-factor-code-command":
+			if unsupported == "" {
+				unsupported = f.Name
+			}
+		}
+	})
+	if unsupported != "" {
+		return nil, shared.UsageError("--" + unsupported + " is unsupported with --experimental-web-session")
+	}
+	return context.WithValue(ctx, ephemeralSessionContextKey{}, true), nil
+}
+
+func resolveEphemeralWebSession(ctx context.Context, appleID string) (*webcore.AuthSession, error) {
+	for _, name := range []string{"ASC_WEB_SESSION_PROVIDER", "ASC_WEB_SESSION_CSRF"} {
+		if os.Getenv(name) != "" {
+			return nil, shared.UsageError(name + " is unsupported with --experimental-web-session")
+		}
+	}
+	value := os.Getenv(webSessionBundleEnvName)
+	if strings.TrimSpace(value) == "" {
+		return nil, shared.UsageError(webSessionBundleEnvName + " is unset or empty when --experimental-web-session is used")
+	}
+	if len(value) > webcore.MaxSessionBundleSize {
+		return nil, shared.UsageError(fmt.Sprintf("%s exceeds %d-byte limit", webSessionBundleEnvName, webcore.MaxSessionBundleSize))
+	}
+	bundle, err := webcore.DecodeSessionBundle([]byte(value))
+	if err != nil {
+		// Decoder errors may contain caller-controlled credential fields.
+		return nil, shared.UsageError("invalid session bundle from " + webSessionBundleEnvName)
+	}
+	if appleID = strings.TrimSpace(appleID); appleID != "" && !strings.EqualFold(appleID, strings.TrimSpace(bundle.AppleID)) {
+		return nil, shared.UsageError("session bundle does not match --apple-id")
+	}
+	shared.ApplyRootLoggingOverrides()
+	validationCtx, cancel := newWebRequestContext(ctx)
+	defer cancel()
+	session, err := webcore.OpenValidatedSessionBundle(validationCtx, bundle)
+	if err != nil {
+		return nil, fmt.Errorf("ephemeral web session validation failed; supply a fresh canonical ASC_WEB_SESSION bundle")
+	}
+	return session, nil
+}

--- a/internal/cli/web/web_session_flags.go
+++ b/internal/cli/web/web_session_flags.go
@@ -44,6 +44,11 @@ func newWebRequestContext(ctx context.Context) (context.Context, context.CancelF
 // a request context whose timeout starts only once authentication is done; the
 // returned cancel func is never nil, so it is safe to defer before checking err.
 func resolveWebSessionForCommand(ctx context.Context, flags webSessionFlags) (*webcore.AuthSession, context.Context, context.CancelFunc, error) {
+	if ephemeral, _ := ctx.Value(ephemeralSessionContextKey{}).(bool); ephemeral {
+		session, err := resolveEphemeralWebSession(ctx, *flags.appleID)
+		requestCtx, cancel := newWebRequestContext(ctx)
+		return session, requestCtx, cancel, err
+	}
 	selection := providerSelectionFromFlags(flags)
 	session, _, err := callResolveSessionForProviderSelection(
 		ctx,

--- a/internal/web/session_transfer.go
+++ b/internal/web/session_transfer.go
@@ -499,35 +499,45 @@ func (b *SessionBundle) normalize(now time.Time) (persistedSession, SessionImpor
 // caller can persist the bundle afterwards with ImportSessionBundleWithOptions
 // when this explicit preflight succeeds.
 func ValidateSessionBundle(ctx context.Context, bundle *SessionBundle) error {
+	_, err := OpenValidatedSessionBundle(ctx, bundle)
+	return err
+}
+
+// OpenValidatedSessionBundle validates a bundle with Apple and returns its
+// in-memory session. It never reads or writes the cache, logs in, or switches
+// providers. The returned provider identity comes from Apple's session response.
+func OpenValidatedSessionBundle(ctx context.Context, bundle *SessionBundle) (*AuthSession, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	if bundle == nil {
-		return fmt.Errorf("%w: web session bundle is empty", ErrSessionBundleValidationFailed)
+		return nil, fmt.Errorf("%w: web session bundle is empty", ErrSessionBundleValidationFailed)
 	}
 
 	sess, _, err := bundle.normalize(time.Now().UTC())
 	if err != nil {
-		return fmt.Errorf("%w: %w", ErrSessionBundleValidationFailed, err)
+		return nil, fmt.Errorf("%w: %w", ErrSessionBundleValidationFailed, err)
 	}
 
-	_, info, ok, err := validatePersistedSessionReadOnly(ctx, sess)
+	client, info, ok, err := validatePersistedSessionReadOnly(ctx, sess)
 	if err != nil {
-		return fmt.Errorf("%w: %w", ErrSessionBundleValidationFailed, err)
+		return nil, fmt.Errorf("%w: %w", ErrSessionBundleValidationFailed, err)
 	}
 	if !ok || info == nil {
-		return fmt.Errorf("%w: %w", ErrSessionBundleValidationFailed, ErrSessionBundleUnusable)
+		return nil, fmt.Errorf("%w: %w", ErrSessionBundleValidationFailed, ErrSessionBundleUnusable)
 	}
 
 	expected := strings.TrimSpace(bundle.AppleID)
 	actual := strings.TrimSpace(info.User.EmailAddress)
 	if actual == "" {
-		return fmt.Errorf("%w: Apple session returned no Apple Account identity", ErrSessionBundleValidationFailed)
+		return nil, fmt.Errorf("%w: Apple session returned no Apple Account identity", ErrSessionBundleValidationFailed)
 	}
 	if !strings.EqualFold(expected, actual) {
-		return fmt.Errorf("%w: Apple session account does not match the bundle", ErrSessionBundleValidationFailed)
+		return nil, fmt.Errorf("%w: Apple session account does not match the bundle", ErrSessionBundleValidationFailed)
 	}
-	return nil
+	session := &AuthSession{Client: client}
+	applySessionInfo(session, info)
+	return session, nil
 }
 
 // ImportSessionBundle stores a bundle in the same cache `asc web auth login`


### PR DESCRIPTION
## Summary

Add experimental `--experimental-web-session` for `web removed-apps list`, `web api-keys list`, and `web api-keys view`. These reads consume a canonical `ASC_WEB_SESSION` bundle in memory, validate its Apple account identity, and discard the session when the command finishes. This supports CI reads without importing credentials into the web-session cache.

The mode rejects all other executable commands and provider or CSRF overrides before the relevant operation. It does not log in, switch providers, persist cookies, or change the default authentication flow. The flag must precede the command.

Refs #567.

## Validation

- Regression coverage for all three readers, command gating including executable groups, malformed and oversized bundles, account mismatch, credential redaction, and unchanged cache state.
- `make build`, `make format`, `make check-docs`, `make lint`, and `ASC_BYPASS_KEYCHAIN=1 make test` passed; generated command documentation is current.
- Normal commit hooks and the prescribed pre-commit review passed.
- Final committed branch review against refreshed `origin/main` found no actionable defects. The reviewer sandbox could not run Go tests; the full suite and hooks passed separately.
- The final committed binary passed live Apple GETs for all three supported readers, including pagination, plus unsupported-command and account-mismatch rejection. Credential output checks passed, the file web-session cache was unchanged, and the temporary exported credential fixture was removed. No Apple mutations were performed.
