### PR TITLE
apps wall: add CFB GameDay Board

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -225,6 +225,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/02/3d/6e/023d6ea0-1a98-d132-613c-d01b115d2e0d/AppIcon-0-0-1x_U007epad-0-1-0-85-220.jpeg/512x512bb.jpg"
   },
   {
+    "app": "CFB GameDay Board",
+    "link": "https://apps.apple.com/us/app/cfb-gameday-board/id6809035228?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/be/8b/53/be8b5384-addc-fd00-0aeb-7e605b9d8817/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "Checkify: #1 AI Bill Splitter",
     "link": "https://apps.apple.com/us/app/checkify-1-ai-bill-splitter/id6755905554?uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/fe/da/29/feda29cd-84dc-ad22-66f4-a276004811fc/appicon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"


### PR DESCRIPTION
## Summary

- add `CFB GameDay Board` to the Wall of Apps

## Entry

- App ID: 6809035228
- App: CFB GameDay Board
- Link: https://apps.apple.com/us/app/cfb-gameday-board/id6809035228?uo=4

## Notes

- Submitted via `asc apps wall submit`
