### PR TITLE
apps wall: add PhotoCal: AI Calorie Tracker

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -1201,6 +1201,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/6c/e0/2f/6ce02fb3-6c3a-902e-3e15-ca189da30cfe/AppIcon-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg"
   },
   {
+    "app": "PhotoCal: AI Calorie Tracker",
+    "link": "https://apps.apple.com/us/app/photocal-ai-calorie-tracker/id6747694364?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/b1/6f/c8/b16fc8e3-34ea-a466-39c4-810c992ce82f/photocaloriecam_icon-2025-09-15-0-0-1x_U007ephone-0-1-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Pickle Rite",
     "link": "https://apps.apple.com/us/app/pickle-rite/id6754095362",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/cb/8f/0b/cb8f0b7e-ba14-a1cf-49ef-09c64d9ce87e/AppIcon-0-0-1x_U007ephone-0-1-0-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `PhotoCal: AI Calorie Tracker` to the Wall of Apps

## Entry

- App ID: 6747694364
- App: PhotoCal: AI Calorie Tracker
- Link: https://apps.apple.com/us/app/photocal-ai-calorie-tracker/id6747694364?uo=4

## Notes

- Submitted via `asc apps wall submit`
