### PR TITLE
apps wall: add Guitar Wiz - Tuner & Chords

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -662,6 +662,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/0c/be/8b/0cbe8bfa-a36d-7ebb-6580-959481f43294/Grow-0-0-1x_U007ephone-0-0-0-1-0-0-sRGB-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Guitar Wiz - Tuner & Chords",
+    "link": "https://apps.apple.com/us/app/guitar-wiz-tuner-chords/id6740015002?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/fc/d0/65/fcd06547-95ac-9d05-23eb-c67ba81e52de/AppIcon-0-0-1x_U007epad-0-1-0-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Habit Tracker - HabitMax",
     "link": "https://apps.apple.com/us/app/habit-tracker-habitmax/id6752316720?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/1c/5a/13/1c5a13a5-02e5-30c8-a359-e49972d11582/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Guitar Wiz - Tuner & Chords` to the Wall of Apps

## Entry

- App ID: 6740015002
- App: Guitar Wiz - Tuner & Chords
- Link: https://apps.apple.com/us/app/guitar-wiz-tuner-chords/id6740015002?uo=4

## Notes

- Submitted via `asc apps wall submit`
