### PR TITLE
apps wall: add BrainDrain: 1 Minute Journal

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -170,6 +170,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/f9/73/48/f9734812-afa3-83b4-4862-a9331863f84b/AppIcon-0-0-1x_U007epad-0-0-0-1-0-0-sRGB-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "BrainDrain: 1 Minute Journal",
+    "link": "https://apps.apple.com/us/app/braindrain-1-minute-journal/id6741376368?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/4b/ce/14/4bce140a-0e8c-3c4b-cba1-80288b5878ae/AppIcon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "BratVPN",
     "link": "https://apps.apple.com/us/app/bratvpn/id6759875957?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/29/91/b8/2991b84b-72ec-130e-071e-18f6fd175a44/AppIcon-0-0-1x_U007emarketing-0-11-0-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `BrainDrain: 1 Minute Journal` to the Wall of Apps

## Entry

- App ID: 6741376368
- App: BrainDrain: 1 Minute Journal
- Link: https://apps.apple.com/us/app/braindrain-1-minute-journal/id6741376368?uo=4

## Notes

- Submitted via `asc apps wall submit`
