### PR TITLE
apps wall: add Countdown Visual Timer: Kids

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -304,6 +304,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/40/b9/d8/40b9d80c-b3e5-79e4-1fc6-44f04efc95c4/AppIcon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "Countdown Visual Timer: Kids",
+    "link": "https://apps.apple.com/us/app/countdown-visual-timer-kids/id6474494320?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/35/3d/ab/353dab23-80da-b33d-4091-db8d3d230cbd/ATVC_Icon-0-0-1x_U007epad-0-1-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Cruisea: Real-time Tracking",
     "link": "https://apps.apple.com/us/app/cruisea-real-time-tracking/id6755068162?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/ad/6c/03/ad6c0376-c349-cdee-bfac-c7882f57a4d7/AppIcon-0-1x_U007ephone-0-1-85-220-0.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `Countdown Visual Timer: Kids` to the Wall of Apps

## Entry

- App ID: 6474494320
- App: Countdown Visual Timer: Kids
- Link: https://apps.apple.com/us/app/countdown-visual-timer-kids/id6474494320?uo=4

## Notes

- Submitted via `asc apps wall submit`
