### PR TITLE
feat(xcode): support macOS PKG export

### DIFF
--- a/docs/design/xcode-export-pkg.md
+++ b/docs/design/xcode-export-pkg.md
@@ -1,0 +1,77 @@
+# Xcode PKG export
+
+## Placement and current behavior
+
+`asc builds upload` already accepts `--pkg`, sends `com.apple.pkg`, and selects
+the macOS platform. The missing layer is local export: `asc xcode export`
+requires an IPA destination, searches only for `*.ipa`, and reports only
+`ipa_path`. Its direct-upload mode also requires an IPA path even though
+`xcodebuild` does not create a local artifact for `destination=upload`.
+
+This change extends the existing local Xcode command. It does not add an App
+Store Connect API operation or alter `asc xcode archive`; Xcode archives remain
+`.xcarchive` bundles and become uploadable artifacts only during export.
+
+## Public command shape
+
+Local exports accept exactly one destination:
+
+```text
+asc xcode export --archive-path MacApp.xcarchive --pkg-path MacApp.pkg
+asc xcode export --archive-path App.xcarchive --ipa-path App.ipa
+```
+
+`--pkg-path` must end in `.pkg`. It shares `--overwrite`, generated or explicit
+ExportOptions.plist handling, timeouts, and xcodebuild argument passthrough with
+IPA export. The generated `release-testing` method remains IPA-only and is
+rejected when combined with `--pkg-path`. The pinned manual-signing generator
+supports only iOS and tvOS archives, so generated manual options are also
+rejected for PKG output with guidance to provide an explicit plist. Automatic
+generation and explicit manual plists remain supported.
+
+With an explicit plist containing `destination=upload`, or with `--wait`, both
+artifact paths are optional because Xcode uploads directly. If a legacy caller
+still supplies an artifact path in direct-upload mode, it is accepted but not
+created, preflighted, or reported as a produced artifact.
+
+No command prompts. Invalid flag combinations and extensions are usage errors
+with exit code 2. Data stays on stdout and diagnostics stay on stderr.
+
+## Export and output contract
+
+Local PKG export runs `xcodebuild -exportArchive` in an owned temporary
+directory, requires exactly one root-level `*.pkg`, verifies that it is a
+non-empty regular file, and publishes it at the requested path without
+silently replacing an existing destination. PKG metadata comes from the input
+archive because an installer package does not expose the existing IPA metadata
+layout.
+
+Structured output adds optional `pkg_path`; existing `archive_path`,
+`ipa_path`, bundle ID, version, and build number fields remain compatible. IPA
+exports are unchanged. Direct upload continues to return archive metadata and
+an empty `ipa_path`, without adding a local path that does not exist.
+
+## RED-GREEN and verification
+
+Focused coverage establishes:
+
+- CLI acceptance and propagation of `--pkg-path`;
+- mutual exclusion of IPA and PKG destinations;
+- exact-path PKG publication and archive-derived metadata;
+- rejection of missing, multiple, empty, or unsafe PKG output;
+- direct upload without a placeholder artifact path or parent-directory write;
+- preserved IPA behavior and help/output compatibility;
+- built-binary usage exit codes and stdout/stderr separation.
+
+Verification uses focused package tests, generated command docs, a built CLI,
+and the repository build, format, docs, lint, full-test, and review gates. A
+real signed archive export is optional because it depends on local signing
+assets; no App Store Connect mutation is required for this change.
+
+## Alternatives
+
+Producing a PKG during `xcode archive` would misrepresent Xcode's archive
+contract and conflate two stages. Requiring callers to find Xcode's temporary
+PKG themselves would lose deterministic output and overwrite guarantees.
+Keeping a dummy `--ipa-path` for direct upload preserves syntax but creates a
+false local-artifact contract.

--- a/internal/cli/cmdtest/xcode_test.go
+++ b/internal/cli/cmdtest/xcode_test.go
@@ -209,6 +209,9 @@ func TestXcodeExportHelpMentionsDirectUploadMode(t *testing.T) {
 	if got := exportCmd.FlagSet.Lookup("ipa-path").Usage; !strings.Contains(got, "when one is produced") {
 		t.Fatalf("expected ipa-path usage to mention produced IPA behavior, got %q", got)
 	}
+	if got := exportCmd.FlagSet.Lookup("pkg-path").Usage; !strings.Contains(got, "macOS .pkg") {
+		t.Fatalf("expected pkg-path usage to mention macOS PKG behavior, got %q", got)
+	}
 	if exportCmd.FlagSet.Lookup("timeout") == nil {
 		t.Fatal("expected xcode export to expose --timeout")
 	}
@@ -506,7 +509,7 @@ func TestXcodeValidateRequiresIPA(t *testing.T) {
 	}
 }
 
-func TestXcodeExportRequiresIPAPath(t *testing.T) {
+func TestXcodeExportRequiresArtifactPath(t *testing.T) {
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)
 
@@ -523,7 +526,7 @@ func TestXcodeExportRequiresIPAPath(t *testing.T) {
 	if stdout != "" {
 		t.Fatalf("expected empty stdout, got %q", stdout)
 	}
-	if !strings.Contains(stderr, "Error: --ipa-path is required") {
-		t.Fatalf("expected ipa-path error, got %q", stderr)
+	if !strings.Contains(stderr, "Error: --ipa-path or --pkg-path is required for a local export") {
+		t.Fatalf("expected artifact path error, got %q", stderr)
 	}
 }

--- a/internal/cli/xcode/export_options_test.go
+++ b/internal/cli/xcode/export_options_test.go
@@ -726,7 +726,7 @@ func TestXcodeExportValidatesIPADestinationBeforeImplicitOptionGeneration(t *tes
 	}
 }
 
-func TestXcodeExportWaitPreflightsIPAParentBeforeImplicitOptionGeneration(t *testing.T) {
+func TestXcodeExportWaitIgnoresUnusedIPAParent(t *testing.T) {
 	restore := overrideXcodeCommandTestHooks(t)
 	defer restore()
 
@@ -734,9 +734,13 @@ func TestXcodeExportWaitPreflightsIPAParentBeforeImplicitOptionGeneration(t *tes
 	if err := os.WriteFile(parent, []byte("file"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	runGenerateExportOptions = func(context.Context, localxcode.ExportOptionsGenerateOptions) (*localxcode.ExportOptionsGenerateResult, error) {
-		t.Fatal("upload export options must not be generated for an unusable IPA parent")
-		return nil, nil
+	wantErr := errors.New("stop after generation")
+	runGenerateExportOptions = func(_ context.Context, opts localxcode.ExportOptionsGenerateOptions) (*localxcode.ExportOptionsGenerateResult, error) {
+		return &localxcode.ExportOptionsGenerateResult{Path: opts.OutputPath}, nil
+	}
+	isDirectUploadExportOptionsFn = func(string) bool { return true }
+	runExport = func(context.Context, localxcode.ExportOptions) (*localxcode.ExportResult, error) {
+		return nil, wantErr
 	}
 
 	cmd := XcodeExportCommand()
@@ -750,8 +754,8 @@ func TestXcodeExportWaitPreflightsIPAParentBeforeImplicitOptionGeneration(t *tes
 	}
 
 	err := cmd.Exec(context.Background(), nil)
-	if err == nil || errors.Is(err, flag.ErrHelp) || !strings.Contains(err.Error(), "ipa output parent") {
-		t.Fatalf("expected runtime IPA-parent error, got %v", err)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected export sentinel without touching the unused IPA parent, got %v", err)
 	}
 }
 

--- a/internal/cli/xcode/xcode.go
+++ b/internal/cli/xcode/xcode.go
@@ -63,14 +63,16 @@ on macOS only. Signing-plan generation is cross-platform. Signing apply
 requires native identity-coupled file mutation support and currently fails
 closed on Windows before modifying project or receipt files.
 
-Use these commands to compile projects and produce deterministic .xcarchive and
-.ipa paths that can be passed directly into asc upload and publish commands.
+Use these commands to compile projects and produce deterministic .xcarchive,
+.ipa, and .pkg paths that can be passed directly into asc upload and publish
+commands.
 
 Examples:
   asc xcode inject --manifest .asc/deployment.json --set version=1.3.0 --overwrite
   asc xcode build --project App.xcodeproj --scheme App --destination 'platform=iOS Simulator,name=iPhone 17 Pro Max,OS=27.0' --no-code-signing --output json
   asc xcode archive --workspace App.xcworkspace --scheme App --archive-path .asc/artifacts/App.xcarchive --output json
   asc xcode export --archive-path .asc/artifacts/App.xcarchive --ipa-path .asc/artifacts/App.ipa --output json
+  asc xcode export --archive-path .asc/artifacts/MacApp.xcarchive --pkg-path .asc/artifacts/MacApp.pkg --output json
   asc xcode install --ipa .asc/artifacts/App.ipa --device-id COREDEVICE_IDENTIFIER --output json
   asc xcode export-options generate --archive-path .asc/artifacts/App.xcarchive
   asc xcode doctor --output json
@@ -195,8 +197,9 @@ func XcodeExportCommand() *ffcli.Command {
 	method := fs.String("method", "app-store-connect", "Method for generated options: app-store-connect or release-testing")
 	signingStyle := fs.String("signing-style", "automatic", "Signing style for generated options: automatic or manual")
 	teamID := fs.String("team-id", "", "Apple Developer team ID for generated options (overrides archive metadata)")
-	ipaPath := fs.String("ipa-path", "", "Destination path for a local .ipa when one is produced (required)")
-	overwrite := fs.Bool("overwrite", false, "Replace an existing IPA at --ipa-path")
+	ipaPath := fs.String("ipa-path", "", "Destination path for a local .ipa when one is produced")
+	pkgPath := fs.String("pkg-path", "", "Destination path for a local macOS .pkg when one is produced")
+	overwrite := fs.Bool("overwrite", false, "Replace an existing local artifact at its destination path")
 	wait := fs.Bool("wait", false, "Wait for App Store Connect build discovery and processing when export uploads directly")
 	pollInterval := fs.Duration("poll-interval", shared.PublishDefaultPollInterval, "Polling interval for --wait when waiting for uploaded builds")
 	timeout := fs.Duration("timeout", 0, "Maximum duration for xcodebuild -exportArchive (0 disables local export timeout)")
@@ -207,8 +210,8 @@ func XcodeExportCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "export",
 		ShortUsage: "asc xcode export [flags]",
-		ShortHelp:  "Export an archive to a deterministic IPA path or direct upload.",
-		LongHelp: `Export an archive to a deterministic IPA path or direct upload.
+		ShortHelp:  "Export an archive to an IPA or PKG path, or use direct upload.",
+		LongHelp: `Export an archive to a deterministic IPA or PKG path, or upload directly.
 
 This command runs xcodebuild -exportArchive into a temporary directory.
 When --export-options is omitted, asc generates archive-adjacent options. It
@@ -216,18 +219,22 @@ uses app-store-connect and automatic signing by default. Use
 --method release-testing for a local IPA installable on registered devices. Use
 --signing-style manual to match locally installed certificates and profiles;
 --team-id optionally overrides archive metadata.
-When ExportOptions.plist produces a local IPA, asc moves it to --ipa-path.
+For local exports, provide exactly one destination: --ipa-path for iOS, tvOS,
+or visionOS, or --pkg-path for macOS. asc moves the exported artifact to that
+exact path. Generated manual signing options support iOS and tvOS archives;
+provide an explicit --export-options plist for a manually signed macOS export.
 When ExportOptions.plist uses destination=upload, xcodebuild uploads directly
 to App Store Connect and asc returns archive metadata without writing a local
-IPA at --ipa-path. Use --wait to poll until the uploaded build appears and
-finishes processing.
+artifact or requiring a destination path. Use --wait to generate direct-upload
+options and poll until the uploaded build appears and finishes processing.
 
 Examples:
   asc xcode export --archive-path .asc/artifacts/App.xcarchive --ipa-path .asc/artifacts/App.ipa
+  asc xcode export --archive-path .asc/artifacts/MacApp.xcarchive --pkg-path .asc/artifacts/MacApp.pkg
   asc xcode export --archive-path .asc/artifacts/App.xcarchive --ipa-path .asc/artifacts/App.ipa --method release-testing --signing-style manual
   asc xcode export --archive-path .asc/artifacts/App.xcarchive --ipa-path .asc/artifacts/App.ipa --signing-style manual --team-id TEAM_ID
   asc xcode export --archive-path .asc/artifacts/App.xcarchive --ipa-path .asc/artifacts/App.ipa --timeout 10m
-  asc xcode export --archive-path .asc/artifacts/App.xcarchive --export-options UploadExportOptions.plist --ipa-path .asc/artifacts/App.ipa --wait
+  asc xcode export --archive-path .asc/artifacts/App.xcarchive --export-options UploadExportOptions.plist --wait
   asc xcode export --archive-path .asc/artifacts/App.xcarchive --export-options ExportOptions.plist --ipa-path .asc/artifacts/App.ipa --xcodebuild-flag=-allowProvisioningUpdates --output json`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
@@ -239,10 +246,6 @@ Examples:
 			if strings.TrimSpace(*archivePath) == "" {
 				fmt.Fprintln(os.Stderr, "Error: --archive-path is required")
 				return shared.MissingRequiredUsageError("--archive-path")
-			}
-			if strings.TrimSpace(*ipaPath) == "" {
-				fmt.Fprintln(os.Stderr, "Error: --ipa-path is required")
-				return shared.MissingRequiredUsageError("--ipa-path")
 			}
 			if *wait && *pollInterval <= 0 {
 				return shared.UsageError("--poll-interval must be greater than 0")
@@ -289,6 +292,11 @@ Examples:
 				return shared.UsageError("--team-id must not be empty")
 			}
 			trimmedArchivePath := strings.TrimSpace(*archivePath)
+			trimmedIPAPath := strings.TrimSpace(*ipaPath)
+			trimmedPKGPath := strings.TrimSpace(*pkgPath)
+			if trimmedIPAPath != "" && trimmedPKGPath != "" {
+				return shared.UsageError("--ipa-path and --pkg-path are mutually exclusive")
+			}
 			exportOptionsPath := strings.TrimSpace(*exportOptions)
 			if exportOptionsPath != "" && generationFlagsSet {
 				return shared.UsageError("--export-options cannot be combined with --method, --signing-style, or --team-id")
@@ -296,25 +304,57 @@ Examples:
 			if *wait && methodValue == "release-testing" {
 				return shared.UsageError("--wait cannot be combined with --method release-testing")
 			}
+			if exportOptionsPath == "" && trimmedPKGPath != "" && methodValue == "release-testing" {
+				return shared.UsageError("--pkg-path cannot be combined with --method release-testing")
+			}
+			if exportOptionsPath == "" && trimmedPKGPath != "" && signingStyleValue == "manual" {
+				return shared.UsageError("--pkg-path with manual signing requires an explicit --export-options plist")
+			}
+			directUpload := *wait
+			if exportOptionsPath != "" {
+				directUpload = isDirectUploadExportOptionsFn(exportOptionsPath)
+			}
+			if trimmedIPAPath == "" && trimmedPKGPath == "" && !directUpload {
+				fmt.Fprintln(os.Stderr, "Error: --ipa-path or --pkg-path is required for a local export")
+				return shared.MissingRequiredUsageError("")
+			}
+			if trimmedIPAPath != "" {
+				if err := localxcode.ValidateExportDestination(trimmedIPAPath, *overwrite, directUpload); err != nil {
+					if localxcode.IsExportDestinationUsageError(err) {
+						return shared.UsageError(err.Error())
+					}
+					return fmt.Errorf("xcode export: %w", err)
+				}
+			}
+			if trimmedPKGPath != "" {
+				if err := localxcode.ValidateExportPKGDestination(trimmedPKGPath, *overwrite, directUpload); err != nil {
+					if localxcode.IsExportDestinationUsageError(err) {
+						return shared.UsageError(err.Error())
+					}
+					return fmt.Errorf("xcode export: %w", err)
+				}
+			}
 			if exportOptionsPath == "" {
 				destination := "export"
 				if *wait {
 					destination = "upload"
 				}
-				if err := localxcode.ValidateExportDestination(strings.TrimSpace(*ipaPath), *overwrite, destination == "upload"); err != nil {
-					if localxcode.IsExportDestinationUsageError(err) {
-						return shared.UsageError(err.Error())
-					}
-					return fmt.Errorf("xcode export: %w", err)
-				}
 				if err := runXcodeExportPreflight(ctx); err != nil {
 					return fmt.Errorf("xcode export: %w", err)
 				}
-				if err := localxcode.PreflightExportDestination(strings.TrimSpace(*ipaPath), *overwrite, destination == "upload"); err != nil {
-					if localxcode.IsExportDestinationUsageError(err) {
-						return shared.UsageError(err.Error())
+				if destination != "upload" {
+					var err error
+					if trimmedPKGPath != "" {
+						err = localxcode.PreflightExportPKGDestination(trimmedPKGPath, *overwrite, false)
+					} else {
+						err = localxcode.PreflightExportDestination(trimmedIPAPath, *overwrite, false)
 					}
-					return fmt.Errorf("xcode export: %w", err)
+					if err != nil {
+						if localxcode.IsExportDestinationUsageError(err) {
+							return shared.UsageError(err.Error())
+						}
+						return fmt.Errorf("xcode export: %w", err)
+					}
 				}
 				generatedPath, err := localxcode.UniqueExportOptionsPathForArchive(trimmedArchivePath)
 				if err != nil {
@@ -354,7 +394,8 @@ Examples:
 			result, err := runExport(exportCtx, localxcode.ExportOptions{
 				ArchivePath:    trimmedArchivePath,
 				ExportOptions:  exportOptionsPath,
-				IPAPath:        strings.TrimSpace(*ipaPath),
+				IPAPath:        trimmedIPAPath,
+				PKGPath:        trimmedPKGPath,
 				Overwrite:      *overwrite,
 				XcodebuildArgs: []string(xcodebuildFlags),
 				LogWriter:      os.Stderr,
@@ -373,6 +414,7 @@ Examples:
 				ArchivePath:       result.ArchivePath,
 				ExportOptionsPath: exportOptionsPath,
 				IPAPath:           result.IPAPath,
+				PKGPath:           result.PKGPath,
 				BundleID:          result.BundleID,
 				Version:           result.Version,
 				BuildNumber:       result.BuildNumber,
@@ -550,6 +592,7 @@ type xcodeExportCommandResult struct {
 	ArchivePath       string `json:"archive_path"`
 	ExportOptionsPath string `json:"export_options_path"`
 	IPAPath           string `json:"ipa_path"`
+	PKGPath           string `json:"pkg_path,omitempty"`
 	BundleID          string `json:"bundle_id,omitempty"`
 	Version           string `json:"version,omitempty"`
 	BuildNumber       string `json:"build_number,omitempty"`
@@ -564,6 +607,8 @@ func exportResultRows(result xcodeExportCommandResult) [][]string {
 	}
 	if result.IPAPath != "" {
 		rows = append(rows, []string{"ipa_path", result.IPAPath})
+	} else if result.PKGPath != "" {
+		rows = append(rows, []string{"pkg_path", result.PKGPath})
 	} else {
 		rows = append(rows, []string{"ipa_path", "(direct upload — no local artifact)"})
 	}

--- a/internal/cli/xcode/xcode_test.go
+++ b/internal/cli/xcode/xcode_test.go
@@ -55,6 +55,166 @@ func TestXcodeExportWaitRequiresDirectUpload(t *testing.T) {
 	}
 }
 
+func TestXcodeExportAcceptsPKGPath(t *testing.T) {
+	restore := overrideXcodeCommandTestHooks(t)
+	defer restore()
+
+	var gotOptions localxcode.ExportOptions
+	runExport = func(_ context.Context, opts localxcode.ExportOptions) (*localxcode.ExportResult, error) {
+		gotOptions = opts
+		return &localxcode.ExportResult{
+			ArchivePath: opts.ArchivePath,
+			PKGPath:     opts.PKGPath,
+			BundleID:    "com.example.mac",
+			Version:     "1.2.3",
+			BuildNumber: "42",
+		}, nil
+	}
+
+	cmd := XcodeExportCommand()
+	cmd.FlagSet.SetOutput(io.Discard)
+	if err := cmd.FlagSet.Parse([]string{
+		"--archive-path", "Demo.xcarchive",
+		"--export-options", "ExportOptions.plist",
+		"--pkg-path", "Demo.pkg",
+		"--output", "json",
+	}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	var runErr error
+	stdout, stderr := captureCommandOutput(t, func() error {
+		runErr = cmd.Exec(context.Background(), nil)
+		return runErr
+	})
+	if runErr != nil {
+		t.Fatalf("Exec() error: %v", runErr)
+	}
+	if gotOptions.PKGPath != "Demo.pkg" || gotOptions.IPAPath != "" {
+		t.Fatalf("export options = %+v, want only PKG path", gotOptions)
+	}
+	var payload struct {
+		PKGPath string `json:"pkg_path"`
+		IPAPath string `json:"ipa_path"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error: %v\nstdout=%s", err, stdout)
+	}
+	if payload.PKGPath != "Demo.pkg" || payload.IPAPath != "" {
+		t.Fatalf("export payload = %+v, want only pkg_path", payload)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+}
+
+func TestXcodeExportRejectsMultipleArtifactPaths(t *testing.T) {
+	restore := overrideXcodeCommandTestHooks(t)
+	defer restore()
+
+	cmd := XcodeExportCommand()
+	cmd.FlagSet.SetOutput(io.Discard)
+	if err := cmd.FlagSet.Parse([]string{
+		"--archive-path", "Demo.xcarchive",
+		"--export-options", "ExportOptions.plist",
+		"--ipa-path", "Demo.ipa",
+		"--pkg-path", "Demo.pkg",
+	}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	var runErr error
+	_, stderr := captureCommandOutput(t, func() error {
+		runErr = cmd.Exec(context.Background(), nil)
+		return runErr
+	})
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("Exec() error = %v, want usage error", runErr)
+	}
+	if !strings.Contains(stderr, "Error: --ipa-path and --pkg-path are mutually exclusive") {
+		t.Fatalf("stderr = %q, want artifact conflict", stderr)
+	}
+}
+
+func TestXcodeExportRejectsGeneratedManualPKGOptions(t *testing.T) {
+	restore := overrideXcodeCommandTestHooks(t)
+	defer restore()
+
+	runGenerateExportOptions = func(context.Context, localxcode.ExportOptionsGenerateOptions) (*localxcode.ExportOptionsGenerateResult, error) {
+		t.Fatal("generator must not run for unsupported macOS manual signing")
+		return nil, nil
+	}
+	runExport = func(context.Context, localxcode.ExportOptions) (*localxcode.ExportResult, error) {
+		t.Fatal("export must not run for unsupported macOS manual signing")
+		return nil, nil
+	}
+
+	cmd := XcodeExportCommand()
+	cmd.FlagSet.SetOutput(io.Discard)
+	if err := cmd.FlagSet.Parse([]string{
+		"--archive-path", "Demo.xcarchive",
+		"--pkg-path", "Demo.pkg",
+		"--signing-style", "manual",
+	}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	var runErr error
+	_, stderr := captureCommandOutput(t, func() error {
+		runErr = cmd.Exec(context.Background(), nil)
+		return runErr
+	})
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("Exec() error = %v, want usage error", runErr)
+	}
+	if !strings.Contains(stderr, "Error: --pkg-path with manual signing requires an explicit --export-options plist") {
+		t.Fatalf("stderr = %q, want manual-signing guidance", stderr)
+	}
+}
+
+func TestXcodeExportDirectUploadDoesNotRequireArtifactPath(t *testing.T) {
+	restore := overrideXcodeCommandTestHooks(t)
+	defer restore()
+
+	isDirectUploadExportOptionsFn = func(string) bool { return true }
+	runExport = func(_ context.Context, opts localxcode.ExportOptions) (*localxcode.ExportResult, error) {
+		if opts.IPAPath != "" || opts.PKGPath != "" {
+			t.Fatalf("direct upload options = %+v, want no local artifact path", opts)
+		}
+		return &localxcode.ExportResult{
+			ArchivePath: opts.ArchivePath,
+			BundleID:    "com.example.mac",
+			Version:     "1.2.3",
+			BuildNumber: "42",
+		}, nil
+	}
+
+	cmd := XcodeExportCommand()
+	cmd.FlagSet.SetOutput(io.Discard)
+	if err := cmd.FlagSet.Parse([]string{
+		"--archive-path", "Demo.xcarchive",
+		"--export-options", "UploadExportOptions.plist",
+		"--output", "json",
+	}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	var runErr error
+	stdout, stderr := captureCommandOutput(t, func() error {
+		runErr = cmd.Exec(context.Background(), nil)
+		return runErr
+	})
+	if runErr != nil {
+		t.Fatalf("Exec() error: %v", runErr)
+	}
+	if strings.TrimSpace(stdout) == "" {
+		t.Fatal("expected JSON output")
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+}
+
 func TestXcodeInjectGeneratesPlistTextAndCopiesAsset(t *testing.T) {
 	dir := t.TempDir()
 	sourceAssetPath := filepath.Join(dir, "Assets", "AppIcon.appiconset", "Contents.json")

--- a/internal/xcode/xcode.go
+++ b/internal/xcode/xcode.go
@@ -93,6 +93,7 @@ type ExportOptions struct {
 	ArchivePath    string
 	ExportOptions  string
 	IPAPath        string
+	PKGPath        string
 	Overwrite      bool
 	XcodebuildArgs []string
 	Environment    []string
@@ -106,6 +107,7 @@ type ExportOptions struct {
 type ExportResult struct {
 	ArchivePath string `json:"archive_path"`
 	IPAPath     string `json:"ipa_path"`
+	PKGPath     string `json:"pkg_path,omitempty"`
 	BundleID    string `json:"bundle_id,omitempty"`
 	Version     string `json:"version,omitempty"`
 	BuildNumber string `json:"build_number,omitempty"`
@@ -183,18 +185,22 @@ func ValidateExportDestination(ipaPath string, overwrite, directUpload bool) err
 	if directUpload {
 		return nil
 	}
-	info, err := os.Lstat(ipaPath)
+	return validateAvailableExportDestination(ipaPath, "--ipa-path", "ipa path", overwrite)
+}
+
+func validateAvailableExportDestination(path, flagName, description string, overwrite bool) error {
+	info, err := os.Lstat(path)
 	switch {
 	case err == nil && info.IsDir():
-		return exportDestinationUsageError{message: fmt.Sprintf("--ipa-path must not be a directory: %s", ipaPath)}
+		return exportDestinationUsageError{message: fmt.Sprintf("%s must not be a directory: %s", flagName, path)}
 	case err == nil && !overwrite:
-		return exportDestinationUsageError{message: fmt.Sprintf("--ipa-path already exists: %s (use --overwrite to replace it)", ipaPath)}
+		return exportDestinationUsageError{message: fmt.Sprintf("%s already exists: %s (use --overwrite to replace it)", flagName, path)}
 	case err == nil && overwrite:
 		return nil
 	case errors.Is(err, os.ErrNotExist):
 		return nil
 	default:
-		return fmt.Errorf("lstat ipa path: %w", err)
+		return fmt.Errorf("lstat %s: %w", description, err)
 	}
 }
 
@@ -206,6 +212,31 @@ func PreflightExportDestination(ipaPath string, overwrite, directUpload bool) er
 		return err
 	}
 	return preflightWritableParent(strings.TrimSpace(ipaPath), "ipa output")
+}
+
+// ValidateExportPKGDestination checks a PKG destination without mutating the
+// filesystem.
+func ValidateExportPKGDestination(pkgPath string, overwrite, directUpload bool) error {
+	pkgPath = strings.TrimSpace(pkgPath)
+	if pkgPath == "" {
+		return exportDestinationUsageError{message: "--pkg-path is required"}
+	}
+	if !strings.EqualFold(filepath.Ext(pkgPath), ".pkg") {
+		return exportDestinationUsageError{message: "--pkg-path must end with .pkg"}
+	}
+	if directUpload {
+		return nil
+	}
+	return validateAvailableExportDestination(pkgPath, "--pkg-path", "pkg path", overwrite)
+}
+
+// PreflightExportPKGDestination validates a PKG destination and proves its
+// parent writable with a transient probe.
+func PreflightExportPKGDestination(pkgPath string, overwrite, directUpload bool) error {
+	if err := ValidateExportPKGDestination(pkgPath, overwrite, directUpload); err != nil {
+		return err
+	}
+	return preflightWritableParent(strings.TrimSpace(pkgPath), "pkg output")
 }
 
 func preflightWritableParent(path, description string) error {
@@ -266,6 +297,10 @@ func Export(ctx context.Context, opts ExportOptions) (*ExportResult, error) {
 	if err := validateExportOptions(opts); err != nil {
 		return nil, err
 	}
+	uploadMode := isDirectUploadMode(opts.ExportOptions)
+	if opts.IPAPath == "" && opts.PKGPath == "" && !uploadMode {
+		return nil, fmt.Errorf("--ipa-path or --pkg-path is required unless ExportOptions.plist uses destination=upload")
+	}
 	if err := ensureXcodeAvailableWithEnvironment(ctx, opts.Environment, opts.terminateProcessGroup); err != nil {
 		return nil, err
 	}
@@ -273,26 +308,30 @@ func Export(ctx context.Context, opts ExportOptions) (*ExportResult, error) {
 		return nil, err
 	}
 
-	// Always ensure parent dir exists (needed for temp dir creation below).
-	if err := os.MkdirAll(filepath.Dir(opts.IPAPath), 0o755); err != nil {
-		return nil, fmt.Errorf("create output directory: %w", err)
-	}
-
 	// When the ExportOptions plist has destination=upload, xcodebuild uploads
-	// directly to App Store Connect and does not produce a local .ipa file.
+	// directly to App Store Connect and does not produce a local artifact.
 	// This is the normal path for tvOS and some macOS exports. Detect this
-	// mode before prepareIPAPath to avoid deleting an existing IPA that will
-	// never be replaced.
-	uploadMode := isDirectUploadMode(opts.ExportOptions)
+	// mode before preparing a destination that will never be written.
 
 	if !uploadMode {
-		if err := prepareIPAPath(opts.IPAPath, opts.Overwrite); err != nil {
-			return nil, err
+		switch {
+		case opts.PKGPath != "":
+			if err := prepareExportArtifactPath(opts.PKGPath, "--pkg-path", "pkg", opts.Overwrite); err != nil {
+				return nil, err
+			}
+		default:
+			if err := prepareIPAPath(opts.IPAPath, opts.Overwrite); err != nil {
+				return nil, err
+			}
 		}
 	}
 	maybeWarnAboutBetaXcodeForAppStoreExport(ctx, opts.ExportOptions, opts.LogWriter)
 
-	tempExportDir, err := os.MkdirTemp(filepath.Dir(opts.IPAPath), ".asc-xcode-export-*")
+	tempParent := ""
+	if !uploadMode {
+		tempParent = filepath.Dir(exportArtifactPath(opts))
+	}
+	tempExportDir, err := os.MkdirTemp(tempParent, ".asc-xcode-export-*")
 	if err != nil {
 		return nil, fmt.Errorf("create temporary export directory: %w", err)
 	}
@@ -304,7 +343,7 @@ func Export(ctx context.Context, opts ExportOptions) (*ExportResult, error) {
 	}
 
 	if uploadMode {
-		// xcodebuild uploaded directly — no local IPA produced.
+		// xcodebuild uploaded directly — no local artifact produced.
 		info, err := readArchiveBundleInfo(opts.ArchivePath)
 		if err != nil {
 			return nil, fmt.Errorf("read archive bundle info after direct upload: %w", err)
@@ -312,6 +351,27 @@ func Export(ctx context.Context, opts ExportOptions) (*ExportResult, error) {
 		return &ExportResult{
 			ArchivePath: opts.ArchivePath,
 			IPAPath:     "",
+			PKGPath:     "",
+			BundleID:    info.BundleID,
+			Version:     info.Version,
+			BuildNumber: info.BuildNumber,
+		}, nil
+	}
+	if opts.PKGPath != "" {
+		exportedPKGPath, err := findExportedArtifact(tempExportDir, ".pkg", "PKG")
+		if err != nil {
+			return nil, err
+		}
+		info, err := readArchiveBundleInfo(opts.ArchivePath)
+		if err != nil {
+			return nil, fmt.Errorf("read archive bundle info after PKG export: %w", err)
+		}
+		if err := moveExportedArtifact(exportedPKGPath, opts.PKGPath, "PKG", opts.Overwrite); err != nil {
+			return nil, err
+		}
+		return &ExportResult{
+			ArchivePath: opts.ArchivePath,
+			PKGPath:     opts.PKGPath,
 			BundleID:    info.BundleID,
 			Version:     info.Version,
 			BuildNumber: info.BuildNumber,
@@ -415,7 +475,7 @@ func SupportsBuildStatusBundleID(ctx context.Context) bool {
 }
 
 // IsDirectUploadMode reports whether ExportOptions.plist uploads directly to
-// App Store Connect instead of producing a local IPA artifact.
+// App Store Connect instead of producing a local artifact.
 func IsDirectUploadMode(exportOptionsPlistPath string) bool {
 	return isDirectUploadMode(exportOptionsPlistPath)
 }
@@ -470,11 +530,14 @@ func validateExportOptions(opts ExportOptions) error {
 	if opts.ExportOptions == "" {
 		return fmt.Errorf("--export-options is required")
 	}
-	if opts.IPAPath == "" {
-		return fmt.Errorf("--ipa-path is required")
+	if opts.IPAPath != "" && opts.PKGPath != "" {
+		return fmt.Errorf("--ipa-path and --pkg-path are mutually exclusive")
 	}
-	if !strings.EqualFold(filepath.Ext(opts.IPAPath), ".ipa") {
+	if opts.IPAPath != "" && !strings.EqualFold(filepath.Ext(opts.IPAPath), ".ipa") {
 		return fmt.Errorf("--ipa-path must end with .ipa")
+	}
+	if opts.PKGPath != "" && !strings.EqualFold(filepath.Ext(opts.PKGPath), ".pkg") {
+		return fmt.Errorf("--pkg-path must end with .pkg")
 	}
 	if err := ValidateExportXcodebuildArgs(opts.XcodebuildArgs); err != nil {
 		return err
@@ -580,6 +643,7 @@ func normalizeExportOptions(opts ExportOptions) ExportOptions {
 	opts.ArchivePath = normalizeDirectoryPath(opts.ArchivePath)
 	opts.ExportOptions = strings.TrimSpace(opts.ExportOptions)
 	opts.IPAPath = strings.TrimSpace(opts.IPAPath)
+	opts.PKGPath = strings.TrimSpace(opts.PKGPath)
 	opts.Environment = cloneEnvironment(opts.Environment)
 	return opts
 }
@@ -1917,39 +1981,54 @@ func prepareArchiveDestination(archivePath string, overwrite bool) error {
 }
 
 func prepareIPAPath(ipaPath string, overwrite bool) error {
-	parent := filepath.Dir(ipaPath)
+	return prepareExportArtifactPath(ipaPath, "--ipa-path", "ipa", overwrite)
+}
+
+func prepareExportArtifactPath(path, flagName, description string, overwrite bool) error {
+	parent := filepath.Dir(path)
 	if err := os.MkdirAll(parent, 0o755); err != nil {
-		return fmt.Errorf("create ipa output directory: %w", err)
+		return fmt.Errorf("create %s output directory: %w", description, err)
 	}
-	_, err := os.Stat(ipaPath)
+	_, err := os.Stat(path)
 	switch {
 	case err == nil && !overwrite:
-		return fmt.Errorf("--ipa-path already exists: %s (use --overwrite to replace it)", ipaPath)
+		return fmt.Errorf("%s already exists: %s (use --overwrite to replace it)", flagName, path)
 	case err == nil && overwrite:
 		return nil
 	case err != nil && !errors.Is(err, os.ErrNotExist):
-		return fmt.Errorf("stat ipa path: %w", err)
+		return fmt.Errorf("stat %s path: %w", description, err)
 	}
 	return nil
 }
 
 func findExportedIPA(exportDir string) (string, error) {
-	matches, err := filepath.Glob(filepath.Join(exportDir, "*.ipa"))
+	return findExportedArtifact(exportDir, ".ipa", "IPA")
+}
+
+func findExportedArtifact(exportDir, extension, artifactName string) (string, error) {
+	matches, err := filepath.Glob(filepath.Join(exportDir, "*"+extension))
 	if err != nil {
-		return "", fmt.Errorf("scan exported ipa: %w", err)
+		return "", fmt.Errorf("scan exported %s: %w", strings.ToLower(artifactName), err)
 	}
 	if len(matches) == 0 {
-		return "", fmt.Errorf("xcodebuild export did not produce an .ipa file")
+		return "", fmt.Errorf("xcodebuild export did not produce a %s file", extension)
 	}
 	if len(matches) > 1 {
-		return "", fmt.Errorf("xcodebuild export produced multiple .ipa files")
+		return "", fmt.Errorf("xcodebuild export produced multiple %s files", extension)
 	}
 	return matches[0], nil
 }
 
+func exportArtifactPath(opts ExportOptions) string {
+	if opts.PKGPath != "" {
+		return opts.PKGPath
+	}
+	return opts.IPAPath
+}
+
 // isDirectUploadMode reads the ExportOptions plist and returns true when
 // destination is set to "upload". In this mode xcodebuild uploads the build
-// directly to App Store Connect and does not produce a local .ipa file.
+// directly to App Store Connect and does not produce a local artifact.
 func isDirectUploadMode(exportOptionsPlistPath string) bool {
 	data, err := os.ReadFile(exportOptionsPlistPath)
 	if err != nil {
@@ -1964,19 +2043,34 @@ func isDirectUploadMode(exportOptionsPlistPath string) bool {
 }
 
 func moveExportedIPA(sourcePath, destinationPath string, overwrite bool) error {
+	return moveExportedArtifact(sourcePath, destinationPath, "IPA", overwrite)
+}
+
+func moveExportedArtifact(sourcePath, destinationPath, artifactName string, overwrite bool) error {
+	artifactLower := strings.ToLower(artifactName)
+	pathInfo, err := os.Lstat(sourcePath)
+	if err != nil {
+		return fmt.Errorf("inspect exported %s: %w", artifactName, err)
+	}
+	if !pathInfo.Mode().IsRegular() {
+		return fmt.Errorf("exported %s is not a regular file", artifactName)
+	}
+	if pathInfo.Size() == 0 {
+		return fmt.Errorf("exported %s is empty", artifactName)
+	}
 	if !overwrite {
 		source, err := os.Open(sourcePath)
 		if err != nil {
-			return fmt.Errorf("open exported ipa: %w", err)
+			return fmt.Errorf("open exported %s: %w", artifactName, err)
 		}
 		defer source.Close()
 		info, err := source.Stat()
 		if err != nil {
-			return fmt.Errorf("inspect exported ipa: %w", err)
+			return fmt.Errorf("inspect exported %s: %w", artifactName, err)
 		}
 		root, err := rootfs.New(filepath.Dir(destinationPath))
 		if err != nil {
-			return fmt.Errorf("open ipa output root: %w", err)
+			return fmt.Errorf("open %s output root: %w", artifactLower, err)
 		}
 		defer root.Close()
 		if _, err := root.CreateNewFrom(filepath.Base(destinationPath), source, info.Mode().Perm()); err != nil {
@@ -1988,9 +2082,9 @@ func moveExportedIPA(sourcePath, destinationPath string, overwrite bool) error {
 	}
 	// Export runs only on macOS, where rename replaces an existing regular file
 	// atomically. Do not unlink the old artifact first: if the final move fails,
-	// the caller's prior IPA remains intact.
+	// the caller's prior artifact remains intact.
 	if err := os.Rename(sourcePath, destinationPath); err != nil {
-		return fmt.Errorf("move exported ipa: %w", err)
+		return fmt.Errorf("move exported %s: %w", artifactLower, err)
 	}
 	return nil
 }

--- a/internal/xcode/xcode_test.go
+++ b/internal/xcode/xcode_test.go
@@ -951,6 +951,116 @@ func TestExportWritesIPAAtExactPathAndReturnsMetadata(t *testing.T) {
 	}
 }
 
+func TestExportWritesPKGAtExactPathAndReturnsArchiveMetadata(t *testing.T) {
+	tempDir := t.TempDir()
+	archivePath := filepath.Join(tempDir, "Demo.xcarchive")
+	if err := writeArchiveInfoPlist(archivePath); err != nil {
+		t.Fatalf("writeArchiveInfoPlist() error: %v", err)
+	}
+	exportOptionsPath := filepath.Join(tempDir, "ExportOptions.plist")
+	if err := os.WriteFile(exportOptionsPath, []byte(`<?xml version="1.0" encoding="UTF-8"?>`), 0o644); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+	logPath := filepath.Join(tempDir, "commands.log")
+
+	restore := overrideTestEnvironment(t)
+	runtimeGOOS = "darwin"
+	lookPathFn = func(file string) (string, error) {
+		return "/usr/bin/xcodebuild", nil
+	}
+	commandContextFn = helperCommandContext(t, logPath)
+	t.Setenv("ASC_XCODE_HELPER_EXPORT_PKG", "1")
+	t.Cleanup(restore)
+
+	pkgPath := filepath.Join(tempDir, "artifacts", "Demo.pkg")
+	result, err := Export(context.Background(), ExportOptions{
+		ArchivePath:   archivePath,
+		ExportOptions: exportOptionsPath,
+		PKGPath:       pkgPath,
+	})
+	if err != nil {
+		t.Fatalf("Export() error: %v", err)
+	}
+	if result.PKGPath != pkgPath || result.IPAPath != "" {
+		t.Fatalf("Export() result = %+v, want only PKG path", result)
+	}
+	if result.BundleID != "com.example.demo" || result.Version != "1.2.3" || result.BuildNumber != "42" {
+		t.Fatalf("Export() metadata = %+v, want archive metadata", result)
+	}
+	data, err := os.ReadFile(pkgPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+	if string(data) != "exported pkg" {
+		t.Fatalf("PKG contents = %q, want exported package", data)
+	}
+}
+
+func TestExportRejectsUnsafePKGWithoutReplacingDestination(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		helperMode string
+		wantError  string
+	}{
+		{name: "missing", wantError: "did not produce a .pkg file"},
+		{name: "empty", helperMode: "empty", wantError: "exported PKG is empty"},
+		{name: "directory", helperMode: "directory", wantError: "exported PKG is not a regular file"},
+		{name: "multiple", helperMode: "multiple", wantError: "produced multiple .pkg files"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			archivePath := filepath.Join(tempDir, "Demo.xcarchive")
+			if err := writeArchiveInfoPlist(archivePath); err != nil {
+				t.Fatalf("writeArchiveInfoPlist() error: %v", err)
+			}
+			exportOptionsPath := filepath.Join(tempDir, "ExportOptions.plist")
+			if err := os.WriteFile(exportOptionsPath, []byte(`<?xml version="1.0" encoding="UTF-8"?>`), 0o644); err != nil {
+				t.Fatalf("WriteFile() error: %v", err)
+			}
+
+			restore := overrideTestEnvironment(t)
+			runtimeGOOS = "darwin"
+			lookPathFn = func(string) (string, error) { return "/usr/bin/xcodebuild", nil }
+			commandContextFn = helperCommandContext(t, filepath.Join(tempDir, "commands.log"))
+			t.Setenv("ASC_XCODE_HELPER_EXPORT_PKG", tc.helperMode)
+			t.Cleanup(restore)
+
+			pkgPath := filepath.Join(tempDir, "Demo.pkg")
+			if err := os.WriteFile(pkgPath, []byte("existing pkg"), 0o644); err != nil {
+				t.Fatalf("WriteFile() error: %v", err)
+			}
+			_, err := Export(context.Background(), ExportOptions{
+				ArchivePath:   archivePath,
+				ExportOptions: exportOptionsPath,
+				PKGPath:       pkgPath,
+				Overwrite:     true,
+			})
+			if err == nil || !strings.Contains(err.Error(), tc.wantError) {
+				t.Fatalf("Export() error = %v, want %q", err, tc.wantError)
+			}
+			data, readErr := os.ReadFile(pkgPath)
+			if readErr != nil {
+				t.Fatalf("ReadFile() error: %v", readErr)
+			}
+			if string(data) != "existing pkg" {
+				t.Fatalf("destination contents = %q, want existing package", data)
+			}
+		})
+	}
+}
+
+func TestExportRejectsMultipleArtifactPaths(t *testing.T) {
+	_, err := Export(context.Background(), ExportOptions{
+		ArchivePath:   "Demo.xcarchive",
+		ExportOptions: "ExportOptions.plist",
+		IPAPath:       "Demo.ipa",
+		PKGPath:       "Demo.pkg",
+	})
+	if err == nil || !strings.Contains(err.Error(), "--ipa-path and --pkg-path are mutually exclusive") {
+		t.Fatalf("Export() error = %v, want artifact conflict", err)
+	}
+}
+
 func TestExportValidatesGeneratedIPABeforeReplacingDestination(t *testing.T) {
 	tempDir := t.TempDir()
 	archivePath := filepath.Join(tempDir, "Demo.xcarchive")
@@ -1080,7 +1190,7 @@ func TestExportDirectUploadPreservesExistingIPAAndReturnsArchiveMetadata(t *test
 	}
 }
 
-func TestExportDirectUploadCreatesIPAParentDirectory(t *testing.T) {
+func TestExportDirectUploadDoesNotRequireOrCreateArtifactDestination(t *testing.T) {
 	tempDir := t.TempDir()
 	archivePath := filepath.Join(tempDir, "Demo.xcarchive")
 	if err := writeArchiveInfoPlist(archivePath); err != nil {
@@ -1098,11 +1208,9 @@ func TestExportDirectUploadCreatesIPAParentDirectory(t *testing.T) {
 	commandContextFn = helperCommandContext(t, logPath)
 	t.Cleanup(restore)
 
-	ipaPath := filepath.Join(tempDir, "nested", "output", "Demo.ipa")
 	result, err := Export(context.Background(), ExportOptions{
 		ArchivePath:   archivePath,
 		ExportOptions: exportOptionsPath,
-		IPAPath:       ipaPath,
 	})
 	if err != nil {
 		t.Fatalf("Export() error: %v", err)
@@ -1110,11 +1218,8 @@ func TestExportDirectUploadCreatesIPAParentDirectory(t *testing.T) {
 	if result.IPAPath != "" {
 		t.Fatalf("expected no local ipa path for direct upload, got %q", result.IPAPath)
 	}
-	if _, err := os.Stat(filepath.Dir(ipaPath)); err != nil {
-		t.Fatalf("expected IPA parent directory to exist, got %v", err)
-	}
-	if _, err := os.Stat(ipaPath); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("expected no IPA artifact to be written, got %v", err)
+	if result.PKGPath != "" {
+		t.Fatalf("expected no local pkg path for direct upload, got %q", result.PKGPath)
 	}
 }
 
@@ -2217,6 +2322,34 @@ func TestXcodeHelperProcess(t *testing.T) {
 			time.Sleep(parsed)
 		}
 		if isDirectUploadMode(exportOptionsPath) {
+			os.Exit(0)
+		}
+		switch os.Getenv("ASC_XCODE_HELPER_EXPORT_PKG") {
+		case "1":
+			if err := os.WriteFile(filepath.Join(exportPath, "Exported.pkg"), []byte("exported pkg"), 0o644); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(2)
+			}
+			os.Exit(0)
+		case "empty":
+			if err := os.WriteFile(filepath.Join(exportPath, "Exported.pkg"), nil, 0o644); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(2)
+			}
+			os.Exit(0)
+		case "directory":
+			if err := os.Mkdir(filepath.Join(exportPath, "Exported.pkg"), 0o700); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(2)
+			}
+			os.Exit(0)
+		case "multiple":
+			for _, name := range []string{"One.pkg", "Two.pkg"} {
+				if err := os.WriteFile(filepath.Join(exportPath, name), []byte("exported pkg"), 0o644); err != nil {
+					fmt.Fprintln(os.Stderr, err)
+					os.Exit(2)
+				}
+			}
 			os.Exit(0)
 		}
 		switch os.Getenv("ASC_XCODE_HELPER_MALICIOUS_IPA") {


### PR DESCRIPTION
## Summary

- add `asc xcode export --pkg-path` for deterministic macOS package output
- preserve existing IPA output while validating and publishing PKGs safely
- allow `destination=upload` without a meaningless local artifact placeholder
- reject unsupported generated manual-signing PKG options with explicit-plist guidance

## Verification

- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- final Codex branch review against refreshed `origin/main`: no actionable findings

Fixes #2493