### PR TITLE
feat(publish): support macOS PKG local builds

### DIFF
--- a/docs/design/publish-local-build-macos-pkg.md
+++ b/docs/design/publish-local-build-macos-pkg.md
@@ -1,0 +1,33 @@
+# macOS PKG support for local-build publish
+
+## Problem
+
+`asc publish testflight` and `asc publish appstore` already accept
+`--platform MAC_OS` in local-build mode and archive with the macOS destination.
+The export and upload stages still force an `.ipa` destination and reserve the
+upload as `com.apple.ipa`, so the advertised macOS path cannot complete.
+
+## Contract
+
+- Local builds for `MAC_OS` export a `.pkg`; other platforms continue to export
+  an `.ipa`.
+- `--pkg-path` is a local-build-only destination override for `MAC_OS`.
+- `--ipa-path` and `--pkg-path` are mutually exclusive. `--ipa-path` is rejected
+  for `MAC_OS`, and `--pkg-path` is rejected for other platforms.
+- The default macOS artifact is
+  `.asc/artifacts/<scheme>-MAC_OS-<version>-<build>.pkg`.
+- The exported PKG is validated as a non-empty regular, non-symlink file before
+  creating an upload reservation with UTI `com.apple.pkg`.
+- JSON and rendered stage output report `pkgPath` / `pkg_path` for macOS and do
+  not claim an IPA was produced.
+
+An explicit ExportOptions plist remains supported. Generated manual signing for
+macOS remains unavailable because Xcode signing-asset synthesis currently only
+supports iOS and tvOS; local-build publish rejects that combination before the
+archive side effect and directs callers to an explicit plist.
+
+## Compatibility
+
+The iOS, tvOS, and visionOS IPA paths are unchanged. The previous
+`--platform MAC_OS --ipa-path` combination could not produce a valid publishable
+artifact, so it now returns a usage error with the PKG migration path.

--- a/internal/asc/output_publish.go
+++ b/internal/asc/output_publish.go
@@ -119,18 +119,25 @@ func publishExportStageRows(stage *PublishExportStageResult) ([]string, [][]stri
 	if stage == nil {
 		return []string{"Field", "Value"}, nil
 	}
-	ipaPath := stage.IPAPath
-	if strings.TrimSpace(ipaPath) == "" {
-		ipaPath = "(direct upload - no local artifact)"
-	}
 	rows := [][]string{
 		{"archive_path", stage.ArchivePath},
-		{"ipa_path", ipaPath},
-		{"bundle_id", stage.BundleID},
-		{"version", stage.Version},
-		{"build_number", stage.BuildNumber},
-		{"export_options_path", stage.ExportOptionsPath},
-		{"direct_upload", fmt.Sprintf("%t", stage.DirectUpload)},
 	}
+	if strings.TrimSpace(stage.PKGPath) != "" {
+		rows = append(rows, []string{"pkg_path", stage.PKGPath})
+	} else {
+		ipaPath := stage.IPAPath
+		if strings.TrimSpace(ipaPath) == "" {
+			ipaPath = "(direct upload - no local artifact)"
+		}
+		rows = append(rows, []string{"ipa_path", ipaPath})
+	}
+	rows = append(
+		rows,
+		[]string{"bundle_id", stage.BundleID},
+		[]string{"version", stage.Version},
+		[]string{"build_number", stage.BuildNumber},
+		[]string{"export_options_path", stage.ExportOptionsPath},
+		[]string{"direct_upload", fmt.Sprintf("%t", stage.DirectUpload)},
+	)
 	return []string{"Field", "Value"}, rows
 }

--- a/internal/asc/output_publish_test.go
+++ b/internal/asc/output_publish_test.go
@@ -50,3 +50,22 @@ func TestAppStorePublishResultRowsDryRunUsesPlanSummaryColumns(t *testing.T) {
 		t.Fatalf("expected will-submit column true, got %q", rows[0][5])
 	}
 }
+
+func TestPublishExportStageRowsUsesPKGPath(t *testing.T) {
+	_, rows := publishExportStageRows(&PublishExportStageResult{
+		ArchivePath: "Demo.xcarchive",
+		PKGPath:     "Demo.pkg",
+	})
+	foundPKG := false
+	for _, row := range rows {
+		if len(row) == 2 && row[0] == "pkg_path" && row[1] == "Demo.pkg" {
+			foundPKG = true
+		}
+		if len(row) == 2 && row[0] == "ipa_path" {
+			t.Fatalf("PKG export must not render an IPA row: %v", rows)
+		}
+	}
+	if !foundPKG {
+		t.Fatalf("expected pkg_path row, got %v", rows)
+	}
+}

--- a/internal/asc/publish.go
+++ b/internal/asc/publish.go
@@ -25,6 +25,7 @@ type PublishArchiveStageResult struct {
 type PublishExportStageResult struct {
 	ArchivePath       string `json:"archivePath"`
 	IPAPath           string `json:"ipaPath,omitempty"`
+	PKGPath           string `json:"pkgPath,omitempty"`
 	BundleID          string `json:"bundleId,omitempty"`
 	Version           string `json:"version,omitempty"`
 	BuildNumber       string `json:"buildNumber,omitempty"`

--- a/internal/cli/publish/local_build.go
+++ b/internal/cli/publish/local_build.go
@@ -31,10 +31,12 @@ var (
 		return shared.GetASCClient()
 	}
 	validatePublishIPAPathFn        = shared.ValidateIPAPath
+	validatePublishPKGPathFn        = shared.ValidatePKGPath
 	resolvePublishNextBuildNumberFn = func(ctx context.Context, client *asc.Client, opts shared.NextBuildNumberOptions) (*asc.BuildsNextBuildNumberResult, error) {
 		return shared.ResolveNextBuildNumber(ctx, client, opts)
 	}
 	uploadBuildAndWaitForIDFn       = uploadBuildAndWaitForID
+	uploadPKGBuildAndWaitForIDFn    = uploadPKGBuildAndWaitForID
 	resolvePublishAppIDWithLookupFn = func(ctx context.Context, client *asc.Client, appID string) (string, error) {
 		return shared.ResolveAppIDWithLookup(ctx, client, appID)
 	}
@@ -54,6 +56,7 @@ type publishLocalBuildFlagValues struct {
 	teamID               *string
 	archivePath          *string
 	ipaPath              *string
+	pkgPath              *string
 	clean                *bool
 	initialBuildNumber   *int
 	archiveXcodebuildArg shared.MultiStringFlag
@@ -71,6 +74,7 @@ type publishLocalBuildConfig struct {
 	TeamID                string
 	ArchivePath           string
 	IPAPath               string
+	PKGPath               string
 	Clean                 bool
 	ArchiveXcodebuildArgs []string
 	ExportXcodebuildArgs  []string
@@ -96,6 +100,7 @@ func bindPublishLocalBuildFlags(fs *flag.FlagSet) *publishLocalBuildFlagValues {
 	values.teamID = fs.String("team-id", "", "Apple Developer team ID for generated local-build options (overrides archive metadata)")
 	values.archivePath = fs.String("archive-path", "", "Destination path for the .xcarchive output in local-build mode")
 	values.ipaPath = fs.String("ipa-path", "", "Destination path for the .ipa output in local-build mode")
+	values.pkgPath = fs.String("pkg-path", "", "Destination path for the macOS .pkg output in local-build mode")
 	values.clean = fs.Bool("clean", false, "Run clean before local-build archive")
 	values.initialBuildNumber = fs.Int("initial-build-number", 1, "Initial build number when local-build mode auto-resolves a build number")
 	fs.Var(&values.archiveXcodebuildArg, "archive-xcodebuild-flag", "Pass a raw argument through to xcodebuild during local-build archive (repeatable)")
@@ -135,6 +140,7 @@ func validateLocalBuildFlagUsage(localBuildMode bool, setFlags map[string]bool) 
 	for _, flagName := range []string{
 		"archive-path",
 		"ipa-path",
+		"pkg-path",
 		"export-options",
 		"signing-style",
 		"team-id",
@@ -148,6 +154,30 @@ func validateLocalBuildFlagUsage(localBuildMode bool, setFlags map[string]bool) 
 		if setFlags[flagName] {
 			return shared.UsageErrorf("--%s requires --workspace or --project", flagName)
 		}
+	}
+	return nil
+}
+
+func validateLocalBuildArtifactFlags(values *publishLocalBuildFlagValues, setFlags map[string]bool, platform string) error {
+	if values == nil {
+		return nil
+	}
+	if setFlags["pkg-path"] && strings.TrimSpace(*values.pkgPath) == "" {
+		return shared.UsageError("--pkg-path must not be empty")
+	}
+	hasIPAPath := setFlags["ipa-path"] || strings.TrimSpace(*values.ipaPath) != ""
+	hasPKGPath := setFlags["pkg-path"] || strings.TrimSpace(*values.pkgPath) != ""
+	if hasIPAPath && hasPKGPath {
+		return shared.UsageError("--ipa-path and --pkg-path are mutually exclusive")
+	}
+	if strings.EqualFold(strings.TrimSpace(platform), "MAC_OS") {
+		if hasIPAPath {
+			return shared.UsageError("--ipa-path is not supported with --platform MAC_OS; use --pkg-path")
+		}
+		return nil
+	}
+	if hasPKGPath {
+		return shared.UsageError("--pkg-path is only supported with --platform MAC_OS")
 	}
 	return nil
 }
@@ -228,18 +258,34 @@ func resolveLocalBuildConfig(values *publishLocalBuildFlagValues, platform, vers
 		return publishLocalBuildConfig{}, err
 	}
 	if exportOptionsPath != "" && localxcode.IsDirectUploadMode(exportOptionsPath) {
-		return publishLocalBuildConfig{}, shared.UsageError("--export-options with destination=upload is not supported by publish; use export options that produce a local IPA")
+		return publishLocalBuildConfig{}, shared.UsageError("--export-options with destination=upload is not supported by publish; use export options that produce a local artifact")
 	}
 	config.ExportOptionsPath = exportOptionsPath
+	if strings.EqualFold(strings.TrimSpace(platform), "MAC_OS") && exportOptionsPath == "" && config.SigningStyle == "manual" {
+		return publishLocalBuildConfig{}, shared.UsageError("manual signing for a macOS local build requires an explicit --export-options plist")
+	}
 
 	config.ArchivePath = strings.TrimSpace(*values.archivePath)
 	if config.ArchivePath == "" {
 		config.ArchivePath = defaultPublishArchivePath(config.Scheme, platform, version, buildNumber)
 	}
 
-	config.IPAPath = strings.TrimSpace(*values.ipaPath)
-	if config.IPAPath == "" {
-		config.IPAPath = defaultPublishIPAPath(config.Scheme, platform, version, buildNumber)
+	if strings.EqualFold(strings.TrimSpace(platform), "MAC_OS") {
+		config.PKGPath = strings.TrimSpace(*values.pkgPath)
+		if config.PKGPath == "" {
+			config.PKGPath = defaultPublishPKGPath(config.Scheme, platform, version, buildNumber)
+		}
+		if err := localxcode.ValidateExportPKGDestination(config.PKGPath, true, false); err != nil {
+			if localxcode.IsExportDestinationUsageError(err) {
+				return publishLocalBuildConfig{}, shared.UsageError(err.Error())
+			}
+			return publishLocalBuildConfig{}, fmt.Errorf("validate local-build PKG destination: %w", err)
+		}
+	} else {
+		config.IPAPath = strings.TrimSpace(*values.ipaPath)
+		if config.IPAPath == "" {
+			config.IPAPath = defaultPublishIPAPath(config.Scheme, platform, version, buildNumber)
+		}
 	}
 
 	return config, nil
@@ -278,7 +324,16 @@ func runPublishLocalBuild(ctx context.Context, client *asc.Client, appID, platfo
 		return nil, shared.UsageError(err.Error())
 	}
 	config.SigningStyle = signingStyle
-	if err := localxcode.ValidateExportDestination(config.IPAPath, true, false); err != nil {
+	isPKG := strings.EqualFold(strings.TrimSpace(platform), "MAC_OS")
+	artifactPath := config.IPAPath
+	validateExportDestination := localxcode.ValidateExportDestination
+	preflightExportDestination := localxcode.PreflightExportDestination
+	if isPKG {
+		artifactPath = config.PKGPath
+		validateExportDestination = localxcode.ValidateExportPKGDestination
+		preflightExportDestination = localxcode.PreflightExportPKGDestination
+	}
+	if err := validateExportDestination(artifactPath, true, false); err != nil {
 		if localxcode.IsExportDestinationUsageError(err) {
 			return nil, shared.UsageError(err.Error())
 		}
@@ -287,7 +342,7 @@ func runPublishLocalBuild(ctx context.Context, client *asc.Client, appID, platfo
 	if err := preflightPublishXcodeFn(ctx); err != nil {
 		return nil, fmt.Errorf("preflight local-build Xcode: %w", err)
 	}
-	if err := localxcode.PreflightExportDestination(config.IPAPath, true, false); err != nil {
+	if err := preflightExportDestination(artifactPath, true, false); err != nil {
 		if localxcode.IsExportDestinationUsageError(err) {
 			return nil, shared.UsageError(err.Error())
 		}
@@ -335,6 +390,7 @@ func runPublishLocalBuild(ctx context.Context, client *asc.Client, appID, platfo
 		ArchivePath:    archiveResult.ArchivePath,
 		ExportOptions:  exportOptionsPath,
 		IPAPath:        config.IPAPath,
+		PKGPath:        config.PKGPath,
 		Overwrite:      true,
 		XcodebuildArgs: publishExportXcodebuildArgs(config.ExportXcodebuildArgs),
 		LogWriter:      os.Stderr,
@@ -354,31 +410,42 @@ func runPublishLocalBuild(ctx context.Context, client *asc.Client, appID, platfo
 		Export: &asc.PublishExportStageResult{
 			ArchivePath:       strings.TrimSpace(exportResult.ArchivePath),
 			IPAPath:           strings.TrimSpace(exportResult.IPAPath),
+			PKGPath:           strings.TrimSpace(exportResult.PKGPath),
 			BundleID:          firstNonEmpty(strings.TrimSpace(exportResult.BundleID), strings.TrimSpace(archiveResult.BundleID)),
 			Version:           firstNonEmpty(strings.TrimSpace(exportResult.Version), strings.TrimSpace(archiveResult.Version), strings.TrimSpace(version)),
 			BuildNumber:       firstNonEmpty(strings.TrimSpace(exportResult.BuildNumber), strings.TrimSpace(archiveResult.BuildNumber), strings.TrimSpace(buildNumber)),
 			ExportOptionsPath: exportOptionsPath,
-			DirectUpload:      strings.TrimSpace(exportResult.IPAPath) == "",
+			DirectUpload:      strings.TrimSpace(exportResult.IPAPath) == "" && strings.TrimSpace(exportResult.PKGPath) == "",
 		},
 		Version:     firstNonEmpty(strings.TrimSpace(exportResult.Version), strings.TrimSpace(archiveResult.Version), strings.TrimSpace(version)),
 		BuildNumber: firstNonEmpty(strings.TrimSpace(exportResult.BuildNumber), strings.TrimSpace(archiveResult.BuildNumber), strings.TrimSpace(buildNumber)),
 	}
 
-	if strings.TrimSpace(exportResult.IPAPath) == "" {
-		return nil, fmt.Errorf("export local build: expected a local IPA artifact for publish upload")
+	exportedArtifactPath := strings.TrimSpace(exportResult.IPAPath)
+	validateArtifactPath := validatePublishIPAPathFn
+	uploadArtifact := uploadBuildAndWaitForIDFn
+	artifactName := "IPA"
+	if isPKG {
+		exportedArtifactPath = strings.TrimSpace(exportResult.PKGPath)
+		validateArtifactPath = validatePublishPKGPathFn
+		uploadArtifact = uploadPKGBuildAndWaitForIDFn
+		artifactName = "PKG"
+	}
+	if exportedArtifactPath == "" {
+		return nil, fmt.Errorf("export local build: expected a local %s artifact for publish upload", artifactName)
 	}
 
-	fileInfo, err := validatePublishIPAPathFn(exportResult.IPAPath)
+	fileInfo, err := validateArtifactPath(exportedArtifactPath)
 	if err != nil {
-		return nil, fmt.Errorf("validate exported IPA: %w", err)
+		return nil, fmt.Errorf("validate exported %s: %w", artifactName, err)
 	}
 	uploadRequestCtx, cancel := shared.ContextWithTimeoutDuration(ctx, timeout)
 	defer cancel()
-	uploadResult, err := uploadBuildAndWaitForIDFn(
+	uploadResult, err := uploadArtifact(
 		uploadRequestCtx,
 		client,
 		appID,
-		exportResult.IPAPath,
+		exportedArtifactPath,
 		fileInfo,
 		result.Version,
 		result.BuildNumber,
@@ -444,6 +511,17 @@ func defaultPublishArchivePath(scheme, platform, version, buildNumber string) st
 func defaultPublishIPAPath(scheme, platform, version, buildNumber string) string {
 	fileName := fmt.Sprintf(
 		"%s-%s-%s-%s.ipa",
+		sanitizePublishArtifactToken(scheme),
+		sanitizePublishArtifactToken(platform),
+		sanitizePublishArtifactToken(version),
+		sanitizePublishArtifactToken(buildNumber),
+	)
+	return filepath.Join(".asc", "artifacts", fileName)
+}
+
+func defaultPublishPKGPath(scheme, platform, version, buildNumber string) string {
+	fileName := fmt.Sprintf(
+		"%s-%s-%s-%s.pkg",
 		sanitizePublishArtifactToken(scheme),
 		sanitizePublishArtifactToken(platform),
 		sanitizePublishArtifactToken(version),

--- a/internal/cli/publish/publish.go
+++ b/internal/cli/publish/publish.go
@@ -100,7 +100,7 @@ func PublishTestFlightCommand() *ffcli.Command {
 		LongHelp: `Upload or local-build a binary, then optionally distribute it to TestFlight beta groups.
 
 Steps:
-1. Build locally with Xcode or upload an IPA (unless --build-id/--build-number is provided)
+1. Build locally with Xcode or upload an IPA (unless --build-id/--build-number is provided); macOS local builds export a PKG
 2. Wait for processing when needed (--wait, --test-notes, or --submit)
 3. Stop and return the build metadata with --upload-only, or add the build to specified beta groups
 4. Optionally notify testers
@@ -111,6 +111,7 @@ Examples:
   asc publish testflight --app "123" --ipa app.ipa --upload-only --wait --output json
   asc publish testflight --app "123" --ipa app.ipa --group "GROUP_ID"
   asc publish testflight --app "123" --workspace App.xcworkspace --scheme App --version 1.2.3 --group "GROUP_ID"
+  asc publish testflight --app "123" --workspace MacApp.xcworkspace --scheme MacApp --version 1.2.3 --platform MAC_OS --pkg-path .asc/artifacts/MacApp.pkg --group "GROUP_ID"
   asc publish testflight --app "123" --workspace App.xcworkspace --scheme App --version 1.2.3 --group "GROUP_ID" --signing-style manual --team-id TEAM_ID
   asc publish testflight --app "123" --ipa app.ipa --group "External Testers"
   asc publish testflight --app "123" --ipa app.ipa --group "G1,G2" --wait --notify
@@ -231,6 +232,11 @@ Examples:
 			normalizedPlatform, err := shared.NormalizeAppStoreVersionPlatform(*platform)
 			if err != nil {
 				return shared.UsageError(err.Error())
+			}
+			if localBuildMode {
+				if err := validateLocalBuildArtifactFlags(localBuild, setFlags, normalizedPlatform); err != nil {
+					return err
+				}
 			}
 
 			var uploadFileInfo os.FileInfo
@@ -502,7 +508,7 @@ func PublishAppStoreCommand() *ffcli.Command {
 		LongHelp: `Use this as the canonical high-level App Store publish command.
 
 Workflow:
-1. Build locally with Xcode or upload an IPA
+1. Build locally with Xcode or upload an IPA; macOS local builds export a PKG
 2. Wait for build processing (if --wait)
 3. Find or create the App Store version
 4. Apply version localization metadata (if --metadata-dir)
@@ -519,6 +525,7 @@ Examples:
   asc publish appstore --app "123" --ipa app.ipa --version 1.2.3 --metadata-dir ./metadata --submit --confirm
   asc publish appstore --app "123" --ipa app.ipa --version 1.2.3 --submit --dry-run
   asc publish appstore --app "123" --workspace App.xcworkspace --scheme App --version 1.2.3
+  asc publish appstore --app "123" --workspace MacApp.xcworkspace --scheme MacApp --version 1.2.3 --platform MAC_OS --pkg-path .asc/artifacts/MacApp.pkg
   asc publish appstore --app "123" --workspace App.xcworkspace --scheme App --version 1.2.3 --signing-style manual --team-id TEAM_ID
   asc publish appstore --app "123" --ipa app.ipa --version 1.2.3 --submit --confirm`,
 		FlagSet:   fs,
@@ -580,6 +587,11 @@ Examples:
 			normalizedPlatform, err := shared.NormalizeAppStoreVersionPlatform(*platform)
 			if err != nil {
 				return shared.UsageError(err.Error())
+			}
+			if localBuildMode {
+				if err := validateLocalBuildArtifactFlags(localBuild, setFlags, normalizedPlatform); err != nil {
+					return err
+				}
 			}
 
 			var fileInfo os.FileInfo
@@ -867,7 +879,7 @@ func plannedAppStorePublishResult(mode asc.PublishMode, version, buildNumber str
 		Uploaded:     false,
 		Attached:     false,
 		Submitted:    false,
-		Plan:         plannedAppStorePublishSteps(localBuildMode, wait, submit, applyMetadata),
+		Plan:         plannedAppStorePublishSteps(localBuildMode, localBuildConfig.PKGPath != "", wait, submit, applyMetadata),
 	}
 
 	if !localBuildMode {
@@ -884,6 +896,7 @@ func plannedAppStorePublishResult(mode asc.PublishMode, version, buildNumber str
 	result.Export = &asc.PublishExportStageResult{
 		ArchivePath:       localBuildConfig.ArchivePath,
 		IPAPath:           localBuildConfig.IPAPath,
+		PKGPath:           localBuildConfig.PKGPath,
 		Version:           version,
 		BuildNumber:       buildNumber,
 		ExportOptionsPath: localBuildConfig.ExportOptionsPath,
@@ -893,17 +906,25 @@ func plannedAppStorePublishResult(mode asc.PublishMode, version, buildNumber str
 	return result
 }
 
-func plannedAppStorePublishSteps(localBuildMode, wait, submit, applyMetadata bool) []asc.PublishPlanStep {
+func plannedAppStorePublishSteps(localBuildMode, pkgLocalBuild, wait, submit, applyMetadata bool) []asc.PublishPlanStep {
 	steps := make([]asc.PublishPlanStep, 0, 8)
 	if localBuildMode {
+		artifactName := "IPA"
+		if pkgLocalBuild {
+			artifactName = "PKG"
+		}
 		steps = append(
 			steps,
 			newPublishPlanStep(publishPlanStepArchiveLocalBuild, "Archive the selected Xcode workspace or project to a local .xcarchive."),
-			newPublishPlanStep(publishPlanStepExportLocalBuild, "Export the archive to a local App Store IPA artifact."),
+			newPublishPlanStep(publishPlanStepExportLocalBuild, "Export the archive to a local App Store "+artifactName+" artifact."),
 		)
 	}
 
-	steps = append(steps, newPublishPlanStep(publishPlanStepUploadBuild, "Upload the IPA to App Store Connect and wait for the build record to appear."))
+	artifactName := "IPA"
+	if pkgLocalBuild {
+		artifactName = "PKG"
+	}
+	steps = append(steps, newPublishPlanStep(publishPlanStepUploadBuild, "Upload the "+artifactName+" to App Store Connect and wait for the build record to appear."))
 	if wait {
 		steps = append(steps, newPublishPlanStep(publishPlanStepWaitForBuildProcessing, "Wait for App Store Connect build processing to reach a terminal state."))
 	}
@@ -951,7 +972,33 @@ type publishUploadResult struct {
 }
 
 func uploadBuildAndWaitForID(ctx context.Context, client *asc.Client, appID, ipaPath string, fileInfo os.FileInfo, version, buildNumber string, platform asc.Platform, pollInterval time.Duration, uploadTimeout time.Duration, overrideUploadTimeout bool) (*publishUploadResult, error) {
-	uploadResp, fileResp, err := shared.PrepareBuildUpload(ctx, client, appID, fileInfo, version, buildNumber, platform, asc.UTIIPA)
+	return uploadBuildArtifactAndWaitForID(ctx, client, appID, ipaPath, fileInfo, version, buildNumber, platform, asc.UTIIPA, pollInterval, uploadTimeout, overrideUploadTimeout)
+}
+
+func uploadPKGBuildAndWaitForID(ctx context.Context, client *asc.Client, appID, pkgPath string, fileInfo os.FileInfo, version, buildNumber string, platform asc.Platform, pollInterval time.Duration, uploadTimeout time.Duration, overrideUploadTimeout bool) (*publishUploadResult, error) {
+	return uploadBuildArtifactAndWaitForID(ctx, client, appID, pkgPath, fileInfo, version, buildNumber, platform, asc.UTIPKG, pollInterval, uploadTimeout, overrideUploadTimeout)
+}
+
+func uploadBuildArtifactAndWaitForID(ctx context.Context, client *asc.Client, appID, artifactPath string, fileInfo os.FileInfo, version, buildNumber string, platform asc.Platform, fileUTI asc.UTI, pollInterval time.Duration, uploadTimeout time.Duration, overrideUploadTimeout bool) (*publishUploadResult, error) {
+	var (
+		artifactFile *os.File
+		openedInfo   os.FileInfo
+		err          error
+	)
+	if fileUTI == asc.UTIPKG {
+		artifactFile, openedInfo, err = shared.OpenValidatedPKGPath(artifactPath)
+	} else {
+		artifactFile, openedInfo, err = shared.OpenValidatedIPAPath(artifactPath)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer artifactFile.Close()
+	if fileInfo != nil && !os.SameFile(fileInfo, openedInfo) {
+		return nil, fmt.Errorf("build artifact changed before upload")
+	}
+
+	uploadResp, fileResp, err := shared.PrepareBuildUpload(ctx, client, appID, openedInfo, version, buildNumber, platform, fileUTI)
 	if err != nil {
 		return nil, err
 	}
@@ -962,7 +1009,7 @@ func uploadBuildAndWaitForID(ctx context.Context, client *asc.Client, appID, ipa
 
 	fmt.Fprintf(os.Stderr, "Uploading %s (%d bytes) to App Store Connect...\n", fileInfo.Name(), fileInfo.Size())
 	uploadCtx, uploadCancel := contextWithPublishUploadTimeout(ctx, uploadTimeout, overrideUploadTimeout)
-	err = asc.ExecuteUploadOperations(uploadCtx, ipaPath, fileResp.Data.Attributes.UploadOperations)
+	err = asc.ExecuteUploadOperationsFromFile(uploadCtx, artifactFile, fileResp.Data.Attributes.UploadOperations)
 	uploadCancel()
 	if err != nil {
 		return nil, err

--- a/internal/cli/publish/publish_local_build_pkg_test.go
+++ b/internal/cli/publish/publish_local_build_pkg_test.go
@@ -1,0 +1,256 @@
+package publish
+
+import (
+	"context"
+	"flag"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	localxcode "github.com/rudrankriyam/App-Store-Connect-CLI/internal/xcode"
+)
+
+func TestUploadPKGBuildAndWaitForIDUsesPKGUTI(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "Demo.pkg")
+	if err := os.WriteFile(path, []byte("pkg"), 0o600); err != nil {
+		t.Fatalf("write PKG: %v", err)
+	}
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat PKG: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	requestCount := 0
+	http.DefaultTransport = publishCommandRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			return publishCommandJSONResponse(http.StatusCreated, `{"data":{"type":"buildUploads","id":"upload-1"}}`)
+		case 2:
+			body, readErr := io.ReadAll(req.Body)
+			if readErr != nil {
+				t.Fatalf("read request body: %v", readErr)
+			}
+			if !strings.Contains(string(body), `"fileName":"Demo.pkg"`) || !strings.Contains(string(body), `"uti":"com.apple.pkg"`) {
+				t.Fatalf("expected PKG file reservation, got %s", body)
+			}
+			return publishCommandJSONResponse(http.StatusCreated, `{"data":{"type":"buildUploadFiles","id":"file-1","attributes":{"fileName":"Demo.pkg","fileSize":3}}}`)
+		default:
+			t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			return nil, nil
+		}
+	})
+
+	_, err = uploadPKGBuildAndWaitForID(context.Background(), newPublishCommandTestClient(t), "app-1", path, fileInfo, "1.2.3", "42", asc.PlatformMacOS, time.Second, time.Second, true)
+	if err == nil || !strings.Contains(err.Error(), "no upload operations returned") {
+		t.Fatalf("expected upload-operation sentinel after reservation, got %v", err)
+	}
+	if requestCount != 2 {
+		t.Fatalf("expected two reservation requests, got %d", requestCount)
+	}
+}
+
+func TestResolveLocalBuildConfigUsesPKGForMacOS(t *testing.T) {
+	fs := flag.NewFlagSet("publish local macos", flag.ContinueOnError)
+	values := bindPublishLocalBuildFlags(fs)
+	if err := fs.Parse([]string{
+		"--project", "Demo.xcodeproj",
+		"--scheme", "Demo",
+		"--export-options", "ExportOptions.plist",
+	}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	if err := validatePublishExportOptionsFlags(values, collectSetFlags(fs)); err != nil {
+		t.Fatalf("validate export options flags: %v", err)
+	}
+
+	config, err := resolveLocalBuildConfig(values, "MAC_OS", "1.2.3", "42")
+	if err != nil {
+		t.Fatalf("resolveLocalBuildConfig() error: %v", err)
+	}
+	if config.PKGPath != filepath.Join(".asc", "artifacts", "Demo-MAC_OS-1.2.3-42.pkg") {
+		t.Fatalf("unexpected PKG path: %q", config.PKGPath)
+	}
+	if config.IPAPath != "" {
+		t.Fatalf("expected no IPA path for MAC_OS, got %q", config.IPAPath)
+	}
+}
+
+func TestResolveLocalBuildConfigRejectsInvalidPKGDestination(t *testing.T) {
+	fs := flag.NewFlagSet("publish local macos invalid pkg", flag.ContinueOnError)
+	values := bindPublishLocalBuildFlags(fs)
+	if err := fs.Parse([]string{
+		"--project", "Demo.xcodeproj",
+		"--scheme", "Demo",
+		"--export-options", "ExportOptions.plist",
+		"--pkg-path", "Demo.zip",
+	}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	if err := validatePublishExportOptionsFlags(values, collectSetFlags(fs)); err != nil {
+		t.Fatalf("validate export options flags: %v", err)
+	}
+
+	_, err := resolveLocalBuildConfig(values, "MAC_OS", "1.2.3", "42")
+	if err == nil || !strings.Contains(err.Error(), "--pkg-path must end with .pkg") {
+		t.Fatalf("expected invalid PKG destination error, got %v", err)
+	}
+}
+
+func TestValidateLocalBuildArtifactFlagsMatchPlatform(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		platform string
+		args     []string
+		wantErr  string
+	}{
+		{
+			name:     "pkg only for macos",
+			platform: "IOS",
+			args:     []string{"--pkg-path", "Demo.pkg"},
+			wantErr:  "--pkg-path is only supported with --platform MAC_OS",
+		},
+		{
+			name:     "pkg path cannot be empty",
+			platform: "MAC_OS",
+			args:     []string{"--pkg-path", ""},
+			wantErr:  "--pkg-path must not be empty",
+		},
+		{
+			name:     "ipa rejected for macos",
+			platform: "MAC_OS",
+			args:     []string{"--ipa-path", "Demo.ipa"},
+			wantErr:  "--ipa-path is not supported with --platform MAC_OS; use --pkg-path",
+		},
+		{
+			name:     "artifact paths mutually exclusive",
+			platform: "MAC_OS",
+			args:     []string{"--ipa-path", "Demo.ipa", "--pkg-path", "Demo.pkg"},
+			wantErr:  "--ipa-path and --pkg-path are mutually exclusive",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fs := flag.NewFlagSet(tc.name, flag.ContinueOnError)
+			values := bindPublishLocalBuildFlags(fs)
+			args := append([]string{"--project", "Demo.xcodeproj", "--scheme", "Demo"}, tc.args...)
+			if err := fs.Parse(args); err != nil {
+				t.Fatalf("parse flags: %v", err)
+			}
+			err := validateLocalBuildArtifactFlags(values, collectSetFlags(fs), tc.platform)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestResolveLocalBuildConfigRejectsGeneratedManualSigningForMacOS(t *testing.T) {
+	t.Chdir(t.TempDir())
+	fs := flag.NewFlagSet("publish local macos manual", flag.ContinueOnError)
+	values := bindPublishLocalBuildFlags(fs)
+	if err := fs.Parse([]string{
+		"--project", "Demo.xcodeproj",
+		"--scheme", "Demo",
+		"--signing-style", "manual",
+	}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	if err := validatePublishExportOptionsFlags(values, collectSetFlags(fs)); err != nil {
+		t.Fatalf("validate export options flags: %v", err)
+	}
+
+	_, err := resolveLocalBuildConfig(values, "MAC_OS", "1.2.3", "42")
+	if err == nil || !strings.Contains(err.Error(), "manual signing for a macOS local build requires an explicit --export-options plist") {
+		t.Fatalf("expected macOS manual-signing usage error, got %v", err)
+	}
+}
+
+func TestRunPublishLocalBuildExportsAndUploadsPKGForMacOS(t *testing.T) {
+	restore := overridePublishCommandTestHooks(t)
+	defer restore()
+
+	tempDir := t.TempDir()
+	pkgPath := filepath.Join(tempDir, "Demo.pkg")
+	archivePath := filepath.Join(tempDir, "Demo.xcarchive")
+
+	preflightPublishXcodeFn = func(context.Context) error { return nil }
+	runPublishArchiveFn = func(_ context.Context, opts localxcode.ArchiveOptions) (*localxcode.ArchiveResult, error) {
+		if !containsString(opts.XcodebuildArgs, "generic/platform=macOS") {
+			t.Fatalf("expected macOS archive destination, got %v", opts.XcodebuildArgs)
+		}
+		return &localxcode.ArchiveResult{
+			ArchivePath: archivePath,
+			BundleID:    "com.example.demo",
+			Version:     "1.2.3",
+			BuildNumber: "42",
+			Scheme:      "Demo",
+		}, nil
+	}
+	runPublishExportFn = func(_ context.Context, opts localxcode.ExportOptions) (*localxcode.ExportResult, error) {
+		if opts.PKGPath != pkgPath || opts.IPAPath != "" {
+			t.Fatalf("expected PKG-only export destination, got IPA=%q PKG=%q", opts.IPAPath, opts.PKGPath)
+		}
+		return &localxcode.ExportResult{
+			ArchivePath: archivePath,
+			PKGPath:     pkgPath,
+			BundleID:    "com.example.demo",
+			Version:     "1.2.3",
+			BuildNumber: "42",
+		}, nil
+	}
+	validatePublishPKGPathFn = func(path string) (os.FileInfo, error) {
+		if path != pkgPath {
+			t.Fatalf("expected PKG validation for %q, got %q", pkgPath, path)
+		}
+		return newPublishTestFileInfo(t)
+	}
+	uploadPKGBuildAndWaitForIDFn = func(_ context.Context, _ *asc.Client, appID, path string, _ os.FileInfo, version, buildNumber string, platform asc.Platform, _ time.Duration, _ time.Duration, _ bool) (*publishUploadResult, error) {
+		if appID != "app-123" || path != pkgPath || platform != asc.PlatformMacOS {
+			t.Fatalf("unexpected PKG upload: app=%q path=%q platform=%q", appID, path, platform)
+		}
+		return &publishUploadResult{
+			Build:   &asc.BuildResponse{Data: asc.Resource[asc.BuildAttributes]{ID: "build-123"}},
+			Version: version, BuildNumber: buildNumber,
+		}, nil
+	}
+
+	result, err := runPublishLocalBuild(
+		context.Background(), nil, "app-123", "MAC_OS", "1.2.3", "42",
+		shared.PublishDefaultPollInterval, time.Minute, false,
+		publishLocalBuildConfig{
+			ProjectPath: "Demo.xcodeproj", Scheme: "Demo", Configuration: "Release",
+			ArchivePath: archivePath, PKGPath: pkgPath, ExportOptionsPath: "ExportOptions.plist",
+		},
+	)
+	if err != nil {
+		t.Fatalf("runPublishLocalBuild() error: %v", err)
+	}
+	if result.Export.PKGPath != pkgPath || result.Export.IPAPath != "" {
+		t.Fatalf("unexpected export result: %#v", result.Export)
+	}
+	if !result.Uploaded || result.Build.Data.ID != "build-123" {
+		t.Fatalf("unexpected upload result: %#v", result)
+	}
+}
+
+func TestPlannedAppStoreMacOSLocalBuildUsesPKG(t *testing.T) {
+	config := publishLocalBuildConfig{
+		Scheme: "Demo", Configuration: "Release",
+		ArchivePath: "Demo.xcarchive", PKGPath: "Demo.pkg",
+	}
+	result := plannedAppStorePublishResult(asc.PublishModeLocalBuild, "1.2.3", "42", false, false, false, true, config)
+	if result.Export == nil || result.Export.PKGPath != "Demo.pkg" || result.Export.IPAPath != "" {
+		t.Fatalf("unexpected planned export: %#v", result.Export)
+	}
+	if len(result.Plan) < 3 || !strings.Contains(result.Plan[1].Message, "PKG") || !strings.Contains(result.Plan[2].Message, "PKG") {
+		t.Fatalf("expected PKG-specific export and upload plan, got %#v", result.Plan)
+	}
+}

--- a/internal/cli/publish/publish_local_build_test.go
+++ b/internal/cli/publish/publish_local_build_test.go
@@ -2526,7 +2526,9 @@ func overridePublishCommandTestHooks(t *testing.T) func() {
 	originalGetClient := getPublishASCClientFn
 	originalResolveNextBuildNumber := resolvePublishNextBuildNumberFn
 	originalValidateIPAPath := validatePublishIPAPathFn
+	originalValidatePKGPath := validatePublishPKGPathFn
 	originalUploadBuildAndWait := uploadBuildAndWaitForIDFn
+	originalUploadPKGBuildAndWait := uploadPKGBuildAndWaitForIDFn
 	originalResolveAppID := resolvePublishAppIDWithLookupFn
 	originalWaitForProcessing := waitForPublishBuildProcessingFn
 	originalMetadataApply := applyPublishVersionMetadataFn
@@ -2541,7 +2543,9 @@ func overridePublishCommandTestHooks(t *testing.T) func() {
 		getPublishASCClientFn = originalGetClient
 		resolvePublishNextBuildNumberFn = originalResolveNextBuildNumber
 		validatePublishIPAPathFn = originalValidateIPAPath
+		validatePublishPKGPathFn = originalValidatePKGPath
 		uploadBuildAndWaitForIDFn = originalUploadBuildAndWait
+		uploadPKGBuildAndWaitForIDFn = originalUploadPKGBuildAndWait
 		resolvePublishAppIDWithLookupFn = originalResolveAppID
 		waitForPublishBuildProcessingFn = originalWaitForProcessing
 		applyPublishVersionMetadataFn = originalMetadataApply

--- a/internal/cli/publish/upload_reconciliation_test.go
+++ b/internal/cli/publish/upload_reconciliation_test.go
@@ -78,3 +78,54 @@ func TestUploadBuildAndWaitForIDRecoversAmbiguousCommit(t *testing.T) {
 		t.Fatalf("expected recovered build result, got %#v", result)
 	}
 }
+
+func TestUploadPKGBuildAndWaitForIDPinsValidatedFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "Demo.pkg")
+	if err := os.WriteFile(path, []byte("old"), 0o600); err != nil {
+		t.Fatalf("write PKG: %v", err)
+	}
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat PKG: %v", err)
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	uploadedOriginal := false
+	http.DefaultTransport = publishCommandRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploads":
+			return publishCommandJSONResponse(http.StatusCreated, `{"data":{"type":"buildUploads","id":"upload-1"}}`)
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/buildUploadFiles":
+			if err := os.Rename(path, path+".validated"); err != nil {
+				t.Fatalf("rename validated PKG: %v", err)
+			}
+			if err := os.WriteFile(path, []byte("new"), 0o600); err != nil {
+				t.Fatalf("replace PKG path: %v", err)
+			}
+			return publishCommandJSONResponse(http.StatusCreated, `{"data":{"type":"buildUploadFiles","id":"file-1","attributes":{"fileName":"Demo.pkg","fileSize":3,"uti":"com.apple.pkg","assetType":"ASSET","uploadOperations":[{"method":"PUT","url":"https://upload.example.com/part-1","length":3,"offset":0}]}}}`)
+		case req.Method == http.MethodPut && req.URL.Host == "upload.example.com":
+			body, readErr := io.ReadAll(req.Body)
+			if readErr != nil {
+				t.Fatalf("read upload body: %v", readErr)
+			}
+			if string(body) != "old" {
+				t.Fatalf("uploaded swapped path contents %q", body)
+			}
+			uploadedOriginal = true
+			return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: io.NopCloser(strings.NewReader(""))}, nil
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/buildUploadFiles/file-1":
+			return publishCommandJSONResponse(http.StatusBadRequest, `{"errors":[{"status":"400","code":"INVALID","title":"stop after upload"}]}`)
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+	})
+
+	_, err = uploadPKGBuildAndWaitForID(context.Background(), newPublishCommandTestClient(t), "app-1", path, fileInfo, "1.2.3", "42", asc.PlatformMacOS, time.Millisecond, time.Second, true)
+	if err == nil || !strings.Contains(err.Error(), "stop after upload") {
+		t.Fatalf("expected commit sentinel, got %v", err)
+	}
+	if !uploadedOriginal {
+		t.Fatal("expected upload to read the pinned validated PKG")
+	}
+}


### PR DESCRIPTION
## Summary
- make local-build publish export macOS archives as PKG artifacts
- upload PKGs with `com.apple.pkg` and report `pkgPath`/`pkg_path`
- reject incompatible artifact flags and unsafe PKG destinations before build side effects
- pin the validated artifact file through reservation and upload

Depends on #2494.

## Verification
- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- uncommitted review: no actionable defects
- final branch review against `origin/codex/2493-xcode-export-pkg`: no actionable defects