### PR TITLE
fix(web): renew request deadlines after interactive authentication

### DIFF
--- a/internal/cli/web/web_auth.go
+++ b/internal/cli/web/web_auth.go
@@ -581,6 +581,9 @@ func twoFactorSubmitFailure(err error, afterPhoneDelivery bool) error {
 }
 
 func loginWithOptionalTwoFactorUsing(ctx context.Context, progressMessage, appleID, password, twoFactorCode string, loginFn func(context.Context, webcore.LoginCredentials) (*webcore.AuthSession, error), twoFactorStarted func(), readCommandCode twoFactorCodeCommandReader, twoFactorCodeCommand ...string) (*webcore.AuthSession, error) {
+	// Credential/keychain prompts may consume the initial command budget.
+	ctx, cancel := shared.ContextWithTimeout(shared.ContextWithoutTimeout(ctx))
+	defer cancel()
 	session, err := withWebSpinnerValue(progressMessage, func() (*webcore.AuthSession, error) {
 		return loginFn(ctx, webcore.LoginCredentials{
 			Username: appleID,
@@ -1073,7 +1076,11 @@ func selectResolvedWebSessionProvider(ctx context.Context, session *webcore.Auth
 	if selection.ProviderID == 0 && strings.TrimSpace(selection.PublicProviderID) == "" {
 		return nil
 	}
-	if err := selectWebProviderFn(ctx, session, selection); err != nil {
+	// Interactive 2FA may outlive the request budget used to start login.
+	// Renew only the internal timeout, preserving caller cancellation.
+	providerCtx, cancel := shared.ContextWithTimeout(shared.ContextWithoutTimeout(ctx))
+	defer cancel()
+	if err := selectWebProviderFn(providerCtx, session, selection); err != nil {
 		return fmt.Errorf("web provider selection failed: %w", err)
 	}
 	if err := persistWebSessionFn(session); err != nil {

--- a/internal/cli/web/web_auth_test.go
+++ b/internal/cli/web/web_auth_test.go
@@ -831,6 +831,7 @@ func TestLoginWithOptionalTwoFactorUsesCommandWhenConfigured(t *testing.T) {
 }
 
 func TestLoginWithOptionalTwoFactorReappliesTimeoutAfterDelayedCommand(t *testing.T) {
+	t.Setenv("ASC_TIMEOUT", "30ms")
 	origLogin := webLoginFn
 	origPrepare := prepareTwoFactorChallengeFn
 	origEnsure := ensureTwoFactorCodeRequestedFn
@@ -3529,5 +3530,58 @@ func TestResolveSessionRetriesFreshLoginAfterRequestDeadlineExpired(t *testing.T
 	}
 	if session != freshSession || source != "fresh" {
 		t.Fatalf("expected the fresh session, got session=%p source=%q", session, source)
+	}
+}
+
+func TestProviderSelectionRenewsExpiredRequestBudget(t *testing.T) {
+	originalSelect, originalPersist := selectWebProviderFn, persistWebSessionFn
+	t.Cleanup(func() { selectWebProviderFn, persistWebSessionFn = originalSelect, originalPersist })
+	t.Setenv("ASC_TIMEOUT", "1s")
+	ctx, cancel := shared.ContextWithResolvedTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+	<-ctx.Done()
+	persisted := false
+	selectWebProviderFn = func(ctx context.Context, session *webcore.AuthSession, selection webcore.ProviderSelection) error {
+		return ctx.Err()
+	}
+	persistWebSessionFn = func(session *webcore.AuthSession) error { persisted = true; return nil }
+	if err := selectResolvedWebSessionProvider(ctx, &webcore.AuthSession{}, webcore.ProviderSelection{ProviderID: 7}); err != nil {
+		t.Fatal(err)
+	}
+	if !persisted {
+		t.Fatal("authenticated selected session was not persisted")
+	}
+}
+
+func TestProviderSelectionPreservesCallerCancellation(t *testing.T) {
+	originalSelect, originalPersist := selectWebProviderFn, persistWebSessionFn
+	t.Cleanup(func() { selectWebProviderFn, persistWebSessionFn = originalSelect, originalPersist })
+	parent, stop := context.WithCancel(context.Background())
+	ctx, cancel := shared.ContextWithTimeout(parent)
+	defer cancel()
+	stop()
+	selectWebProviderFn = func(ctx context.Context, session *webcore.AuthSession, selection webcore.ProviderSelection) error {
+		return ctx.Err()
+	}
+	persistWebSessionFn = func(session *webcore.AuthSession) error {
+		t.Fatal("must not persist after canceled selection")
+		return nil
+	}
+	if err := selectResolvedWebSessionProvider(ctx, &webcore.AuthSession{}, webcore.ProviderSelection{ProviderID: 7}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected cancellation, got %v", err)
+	}
+}
+
+func TestLoginRenewsBudgetAfterCredentialPrompt(t *testing.T) {
+	t.Setenv("ASC_TIMEOUT", "1s")
+	ctx, cancel := shared.ContextWithResolvedTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+	<-ctx.Done()
+	expected := &webcore.AuthSession{}
+	result, err := loginWithOptionalTwoFactorUsing(ctx, "test", "user@example.com", "test-only", "", func(ctx context.Context, creds webcore.LoginCredentials) (*webcore.AuthSession, error) {
+		return expected, ctx.Err()
+	}, nil, nil)
+	if err != nil || result != expected {
+		t.Fatalf("credential wait consumed login budget: %v", err)
 	}
 }


### PR DESCRIPTION
Interactive credential retrieval and 2FA entry can outlast the request context created at the start of `asc web auth login`. Verification already renews its timeout, but provider selection reuses the expired context. A correct code can therefore be followed by `web provider selection failed ... context deadline exceeded`, and the authenticated session is never persisted. A Keychain wait can consume the same budget before SRP login starts.

Renew the internal request budget when login starts after credential retrieval and when selecting the provider after authentication. Use the existing shared context helper so caller cancellation and caller-owned deadlines remain effective. Keep provider selection before persistence; flags, output shape and credentials are unchanged.

Validation:
- Reproduced expired-login and expired-provider failures with regression tests on current `main`, then passed with the fix; caller cancellation remains covered.
- Updated the delayed-2FA test to set its request budget explicitly, preserving its check that verification succeeds after the preceding budget expires.
- Live-tested the equivalent patch on 4.11.0: Apple accepted authentication, selected the intended provider, persisted the session, and a second invocation reused the cache without another OTP. The current-main port was tested locally without requesting another live challenge.

Companion workflow guidance: https://github.com/rorkai/app-store-connect-cli-skills/pull/77

Current-main checks passed: `make build`, `make format`, `make check-docs`, `make lint` (repository fallback to `go vet ./...`; golangci-lint is not installed), and `ASC_BYPASS_KEYCHAIN=1 GOFLAGS=-p=2 make test` (full suite).
