### PR TITLE
fix(web): clarify login configuration failures

### DIFF
--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -615,7 +615,7 @@ func loginWithHTTPClient(ctx context.Context, client *http.Client, creds LoginCr
 
 	serviceKey, err := getAuthServiceKey(ctx, client)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get auth service key: %w", err)
+		return nil, fmt.Errorf("could not load Apple login configuration; password authentication has not started. Run with --api-debug for request details: %w", err)
 	}
 
 	if err := performSRPLogin(ctx, client, creds, serviceKey); err != nil {

--- a/internal/web/auth_service_key_test.go
+++ b/internal/web/auth_service_key_test.go
@@ -3,8 +3,11 @@ package web
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/handlertest"
@@ -12,6 +15,57 @@ import (
 
 // Captured from Apple's public production ASC login configuration on 2026-09-11.
 const testPublicASCWidgetKey = "e0b80c3bf78523bfe80974d320935bfa30add02e1bff88ec2166c6bd5a706c42"
+
+func TestLoginAuthServiceKeyFailureGuidance(t *testing.T) {
+	transportErr := errors.New("fixture transport failure")
+	tests := []struct {
+		name   string
+		status int
+		body   string
+		cause  error
+	}{
+		{name: "forbidden", status: http.StatusForbidden, body: `{}`},
+		{name: "server failure", status: http.StatusInternalServerError, body: `{}`},
+		{name: "invalid JSON", status: http.StatusOK, body: `<html>Unavailable</html>`},
+		{name: "transport failure", cause: transportErr},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := handlertest.New(t)
+			var requests int
+			client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				requests++
+				if req.Method != http.MethodGet || req.URL.Host != "appstoreconnect.apple.com" || req.URL.Path != "/olympus/v1/app/config" {
+					return nil, fixture.Errorf("unexpected request after bootstrap failure: %s %s", req.Method, req.URL)
+				}
+				if tt.cause != nil {
+					return nil, tt.cause
+				}
+				return &http.Response{StatusCode: tt.status, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(tt.body)), Request: req}, nil
+			})}
+			session, err := loginWithHTTPClient(context.Background(), client, LoginCredentials{
+				Username: "fixture@example.invalid", Password: "fixture-password",
+			})
+			if err == nil || session != nil {
+				t.Fatal("expected bootstrap failure without a session")
+			}
+			const guidance = "could not load Apple login configuration; password authentication has not started. Run with --api-debug for request details: "
+			if !strings.HasPrefix(err.Error(), guidance) {
+				t.Errorf("missing pre-authentication diagnostic guidance: %v", err)
+			}
+			cause := errors.Unwrap(err)
+			if cause == nil || strings.TrimPrefix(err.Error(), guidance) != cause.Error() {
+				t.Errorf("bootstrap error must preserve its wrapped cause: %v", err)
+			}
+			if tt.cause != nil && !errors.Is(err, tt.cause) {
+				t.Errorf("bootstrap error must wrap the transport failure: %v", err)
+			}
+			if requests != 1 {
+				t.Errorf("requests = %d, want only the bootstrap request", requests)
+			}
+		})
+	}
+}
 
 func TestGetAuthServiceKey(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Fatal Apple login configuration errors currently say only that fetching the auth service key failed. This follow-up to #2483 explains that password authentication has not started and points users to `--api-debug`, while retaining the original error and wrapped cause.

The change is limited to the bootstrap error message. The merged HTTP 404 fallback, successful login, session caching, retries, and 2FA behavior are unchanged.

Validation:
- Regression test failed before the change and passes afterward for HTTP 403/500, malformed JSON, and transport errors; verifies no SRP request occurs and the cause remains wrapped.
- Existing 404-to-SRP fallback test and both web packages pass.
- Built CLI with an isolated failing proxy: exit 1, empty stdout, diagnostic guidance and original cause on stderr, no sign-in request.
- `make format`, `make build`, `make check-docs`, `make lint`, and `ASC_BYPASS_KEYCHAIN=1 make test` pass.
- Local uncommitted and full-branch Codex reviews report no actionable findings.

Refs #2482.
