### PR TITLE
fix(web): fall back when auth service config returns 404

### DIFF
--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -43,6 +43,11 @@ const (
 	irisV2BaseURL     = appStoreBaseURL + "/iris/v2"
 	olympusBaseURL    = appStoreBaseURL + "/olympus/v1"
 
+	// Public production widget identifier shipped by Apple's ASC login page,
+	// not an account credential. Fallback when the legacy config endpoint is absent.
+	// Verified 2026-09-11: https://unpkg.apple.com/@maison/preauthorization-container@0.2.1/umd/chunks/ASC.BRGDgul9.js
+	appStoreConnectWidgetKey = "e0b80c3bf78523bfe80974d320935bfa30add02e1bff88ec2166c6bd5a706c42"
+
 	// Apple currently uses RFC5054 group 2048 + 32-byte derived password.
 	srpClientSecretBytes  = 256
 	srpDerivedPasswordLen = 32
@@ -661,6 +666,12 @@ func getAuthServiceKey(ctx context.Context, client *http.Client) (string, error)
 		return "", fmt.Errorf("failed to read auth service key response: %w", err)
 	}
 	logWebAuthHTTP("auth_service_key", req, resp, body, nil)
+	if resp.StatusCode == http.StatusNotFound {
+		if webDebugEnabledFn() {
+			webDebugLogger.Info("using public App Store Connect widget key", "stage", "auth_service_key_fallback")
+		}
+		return appStoreConnectWidgetKey, nil
+	}
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("failed to fetch auth service key (status %d)", resp.StatusCode)
 	}

--- a/internal/web/auth_service_key_test.go
+++ b/internal/web/auth_service_key_test.go
@@ -1,0 +1,94 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/handlertest"
+)
+
+// Captured from Apple's public production ASC login configuration on 2026-09-11.
+const testPublicASCWidgetKey = "e0b80c3bf78523bfe80974d320935bfa30add02e1bff88ec2166c6bd5a706c42"
+
+func TestGetAuthServiceKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  int
+		body    string
+		want    string
+		wantErr bool
+	}{
+		{name: "discovered key wins", status: 200, body: `{"authServiceKey":" discovered ","serviceKey":"legacy"}`, want: "discovered"},
+		{name: "legacy field", status: 200, body: `{"serviceKey":" legacy "}`, want: "legacy"},
+		{name: "missing endpoint", status: 404, body: `<html>Not Found</html>`, want: testPublicASCWidgetKey},
+		{name: "unauthorized", status: 401, body: `{}`, wantErr: true},
+		{name: "forbidden", status: 403, body: `{}`, wantErr: true},
+		{name: "server failure", status: 500, body: `{}`, wantErr: true},
+		{name: "invalid JSON", status: 200, body: `<html>Unavailable</html>`, wantErr: true},
+		{name: "empty key", status: 200, body: `{"authServiceKey":" "}`, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := handlertest.New(t)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet || r.URL.Path != "/olympus/v1/app/config" || r.URL.Query().Get("hostname") != "itunesconnect.apple.com" {
+					fixture.Respond(w, "unexpected bootstrap request: %s %s", r.Method, r.URL)
+					return
+				}
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+			got, err := getAuthServiceKey(context.Background(), newTestServerRoutedClient(t, server))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("getAuthServiceKey error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Fatal("getAuthServiceKey returned an unexpected key")
+			}
+		})
+	}
+}
+
+func TestLoginContinuesToSRPAfterAuthServiceKey404(t *testing.T) {
+	fixture := handlertest.New(t)
+	var bootstrapCalls, signinCalls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/olympus/v1/app/config":
+			bootstrapCalls++
+			w.WriteHeader(http.StatusNotFound)
+		case "/appleauth/auth/signin/init":
+			signinCalls++
+			if r.Method != http.MethodPost || r.Header.Get("X-Apple-Widget-Key") != testPublicASCWidgetKey {
+				fixture.Respond(w, "SRP did not receive the public ASC widget key in a POST")
+				return
+			}
+			var payload struct {
+				AccountName string `json:"accountName"`
+				PublicKey   string `json:"a"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil || payload.AccountName != "fixture@example.invalid" || payload.PublicKey == "" {
+				fixture.Respond(w, "invalid SRP init payload")
+				return
+			}
+			// Stop at a deliberate downstream failure: bootstrap must have succeeded.
+			w.WriteHeader(http.StatusServiceUnavailable)
+		default:
+			fixture.Respond(w, "unexpected request: %s %s", r.Method, r.URL)
+		}
+	}))
+	defer server.Close()
+	session, err := loginWithHTTPClient(context.Background(), newTestServerRoutedClient(t, server), LoginCredentials{
+		Username: "fixture@example.invalid", Password: "fixture-password",
+	})
+	if err == nil || session != nil {
+		t.Fatal("expected the downstream SRP failure")
+	}
+	if bootstrapCalls != 1 || signinCalls != 1 {
+		t.Fatalf("bootstrap requests = %d, SRP requests = %d; want one each", bootstrapCalls, signinCalls)
+	}
+}


### PR DESCRIPTION
Fresh `asc web auth login` attempts stop before SRP when Apple's legacy Olympus configuration endpoint returns HTTP 404. Preserve successful service-key discovery and use the public production widget identifier shipped by Apple's App Store Connect login page only when that endpoint returns 404. `--api-debug` now identifies the fallback without printing the key. Other HTTP and response-decoding failures retain their existing behavior.

Fixes #2482.

Regression coverage was RED before the fix: the 404 returned an error and no SRP request was made. Tests now cover both successful response fields, the 404 fallback, other HTTP failures, malformed/empty responses, and delivery of the fallback key to SRP initialization.

Live verification on the patched binary completed from an expired cached session: configuration 404, fallback, SRP, accepted 2FA, trust established, and App Store Connect session HTTP 200. The login returned `authenticated: true`, `source: fresh`, and exit code 0. A subsequent separate `web auth status` invocation returned `authenticated: true`, `source: cache`, and exit code 0. Account identifiers, credentials, and session data are omitted.

Validation passed: focused regression tests, both adjacent web packages, `make build`, `make format`, `make check-docs`, `make lint`, and `ASC_BYPASS_KEYCHAIN=1 make test`. The code-simplifier review, required uncommitted review, and final full-branch review against `origin/main` reported no actionable defects. Tests passed separately from the final review, whose read-only sandbox could not run Go tests. The normal pre-commit checks also passed.

During live verification the old Apple endpoint still returned 404; this change recovered from that response. The bundled public widget identifier may need updating if Apple rotates it. No flags or output schemas changed.
