### PR TITLE
fix: bootstrap app availability through the public API

### DIFF
--- a/internal/cli/cmdtest/pricing_availability_create_test.go
+++ b/internal/cli/cmdtest/pricing_availability_create_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -18,110 +19,123 @@ import (
 )
 
 func TestPricingAvailabilityCreate_SendsPublicAPIRequest(t *testing.T) {
-	setupAuth(t)
+	for _, available := range []bool{true, false} {
+		t.Run(strconv.FormatBool(available), func(t *testing.T) {
+			setupAuth(t)
 
-	requestCount := 0
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		requestCount++
-		if req.Method != http.MethodPost || req.URL.Path != "/v2/appAvailabilities" {
-			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
-		}
+			requestCount := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				requestCount++
+				if req.Method == http.MethodGet && req.URL.Path == "/v1/territories" {
+					w.Header().Set("Content-Type", "application/json")
+					if req.URL.Query().Get("cursor") == "next" {
+						_, _ = io.WriteString(w, `{"data":[{"type":"territories","id":"CAN"}],"links":{}}`)
+					} else {
+						_, _ = io.WriteString(w, `{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"FRA"}],"links":{"next":"https://api.appstoreconnect.apple.com/v1/territories?cursor=next"}}`)
+					}
+					return
+				}
+				if req.Method != http.MethodPost || req.URL.Path != "/v2/appAvailabilities" {
+					t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+				}
 
-		var payload asc.AppAvailabilityV2CreateRequest
-		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
-			t.Fatalf("decode request: %v", err)
-		}
-		if payload.Data.Relationships.App.Data.ID != "app-1" {
-			t.Fatalf("expected app-1, got %q", payload.Data.Relationships.App.Data.ID)
-		}
-		if payload.Data.Attributes == nil || payload.Data.Attributes.AvailableInNewTerritories == nil || !*payload.Data.Attributes.AvailableInNewTerritories {
-			t.Fatalf("expected availableInNewTerritories=true, got %#v", payload.Data.Attributes)
-		}
-		if payload.Data.Relationships.TerritoryAvailabilities == nil || len(payload.Data.Relationships.TerritoryAvailabilities.Data) != 2 {
-			t.Fatalf("expected two territory availability relationships, got %#v", payload.Data.Relationships.TerritoryAvailabilities)
-		}
-		if got := payload.Data.Relationships.TerritoryAvailabilities.Data[0].ID; got != "${local-usa}" {
-			t.Fatalf("expected first local ID ${local-usa}, got %q", got)
-		}
-		if got := payload.Data.Relationships.TerritoryAvailabilities.Data[1].ID; got != "${local-fra}" {
-			t.Fatalf("expected second local ID ${local-fra}, got %q", got)
-		}
-		if len(payload.Included) != 2 {
-			t.Fatalf("expected two inline territory availabilities, got %d", len(payload.Included))
-		}
-		for _, included := range payload.Included {
-			if included.Type != asc.ResourceTypeTerritoryAvailabilities {
-				t.Fatalf("unexpected included type %q", included.Type)
+				var payload asc.AppAvailabilityV2CreateRequest
+				if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+					t.Fatalf("decode request: %v", err)
+				}
+				if payload.Data.Relationships.App.Data.ID != "app-1" {
+					t.Fatalf("expected app-1, got %q", payload.Data.Relationships.App.Data.ID)
+				}
+				if payload.Data.Attributes == nil || payload.Data.Attributes.AvailableInNewTerritories == nil || !*payload.Data.Attributes.AvailableInNewTerritories {
+					t.Fatalf("expected availableInNewTerritories=true, got %#v", payload.Data.Attributes)
+				}
+				if payload.Data.Relationships.TerritoryAvailabilities == nil || len(payload.Data.Relationships.TerritoryAvailabilities.Data) != 3 {
+					t.Fatalf("expected three territory availability relationships, got %#v", payload.Data.Relationships.TerritoryAvailabilities)
+				}
+				if got := payload.Data.Relationships.TerritoryAvailabilities.Data[0].ID; got != "${local-usa}" {
+					t.Fatalf("expected first local ID ${local-usa}, got %q", got)
+				}
+				if got := payload.Data.Relationships.TerritoryAvailabilities.Data[1].ID; got != "${local-fra}" {
+					t.Fatalf("expected second local ID ${local-fra}, got %q", got)
+				}
+				if len(payload.Included) != 3 {
+					t.Fatalf("expected three inline territory availabilities, got %d", len(payload.Included))
+				}
+				for _, included := range payload.Included {
+					if included.Type != asc.ResourceTypeTerritoryAvailabilities {
+						t.Fatalf("unexpected included type %q", included.Type)
+					}
+					if included.Attributes == nil || included.Attributes.Available != (available && included.Relationships.Territory.Data.ID != "CAN") {
+						t.Fatalf("unexpected included territory availability, got %#v", included.Attributes)
+					}
+					if included.Relationships == nil || included.Relationships.Territory.Data.ID == "" {
+						t.Fatalf("expected included territory relationship, got %#v", included.Relationships)
+					}
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+				_, _ = io.WriteString(w, `{"data":{"type":"appAvailabilities","id":"app-1","attributes":{"availableInNewTerritories":true}}}`)
+			}))
+			t.Cleanup(server.Close)
+
+			serverURL, err := url.Parse(server.URL)
+			if err != nil {
+				t.Fatalf("parse server URL: %v", err)
 			}
-			if included.Attributes == nil || !included.Attributes.Available {
-				t.Fatalf("expected included territory to be available, got %#v", included.Attributes)
+			transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				cloned := req.Clone(req.Context())
+				cloned.URL.Scheme = serverURL.Scheme
+				cloned.URL.Host = serverURL.Host
+				return server.Client().Transport.RoundTrip(cloned)
+			})
+			client, err := asc.NewClientWithHTTPClient(
+				"TEST_KEY",
+				"TEST_ISSUER",
+				os.Getenv("ASC_PRIVATE_KEY_PATH"),
+				&http.Client{Transport: transport},
+			)
+			if err != nil {
+				t.Fatalf("new client: %v", err)
 			}
-			if included.Relationships == nil || included.Relationships.Territory.Data.ID == "" {
-				t.Fatalf("expected included territory relationship, got %#v", included.Relationships)
+			restore := pricingcli.SetAvailabilityClientFactory(func() (*asc.Client, error) {
+				return client, nil
+			})
+			t.Cleanup(restore)
+
+			root := RootCommand("1.2.3")
+			root.FlagSet.SetOutput(io.Discard)
+
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse([]string{
+					"pricing", "availability", "create",
+					"--app", "app-1",
+					"--territory", "US,USA,France",
+					"--available", strconv.FormatBool(available),
+					"--available-in-new-territories", "true",
+					"--output", "json",
+				}); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				if err := root.Run(context.Background()); err != nil {
+					t.Fatalf("run error: %v", err)
+				}
+			})
+
+			if stderr != "" {
+				t.Fatalf("expected empty stderr, got %q", stderr)
 			}
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusCreated)
-		_, _ = io.WriteString(w, `{"data":{"type":"appAvailabilities","id":"app-1","attributes":{"availableInNewTerritories":true}}}`)
-	}))
-	t.Cleanup(server.Close)
-
-	serverURL, err := url.Parse(server.URL)
-	if err != nil {
-		t.Fatalf("parse server URL: %v", err)
-	}
-	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		cloned := req.Clone(req.Context())
-		cloned.URL.Scheme = serverURL.Scheme
-		cloned.URL.Host = serverURL.Host
-		return server.Client().Transport.RoundTrip(cloned)
-	})
-	client, err := asc.NewClientWithHTTPClient(
-		"TEST_KEY",
-		"TEST_ISSUER",
-		os.Getenv("ASC_PRIVATE_KEY_PATH"),
-		&http.Client{Transport: transport},
-	)
-	if err != nil {
-		t.Fatalf("new client: %v", err)
-	}
-	restore := pricingcli.SetAvailabilityClientFactory(func() (*asc.Client, error) {
-		return client, nil
-	})
-	t.Cleanup(restore)
-
-	root := RootCommand("1.2.3")
-	root.FlagSet.SetOutput(io.Discard)
-
-	stdout, stderr := captureOutput(t, func() {
-		if err := root.Parse([]string{
-			"pricing", "availability", "create",
-			"--app", "app-1",
-			"--territory", "US,USA,France",
-			"--available", "true",
-			"--available-in-new-territories", "true",
-			"--output", "json",
-		}); err != nil {
-			t.Fatalf("parse error: %v", err)
-		}
-		if err := root.Run(context.Background()); err != nil {
-			t.Fatalf("run error: %v", err)
-		}
-	})
-
-	if stderr != "" {
-		t.Fatalf("expected empty stderr, got %q", stderr)
-	}
-	if requestCount != 1 {
-		t.Fatalf("expected one request, got %d", requestCount)
-	}
-	var output asc.AppAvailabilityV2Response
-	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
-		t.Fatalf("parse stdout JSON: %v; stdout=%q", err, stdout)
-	}
-	if output.Data.ID != "app-1" || !output.Data.Attributes.AvailableInNewTerritories {
-		t.Fatalf("unexpected output: %#v", output.Data)
+			if requestCount != 3 {
+				t.Fatalf("expected two catalog pages and one mutation, got %d", requestCount)
+			}
+			var output asc.AppAvailabilityV2Response
+			if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+				t.Fatalf("parse stdout JSON: %v; stdout=%q", err, stdout)
+			}
+			if output.Data.ID != "app-1" || !output.Data.Attributes.AvailableInNewTerritories {
+				t.Fatalf("unexpected output: %#v", output.Data)
+			}
+		})
 	}
 }
 
@@ -129,6 +143,11 @@ func TestPricingAvailabilityCreate_RelationshipRejectionExplainsFallback(t *test
 	setupAuth(t)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Method == http.MethodGet && req.URL.Path == "/v1/territories" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"data":[{"type":"territories","id":"USA"}],"links":{}}`)
+			return
+		}
 		if req.Method != http.MethodPost || req.URL.Path != "/v2/appAvailabilities" {
 			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
 		}
@@ -262,5 +281,63 @@ func TestPricingAvailabilityCreate_RejectsPositionalArguments(t *testing.T) {
 	}
 	if !strings.Contains(stderr, "pricing availability create does not accept positional arguments") {
 		t.Fatalf("unexpected stderr: %q", stderr)
+	}
+}
+
+func TestPricingAvailabilityCreate_CatalogFailureDoesNotCreate(t *testing.T) {
+	for _, tc := range []struct{ name, catalog, want string }{
+		{"empty", `{"data":[],"links":{}}`, "territory catalog is empty"},
+		{"missing selected", `{"data":[{"type":"territories","id":"CAN"}],"links":{}}`, "missing from Apple's territory catalog"},
+		{"invalid id", `{"data":[{"type":"territories","id":""}],"links":{}}`, "empty ID"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			setupAuth(t)
+			posts := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				if req.Method != http.MethodGet || req.URL.Path != "/v1/territories" {
+					posts++
+					http.Error(w, "unexpected mutation", 500)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, tc.catalog)
+			}))
+			t.Cleanup(server.Close)
+			serverURL, err := url.Parse(server.URL)
+			if err != nil {
+				t.Fatalf("parse server URL: %v", err)
+			}
+			transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				cloned := req.Clone(req.Context())
+				cloned.URL.Scheme = serverURL.Scheme
+				cloned.URL.Host = serverURL.Host
+				return server.Client().Transport.RoundTrip(cloned)
+			})
+			client, err := asc.NewClientWithHTTPClient(
+				"TEST_KEY",
+				"TEST_ISSUER",
+				os.Getenv("ASC_PRIVATE_KEY_PATH"),
+				&http.Client{Transport: transport},
+			)
+			if err != nil {
+				t.Fatalf("new client: %v", err)
+			}
+			restore := pricingcli.SetAvailabilityClientFactory(func() (*asc.Client, error) {
+				return client, nil
+			})
+			t.Cleanup(restore)
+
+			root := RootCommand("test")
+			if err := root.Parse([]string{"pricing", "availability", "create", "--app", "app-1", "--territory", "USA", "--available", "true", "--available-in-new-territories", "true"}); err != nil {
+				t.Fatal(err)
+			}
+			err = root.Run(context.Background())
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected %q, got %v", tc.want, err)
+			}
+			if posts != 0 {
+				t.Fatalf("catalog failure caused %d mutations", posts)
+			}
+		})
 	}
 }

--- a/internal/cli/pricing/availability_create.go
+++ b/internal/cli/pricing/availability_create.go
@@ -1,0 +1,58 @@
+package pricing
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+// Initial availability requires an entry for every territory, including those
+// where the app must remain unavailable.
+func initialTerritoryAvailabilities(ctx context.Context, client *asc.Client, selected []string, available bool) ([]asc.TerritoryAvailabilityCreate, error) {
+	first, err := client.GetTerritories(ctx, asc.WithTerritoriesLimit(200))
+	if err != nil {
+		return nil, fmt.Errorf("fetch territories: %w", err)
+	}
+	pages, err := asc.PaginateAll(ctx, first, func(ctx context.Context, next string) (asc.PaginatedResponse, error) {
+		return client.GetTerritories(ctx, asc.WithTerritoriesNextURL(next))
+	})
+	if err != nil {
+		return nil, fmt.Errorf("fetch territories: %w", err)
+	}
+	catalog := pages.(*asc.TerritoriesResponse)
+	if len(catalog.Data) == 0 {
+		return nil, fmt.Errorf("territory catalog is empty; availability was not created")
+	}
+	known := make(map[string]bool, len(catalog.Data))
+	for _, territory := range catalog.Data {
+		id := strings.ToUpper(strings.TrimSpace(territory.ID))
+		if id == "" {
+			return nil, fmt.Errorf("territory catalog contains an empty ID")
+		}
+		known[id] = true
+	}
+	result := make([]asc.TerritoryAvailabilityCreate, 0, len(known))
+	for _, id := range selected {
+		if !known[id] {
+			return nil, fmt.Errorf("territory %q is missing from Apple's territory catalog", id)
+		}
+	}
+	for _, id := range selected {
+		if !known[id] {
+			continue
+		}
+		result = append(result, asc.TerritoryAvailabilityCreate{TerritoryID: id, Available: available})
+		delete(known, id)
+	}
+	for _, territory := range catalog.Data {
+		id := strings.ToUpper(strings.TrimSpace(territory.ID))
+		if !known[id] {
+			continue
+		}
+		result = append(result, asc.TerritoryAvailabilityCreate{TerritoryID: id, Available: false})
+		delete(known, id)
+	}
+	return result, nil
+}

--- a/internal/cli/pricing/pricing.go
+++ b/internal/cli/pricing/pricing.go
@@ -754,11 +754,9 @@ func PricingAvailabilityCreateCommand() *ffcli.Command {
 		ShortHelp:  "Initialize app availability for territories.",
 		LongHelp: `Initialize app availability for territories.
 
-Creates the initial app availability record and its territory availability
-entries through the public App Store Connect API. Apple can reject this
-bootstrap request even when it matches the published schema. If that happens,
-the command fails without treating availability as configured and explains the
-authenticated web-session or App Store Connect fallback. Once created, use
+Creates the initial app availability record through the public App Store Connect
+API. Every current territory is included: selected territories use --available,
+and unselected territories are initialized as unavailable. Once created, use
 "asc pricing availability edit" to update the record.
 
 Examples:
@@ -804,17 +802,9 @@ Examples:
 
 			availableInNewTerritoriesValue := availableInNewTerritories.Value()
 			availableValue := available.Value()
-			territoryAvailabilities := make([]asc.TerritoryAvailabilityCreate, 0, len(territories))
-			seenTerritories := make(map[string]struct{}, len(territories))
-			for _, territoryID := range territories {
-				if _, exists := seenTerritories[territoryID]; exists {
-					continue
-				}
-				seenTerritories[territoryID] = struct{}{}
-				territoryAvailabilities = append(territoryAvailabilities, asc.TerritoryAvailabilityCreate{
-					TerritoryID: territoryID,
-					Available:   availableValue,
-				})
+			territoryAvailabilities, err := initialTerritoryAvailabilities(requestCtx, client, territories, availableValue)
+			if err != nil {
+				return fmt.Errorf("pricing availability create: %w", err)
 			}
 
 			resp, err := client.CreateAppAvailabilityV2(requestCtx, resolvedAppID, asc.AppAvailabilityV2CreateAttributes{

--- a/internal/cli/web/web_app_availability.go
+++ b/internal/cli/web/web_app_availability.go
@@ -72,7 +72,8 @@ func WebAppsAvailabilityCreateCommand() *ffcli.Command {
 		LongHelp: `WEB SESSION WORKFLOWS
 
 Create the initial app availability record for an app that does not yet have one.
-The territories passed with --territory become initially available.
+The territories passed with --territory become initially available. All other
+current territories are initialized as unavailable.
 
 Examples:
   asc web apps availability create --app "123456789" --territory "United States" --available-in-new-territories false

--- a/internal/web/app_availability.go
+++ b/internal/web/app_availability.go
@@ -304,7 +304,13 @@ func (c *Client) CreateAppAvailability(ctx context.Context, attrs AppAvailabilit
 
 	requestBody["included"] = included
 
-	responseBody, err := c.doRequestBase(ctx, c.webIrisV2BaseURL(), http.MethodPost, "/appAvailabilities", requestBody, nil)
+	headers := make(http.Header)
+	headers.Set("Content-Type", "application/json")
+	headers.Set("Accept", "application/json")
+	headers.Set("X-Requested-With", "XMLHttpRequest")
+	headers.Set("Origin", appStoreBaseURL)
+	headers.Set("Referer", appStoreBaseURL+"/")
+	responseBody, err := c.doRequestBase(ctx, c.webIrisV2BaseURL(), http.MethodPost, "/appAvailabilities", requestBody, headers)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/web/app_availability.go
+++ b/internal/web/app_availability.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -237,11 +238,47 @@ func (c *Client) CreateAppAvailability(ctx context.Context, attrs AppAvailabilit
 		return nil, err
 	}
 
-	territories := make([]map[string]string, 0, len(normalized.AvailableTerritories))
-	for _, territoryID := range normalized.AvailableTerritories {
-		territories = append(territories, map[string]string{
-			"type": "territories",
-			"id":   territoryID,
+	catalog, err := c.fetchJSONAPIPagesFromWithRequiredLinks(ctx, c.baseURL, "/territories?limit=200", "territories")
+	if err != nil {
+		return nil, fmt.Errorf("fetch territories: %w", err)
+	}
+	if len(catalog.Data) == 0 {
+		return nil, fmt.Errorf("territory catalog is empty; availability was not created")
+	}
+	known := make(map[string]bool, len(catalog.Data))
+	for _, resource := range catalog.Data {
+		id := strings.ToUpper(strings.TrimSpace(resource.ID))
+		if id == "" {
+			return nil, fmt.Errorf("territory catalog contains an empty ID")
+		}
+		known[id] = true
+	}
+	selected := make(map[string]bool, len(normalized.AvailableTerritories))
+	for _, id := range normalized.AvailableTerritories {
+		if !known[id] {
+			return nil, fmt.Errorf("territory %q is missing from Apple's territory catalog", id)
+		}
+		selected[id] = true
+	}
+	territories := make([]map[string]string, 0, len(known))
+	included := make([]map[string]any, 0, len(known))
+	for _, resource := range catalog.Data {
+		territoryID := strings.ToUpper(strings.TrimSpace(resource.ID))
+		if !known[territoryID] {
+			continue
+		}
+		delete(known, territoryID)
+		// Match the browser's temporary compound-resource identifiers.
+		localID, err := json.Marshal(map[string]string{"s": normalized.AppID, "t": territoryID})
+		if err != nil {
+			return nil, err
+		}
+		id := "${" + base64.StdEncoding.EncodeToString(localID) + "}"
+		territories = append(territories, map[string]string{"type": "territoryAvailabilities", "id": id})
+		included = append(included, map[string]any{
+			"type": "territoryAvailabilities", "id": id,
+			"attributes":    map[string]bool{"available": selected[territoryID]},
+			"relationships": map[string]any{"territory": map[string]any{"data": map[string]string{"type": "territories", "id": territoryID}}},
 		})
 	}
 
@@ -258,14 +295,16 @@ func (c *Client) CreateAppAvailability(ctx context.Context, attrs AppAvailabilit
 						"id":   normalized.AppID,
 					},
 				},
-				"availableTerritories": map[string]any{
+				"territoryAvailabilities": map[string]any{
 					"data": territories,
 				},
 			},
 		},
 	}
 
-	responseBody, err := c.doRequest(ctx, http.MethodPost, "/appAvailabilities", requestBody)
+	requestBody["included"] = included
+
+	responseBody, err := c.doRequestBase(ctx, c.webIrisV2BaseURL(), http.MethodPost, "/appAvailabilities", requestBody, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -278,5 +317,9 @@ func (c *Client) CreateAppAvailability(ctx context.Context, attrs AppAvailabilit
 	}
 
 	availability := decodeAppAvailabilityResource(payload.Data)
+	// The create response can omit relationships while Apple propagates the
+	// new record. This mutation receipt reflects the accepted request.
+	availability.AvailableTerritories = normalized.AvailableTerritories
+	availability.AvailableInNewTerritories = normalized.AvailableInNewTerritories
 	return &availability, nil
 }

--- a/internal/web/app_availability_test.go
+++ b/internal/web/app_availability_test.go
@@ -49,79 +49,89 @@ func TestNormalizeAppAvailabilityCreateAttributes(t *testing.T) {
 }
 
 func TestCreateAppAvailabilityBuildsExpectedRequest(t *testing.T) {
+	catalogPages, creates := 0, 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/appAvailabilities" {
-			t.Fatalf("unexpected path: %s", r.URL.Path)
-		}
-		if r.Method != http.MethodPost {
-			t.Fatalf("unexpected method: %s", r.Method)
-		}
-
-		var body map[string]any
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("decode body: %v", err)
-		}
-
-		data := body["data"].(map[string]any)
-		attributes := data["attributes"].(map[string]any)
-		if got := attributes["availableInNewTerritories"]; got != false {
-			t.Fatalf("expected availableInNewTerritories=false, got %#v", got)
-		}
-		relationships := data["relationships"].(map[string]any)
-		app := relationships["app"].(map[string]any)["data"].(map[string]any)
-		if app["id"] != "app-123" || app["type"] != "apps" {
-			t.Fatalf("unexpected app relationship: %#v", app)
-		}
-		territories := relationships["availableTerritories"].(map[string]any)["data"].([]any)
-		if len(territories) != 2 {
-			t.Fatalf("expected 2 territories, got %d", len(territories))
-		}
-		first := territories[0].(map[string]any)
-		second := territories[1].(map[string]any)
-		if first["id"] != "GBR" || second["id"] != "USA" {
-			t.Fatalf("expected sorted territory ids GBR/USA, got %#v %#v", first, second)
-		}
-
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{
-			"data": {
-				"id": "avail-123",
-				"type": "appAvailabilities",
-				"attributes": {"availableInNewTerritories": false},
-				"relationships": {
-					"availableTerritories": {
-						"data": [
-							{"type": "territories", "id": "GBR"},
-							{"type": "territories", "id": "USA"}
-						]
-					}
-				}
+		if r.Method == http.MethodGet && r.URL.Path == "/territories" {
+			catalogPages++
+			if r.URL.Query().Get("cursor") == "next" {
+				_, _ = w.Write([]byte(`{"data":[{"type":"territories","id":"CAN"}],"links":{"self":"/territories?cursor=next"}}`))
+			} else {
+				_, _ = w.Write([]byte(`{"data":[{"type":"territories","id":"USA"},{"type":"territories","id":"GBR"}],"links":{"self":"/territories","next":"/territories?cursor=next"}}`))
 			}
-		}`))
+			return
+		}
+		if r.Method != http.MethodPost || r.URL.Path != "/iris/v2/appAvailabilities" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+			return
+		}
+		creates++
+		var body struct {
+			Data struct {
+				Attributes    map[string]bool `json:"attributes"`
+				Relationships map[string]struct {
+					Data json.RawMessage `json:"data"`
+				} `json:"relationships"`
+			} `json:"data"`
+			Included []struct {
+				ID            string          `json:"id"`
+				Type          string          `json:"type"`
+				Attributes    map[string]bool `json:"attributes"`
+				Relationships map[string]struct {
+					Data struct {
+						ID   string `json:"id"`
+						Type string `json:"type"`
+					} `json:"data"`
+				} `json:"relationships"`
+			} `json:"included"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Error(err)
+			return
+		}
+		if body.Data.Attributes["availableInNewTerritories"] {
+			t.Error("expected future territories disabled")
+		}
+		if _, legacy := body.Data.Relationships["availableTerritories"]; legacy {
+			t.Error("legacy relationship must not be sent")
+		}
+		var refs []struct {
+			ID   string `json:"id"`
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal(body.Data.Relationships["territoryAvailabilities"].Data, &refs); err != nil {
+			t.Error(err)
+			return
+		}
+		if len(refs) != 3 || len(body.Included) != 3 {
+			t.Errorf("expected all three territories: refs=%d included=%d", len(refs), len(body.Included))
+			return
+		}
+		found := map[string]bool{}
+		for i, resource := range body.Included {
+			territory := resource.Relationships["territory"].Data.ID
+			found[territory] = resource.Attributes["available"]
+			if resource.Type != "territoryAvailabilities" || refs[i].Type != resource.Type || refs[i].ID != resource.ID {
+				t.Errorf("unmatched resource: %#v", resource)
+			}
+		}
+		if !found["USA"] || !found["GBR"] || found["CAN"] {
+			t.Errorf("selection changed: %v", found)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"data":{"type":"appAvailabilities","id":"avail-123","attributes":{"availableInNewTerritories":false},"relationships":{"territoryAvailabilities":{"data":[]}}}}`))
 	}))
 	defer server.Close()
-
-	client := testWebClient(server)
-	created, err := client.CreateAppAvailability(context.Background(), AppAvailabilityCreateAttributes{
-		AppID:                     "app-123",
-		AvailableInNewTerritories: false,
-		AvailableTerritories:      []string{"usa", "gbr"},
-	})
+	created, err := testWebClient(server).CreateAppAvailability(context.Background(), AppAvailabilityCreateAttributes{AppID: "app-123", AvailableTerritories: []string{"usa", "gbr"}})
 	if err != nil {
-		t.Fatalf("CreateAppAvailability() error = %v", err)
+		t.Fatalf("CreateAppAvailability: %v", err)
 	}
-	if created == nil {
-		t.Fatal("expected created app availability")
-		return
+	if catalogPages != 2 || creates != 1 {
+		t.Fatalf("pages=%d creates=%d", catalogPages, creates)
 	}
-	if created.ID != "avail-123" {
-		t.Fatalf("expected id avail-123, got %q", created.ID)
-	}
-	if created.AvailableInNewTerritories {
-		t.Fatal("expected availableInNewTerritories=false")
-	}
-	if got := strings.Join(created.AvailableTerritories, ","); got != "GBR,USA" {
-		t.Fatalf("expected decoded territories GBR,USA, got %q", got)
+	if created.ID != "avail-123" || created.AvailableInNewTerritories || strings.Join(created.AvailableTerritories, ",") != "GBR,USA" {
+		t.Fatalf("unexpected receipt: %#v", created)
 	}
 }
 
@@ -580,5 +590,34 @@ func TestIsNotFound(t *testing.T) {
 	}
 	if IsNotFound(&APIError{Status: http.StatusConflict}) {
 		t.Fatal("did not expect 409 APIError to be treated as not found")
+	}
+}
+
+func TestCreateAppAvailabilityCatalogFailureDoesNotCreate(t *testing.T) {
+	for _, tc := range []struct{ name, catalog, want string }{
+		{"empty", `{"data":[],"links":{"self":"/territories"}}`, "territory catalog is empty"},
+		{"missing selected", `{"data":[{"type":"territories","id":"CAN"}],"links":{"self":"/territories"}}`, "missing from Apple's territory catalog"},
+		{"missing links", `{"data":[{"type":"territories","id":"USA"}]}`, "missing non-null links"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			posts := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet || r.URL.Path != "/territories" {
+					posts++
+					http.Error(w, "unexpected mutation", 500)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tc.catalog))
+			}))
+			defer server.Close()
+			_, err := testWebClient(server).CreateAppAvailability(context.Background(), AppAvailabilityCreateAttributes{AppID: "app-1", AvailableTerritories: []string{"USA"}})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected %q, got %v", tc.want, err)
+			}
+			if posts != 0 {
+				t.Fatalf("catalog failure caused %d mutations", posts)
+			}
+		})
 	}
 }

--- a/internal/web/app_availability_test.go
+++ b/internal/web/app_availability_test.go
@@ -67,6 +67,11 @@ func TestCreateAppAvailabilityBuildsExpectedRequest(t *testing.T) {
 			return
 		}
 		creates++
+		for name, want := range map[string]string{"Origin": appStoreBaseURL, "Referer": appStoreBaseURL + "/", "X-Requested-With": "XMLHttpRequest"} {
+			if got := r.Header.Get(name); got != want {
+				t.Errorf("%s = %q, want %q", name, got, want)
+			}
+		}
 		var body struct {
 			Data struct {
 				Attributes    map[string]bool `json:"attributes"`


### PR DESCRIPTION
Fixes #2465.

Initial availability creation with `--territory USA` fails in 5.1.0 because the public request omits other current territories. The public API accepts the bootstrap when every territory is represented, including disabled entries.

This keeps the public API as the primary path: fetch the full paginated territory catalog, apply `--available` to selected countries, and initialize all others as unavailable. Empty catalogs and selections absent from the catalog fail before creation. The existing web command is also repaired to use Iris v2 and the browser-observed compound payload, with its own web-session catalog lookup.

Validation:
- Reproduced the original USA-only public failure on 5.1.0; verified the all-territory public workaround.
- Tested the patched public command on a fresh disposable app: USA-only creation succeeded; independent readback returned 175 entries, USA enabled and 174 disabled.
- Tested the patched web command on a separate fresh disposable app using a cached session: the same 1 enabled / 174 disabled result was confirmed through the public API and browser. Initial empty readback resolved after propagation; creation was not retried.
- Regression tests cover pagination, disabled selections, catalog failures, and compound request shape. `make build`, `make format`, `make check-docs`, `make lint`, and `ASC_BYPASS_KEYCHAIN=1 make test` passed. Command-doc generation produced no changes.
- Local uncommitted reviews found no actionable defects. Full-branch review identified dropped browser headers in the web POST; a follow-up restores them with a RED/GREEN regression. Final full-branch `/review` against current `origin/main` on commit `0858f205d` found no actionable regressions.

The final header-preservation follow-up passed focused and full local tests; the live bootstrap trials preceded that header-only adjustment.

Both live probes remain unreleased; no build, submission, or pricing was added. Paid-price configuration parity was not tested.
