### PR TITLE
apps wall: add Tunable – Tuner & Metronome

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1821,6 +1821,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/ea/b1/01/eab10103-3a5d-9de7-5094-0e6233c9c034/AppIcon-1x_U007ephone-0-1-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "Tunable – Tuner & Metronome",
+    "link": "https://apps.apple.com/us/app/tunable-tuner-metronome/id608540795?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple115/v4/93/bd/99/93bd992d-825e-df5d-eedb-550eb17895c5/AppIcon-1x_U007emarketing-0-10-0-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "TV Show Tracker",
     "link": "https://apps.apple.com/us/app/tv-show-tracker-tv-club/id6497563903",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/43/b8/67/43b86702-f67b-c314-f65b-cd60980205b0/Icon-0-1x_U007epad-0-1-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Tunable – Tuner & Metronome` to the Wall of Apps

## Entry

- App ID: 608540795
- App: Tunable – Tuner & Metronome
- Link: https://apps.apple.com/us/app/tunable-tuner-metronome/id608540795?uo=4

## Notes

- Submitted via `asc apps wall submit`
