### PR TITLE
Add website changelog updates to the release workflow

### DIFF
--- a/.agents/skills/release-asc-cli/SKILL.md
+++ b/.agents/skills/release-asc-cli/SKILL.md
@@ -50,13 +50,50 @@ Verify:
 
 If the `winget` job failed, inspect its rate-limit preflight, retry history, and current submission state first. For a transient failure, prefer one rerun of the failed job before manual repair; dispatch the full workflow only after confirming it will safely reuse the existing release. Wait for the logged reset time only when the primary quota bucket is zero; back off a few minutes for secondary throttles, 5xx responses, or transport failures. After a failed retry or a non-transient error, report the exact blocker instead of looping. See `docs/WINGET.md`.
 
+## Update the website changelog
+
+After every published release, prepare the changelog update for the root `CHANGELOG.md` in [rorkai/asc-website](https://github.com/rorkai/asc-website). It is the single source for [asccli.sh/changelog](https://asccli.sh/changelog); keep all release history in that file, without separate archives or a second CLI-repository changelog. Apply it to the website checkout when website edits are authorized by the request or session. Otherwise draft the entry text in the release handoff and report the website update as pending; do not modify the website checkout.
+
+1. Build the release inventory from the previous published tag through the released tag, using GitHub release notes, merged PRs, and tagged source. Include only changes shipped in that release. Verify command names, flags, and migration replacements against the released binary's help or tagged source, not a newer checkout.
+2. With website-edit authority, locate the website checkout by its remote and follow its `AGENTS.md`. Work from current website `origin/main` in an isolated worktree when needed. Inspect an existing entry or pending changelog PR before resuming so the same release is not added twice.
+3. Add the version under its UTC publication month, newest first, using the GitHub release publication date. Preserve older entries and update the month navigation when a new month begins.
+4. Write the entry using the rules and examples below. Keep one release link and one previous-tag comparison link at the end, with migration-guide links where relevant.
+5. Run the website's `pnpm run lint` and `pnpm build`, plus `git diff --check`. Verify the new entry renders, month links work, prior releases remain, and no inline PR references were introduced. Require session authority explicitly covering each website write: PR creation, merge, and deployment. A CLI release request alone does not grant those permissions. If a later website write is not authorized, retain the authorized edits and report that pending step separately from the binary release.
+
+### Changelog writing rules
+
+- Use short, flat bullets under `New features`, `Improvements and fixes`, and `Breaking changes` as applicable; omit empty sections. Split unrelated changes into separate bullets and use domain subheadings for large releases.
+- Describe the concrete behavior and its user impact, usually in one or two sentences. Keep important features, fixes, limitations, confirmation requirements, output or exit-code changes, and actionable migration replacements.
+- Omit PR numbers, inline PR links, commit hashes, introductory paragraphs, and generic claims such as “improved reliability.” PRs are evidence for writing the notes, not visible labels in the notes.
+- Cover significant shipped changes individually. Group routine dependency, CI, test, and Wall of Apps updates where appropriate; the release and comparison links retain the complete source history.
+- Use backticks for commands, flags, environment variables, and JSON. Do not invent detail to expand a short entry or remove compatibility details merely to shorten a bullet.
+
+Example entry from the published 5.1.0 release (illustrative excerpt, not its complete notes):
+
+```markdown
+### 5.1.0 (2026-09-08)
+
+#### New features
+
+- `asc web api-keys list` accepts `--session-from-env` for CI reads.
+- `--session-from-env` reads `ASC_WEB_SESSION` in memory without changing the session cache or keychain.
+
+#### Improvements and fixes
+
+- Review-draft creation stops before writing when a successful preflight response omits `data`.
+
+[Release](https://github.com/rorkai/App-Store-Connect-CLI/releases/tag/5.1.0) · [Compare changes](https://github.com/rorkai/App-Store-Connect-CLI/compare/5.0.0...5.1.0)
+```
+
+Migration wording should name the replacement, for example: “App-scoped `--build-number` queries require `--platform` instead of assuming `IOS`.” Keep this behavior in its 5.0.0 entry; do not present historical examples as new changes in the next release.
+
 ## Draft the announcement
 
 Read [references/release-announcement.md](references/release-announcement.md) and prepare the announcement copy after the release is visibly published. Create an external Typefully draft only when the request or established context authorizes that write; otherwise return the copy locally. Never schedule or publish the post unless the user explicitly asks.
 
 ## Clean up and hand off
 
-Remove only a clean temporary release worktree created by this run as part of its authorized cleanup; preserve unexpected changes. Report the released commit and tag, release URL, artifact verification, Homebrew and WinGet state, remaining blockers, and announcement status separately. An optional external draft does not prevent reporting a verified binary release.
+Remove only a clean temporary release worktree created by this run as part of its authorized cleanup; preserve unexpected changes. Report the released commit and tag, release URL, artifact verification, Homebrew and WinGet state, remaining blockers, website changelog state (edited, PR opened, merged, or live), and announcement status separately. An optional external draft does not prevent reporting a verified binary release.
 
 ## Automation boundary
 


### PR DESCRIPTION
The release skill now includes a website changelog update after every published CLI release, using the single root `CHANGELOG.md` in `rorkai/asc-website`.

The guidance requires short behavior-focused bullets without PR numbers or inline PR links, preserves significant features, fixes, and migration details, and includes a historical example. It also covers release/date placement, month navigation, release comparisons, website validation, and separate reporting of binary and website publication state. Website writes require authority covering each step.

Validation: `ASC_BYPASS_KEYCHAIN=1 GOMAXPROCS=2 make check-docs`, the skill-creator validator, and the affected repository/skill validators passed. Both the final uncommitted review and the full-branch review against current `origin/main` found no actionable defects.
