### PR TITLE
apps wall: add Gazolina - Prix Essence Gasoil

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -612,6 +612,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/fb/f2/5e/fbf25e58-55d1-77de-a0ad-a1e8488ab7d7/AppIcon-0-0-1x_U007epad-0-1-0-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Gazolina - Prix Essence Gasoil",
+    "link": "https://apps.apple.com/fr/app/gazolina-prix-essence-gasoil/id6757231174?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/3a/5d/48/3a5d4831-2f9a-7d7e-adfa-2e5eb7057c2f/AppIcon-0-0-1x_U007epad-0-1-0-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Gecko Med",
     "link": "https://apps.apple.com/us/app/gecko-med/id6737719743?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/63/4c/14/634c143e-7e6b-4afb-9748-0816af5d4544/apple-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Gazolina - Prix Essence Gasoil` to the Wall of Apps

## Entry

- App ID: 6757231174
- App: Gazolina - Prix Essence Gasoil
- Link: https://apps.apple.com/fr/app/gazolina-prix-essence-gasoil/id6757231174?uo=4

## Notes

- Submitted via `asc apps wall submit`
