### PR TITLE
apps wall: add Wordroot

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1966,6 +1966,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/eb/e9/b7/ebe9b79a-9dd1-d0a7-3bd9-ecb2a4517c83/AppIcon-0-0-1x_U007ephone-0-1-0-sRGB-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Wordroot",
+    "link": "https://apps.apple.com/us/app/wordroot/id6794988021?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/4b/9d/f9/4b9df903-d342-3152-ec35-c823dcd86bc6/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Wozi Vocabulary Builder",
     "link": "https://apps.apple.com/app/id1536585848",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/cd/33/e3/cd33e3a5-2c7d-34e8-5c22-07bca8f44d7d/WoziAppIcon-0-0-1x_U007epad-0-1-P3-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Wordroot` to the Wall of Apps

## Entry

- App ID: 6794988021
- App: Wordroot
- Link: https://apps.apple.com/us/app/wordroot/id6794988021?uo=4

## Notes

- Submitted via `asc apps wall submit`
