### PR TITLE
feat(xcode): validate macOS PKG artifacts

### DIFF
--- a/docs/design/xcode-validate-pkg.md
+++ b/docs/design/xcode-validate-pkg.md
@@ -1,0 +1,26 @@
+# Xcode PKG validation
+
+## Problem
+
+`asc xcode validate` wraps Apple's server-side `altool --validate-app` check but
+only accepts an IPA. Apple's current tool also validates macOS PKG archives, so
+the command unnecessarily blocks the artifact produced by a macOS export.
+
+## Contract
+
+- Exactly one of `--ipa` or `--pkg` is required.
+- `--ipa` continues to infer iOS, tvOS, or visionOS from IPA metadata.
+- `--pkg` requires a `.pkg` file and invokes validation with the macOS type.
+- JSON and rendered output report only the selected artifact path plus the
+  existing `validated` result.
+- Authentication flags and server-error classification are unchanged.
+
+Invalid combinations and extensions remain usage errors. Validation is
+read-only with respect to App Store Connect resources, but it sends the local
+artifact to Apple's validation service.
+
+## Verification
+
+Focused tests cover command routing, output, exact-one validation, extensions,
+and the `altool` arguments. Repository build, format, documentation, lint, full
+tests, and branch review remain the release gates.

--- a/internal/cli/cmdtest/xcode_test.go
+++ b/internal/cli/cmdtest/xcode_test.go
@@ -50,8 +50,14 @@ func TestXcodeCommandExists(t *testing.T) {
 	if findSubcommand(root, "xcode", "export") == nil {
 		t.Fatal("expected xcode export command")
 	}
-	if findSubcommand(root, "xcode", "validate") == nil {
+	validateCmd := findSubcommand(root, "xcode", "validate")
+	if validateCmd == nil {
 		t.Fatal("expected xcode validate command")
+	}
+	for _, name := range []string{"ipa", "pkg", "api-key", "api-issuer", "output"} {
+		if validateCmd.FlagSet.Lookup(name) == nil {
+			t.Fatalf("expected xcode validate to expose --%s", name)
+		}
 	}
 	if findSubcommand(root, "xcode", "version") == nil {
 		t.Fatal("expected xcode version command")
@@ -484,7 +490,7 @@ func TestXcodeExportRejectsInvalidImplicitDestinationAsUsage(t *testing.T) {
 	}
 }
 
-func TestXcodeValidateRequiresIPA(t *testing.T) {
+func TestXcodeValidateRequiresArtifact(t *testing.T) {
 	root := RootCommand("1.2.3")
 	root.FlagSet.SetOutput(io.Discard)
 
@@ -501,8 +507,8 @@ func TestXcodeValidateRequiresIPA(t *testing.T) {
 	if stdout != "" {
 		t.Fatalf("expected empty stdout, got %q", stdout)
 	}
-	if !strings.Contains(stderr, "Error: --ipa is required") {
-		t.Fatalf("expected ipa error, got %q", stderr)
+	if !strings.Contains(stderr, "Error: --ipa or --pkg is required") {
+		t.Fatalf("expected artifact error, got %q", stderr)
 	}
 }
 

--- a/internal/cli/xcode/xcode.go
+++ b/internal/cli/xcode/xcode.go
@@ -447,7 +447,8 @@ Examples:
 func XcodeValidateCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("xcode validate", flag.ExitOnError)
 
-	ipaPath := fs.String("ipa", "", "Path to the .ipa input (required)")
+	ipaPath := fs.String("ipa", "", "Path to an iOS, tvOS, or visionOS .ipa input")
+	pkgPath := fs.String("pkg", "", "Path to a macOS .pkg input")
 	apiKey := fs.String("api-key", "", "App Store Connect API key ID for altool")
 	apiIssuer := fs.String("api-issuer", "", "App Store Connect API issuer ID for altool")
 	output := shared.BindOutputFlags(fs)
@@ -455,19 +456,24 @@ func XcodeValidateCommand() *ffcli.Command {
 	return &ffcli.Command{
 		Name:       "validate",
 		ShortUsage: "asc xcode validate [flags]",
-		ShortHelp:  "Validate an IPA with Apple before upload.",
-		LongHelp: `Validate an IPA with Apple before upload.
+		ShortHelp:  "Validate an IPA or PKG with Apple before upload.",
+		LongHelp: `Validate an IPA or PKG with Apple before upload.
 
-This command wraps xcrun altool --validate-app to check whether an IPA passes
+This command wraps xcrun altool --validate-app to check whether an IPA or PKG passes
 Apple's server-side validation before you upload or submit it.
+
+Exactly one of --ipa or --pkg is required. IPA platform metadata is detected
+from the artifact; PKG validation uses the macOS platform.
 
 Examples:
   asc xcode validate --ipa .asc/artifacts/App.ipa
+  asc xcode validate --pkg .asc/artifacts/MacApp.pkg
   asc xcode validate --ipa .asc/artifacts/App.ipa --api-key KEY123ABC --api-issuer 00000000-0000-0000-0000-000000000000 --output json`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
 			trimmedIPAPath := strings.TrimSpace(*ipaPath)
+			trimmedPKGPath := strings.TrimSpace(*pkgPath)
 			trimmedAPIKey := strings.TrimSpace(*apiKey)
 			trimmedAPIIssuer := strings.TrimSpace(*apiIssuer)
 
@@ -475,12 +481,23 @@ Examples:
 				fmt.Fprintln(os.Stderr, "Error: xcode validate does not accept positional arguments")
 				return flag.ErrHelp
 			}
-			if trimmedIPAPath == "" {
-				fmt.Fprintln(os.Stderr, "Error: --ipa is required")
-				return shared.MissingRequiredUsageError("--ipa")
+			if emptyFlag := firstExplicitlyEmptyFlag(fs, "ipa", "pkg"); emptyFlag != "" {
+				return shared.UsageErrorf("--%s must not be empty", emptyFlag)
 			}
-			if !strings.EqualFold(filepath.Ext(trimmedIPAPath), ".ipa") {
+			hasIPA := trimmedIPAPath != ""
+			hasPKG := trimmedPKGPath != ""
+			if !hasIPA && !hasPKG {
+				fmt.Fprintln(os.Stderr, "Error: --ipa or --pkg is required")
+				return shared.MissingRequiredUsageError("")
+			}
+			if hasIPA && hasPKG {
+				return shared.UsageError("--ipa and --pkg are mutually exclusive")
+			}
+			if hasIPA && !strings.EqualFold(filepath.Ext(trimmedIPAPath), ".ipa") {
 				return shared.UsageError("--ipa must end with .ipa")
+			}
+			if hasPKG && !strings.EqualFold(filepath.Ext(trimmedPKGPath), ".pkg") {
+				return shared.UsageError("--pkg must end with .pkg")
 			}
 			if (trimmedAPIKey == "") != (trimmedAPIIssuer == "") {
 				return shared.UsageError("--api-key and --api-issuer must be provided together")
@@ -488,6 +505,7 @@ Examples:
 
 			result, err := runValidate(ctx, localxcode.ValidateOptions{
 				IPAPath:   trimmedIPAPath,
+				PKGPath:   trimmedPKGPath,
 				APIKey:    trimmedAPIKey,
 				APIIssuer: trimmedAPIIssuer,
 				LogWriter: os.Stderr,
@@ -583,8 +601,11 @@ func exportResultRows(result xcodeExportCommandResult) [][]string {
 }
 
 func validateResultRows(result *localxcode.ValidateResult) [][]string {
-	return [][]string{
-		{"ipa_path", result.IPAPath},
-		{"validated", fmt.Sprintf("%t", result.Validated)},
+	rows := make([][]string, 0, 2)
+	if strings.TrimSpace(result.PKGPath) != "" {
+		rows = append(rows, []string{"pkg_path", result.PKGPath})
+	} else {
+		rows = append(rows, []string{"ipa_path", result.IPAPath})
 	}
+	return append(rows, []string{"validated", fmt.Sprintf("%t", result.Validated)})
 }

--- a/internal/cli/xcode/xcode_test.go
+++ b/internal/cli/xcode/xcode_test.go
@@ -781,6 +781,114 @@ func TestXcodeValidatePassesIPAAndAuthFlags(t *testing.T) {
 	}
 }
 
+func TestXcodeValidatePassesPKGAndRendersPKGPath(t *testing.T) {
+	restore := overrideXcodeCommandTestHooks(t)
+	defer restore()
+
+	var gotOpts localxcode.ValidateOptions
+	runValidate = func(_ context.Context, opts localxcode.ValidateOptions) (*localxcode.ValidateResult, error) {
+		gotOpts = opts
+		return &localxcode.ValidateResult{
+			PKGPath:   opts.PKGPath,
+			Validated: true,
+		}, nil
+	}
+
+	cmd := XcodeValidateCommand()
+	cmd.FlagSet.SetOutput(io.Discard)
+	if err := cmd.FlagSet.Parse([]string{"--pkg", "Demo.pkg", "--output", "json"}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	var runErr error
+	stdout, stderr := captureCommandOutput(t, func() error {
+		runErr = cmd.Exec(context.Background(), nil)
+		return runErr
+	})
+	if runErr != nil {
+		t.Fatalf("Exec() error: %v", runErr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected no stderr output, got %q", stderr)
+	}
+	if gotOpts.PKGPath != "Demo.pkg" || gotOpts.IPAPath != "" {
+		t.Fatalf("unexpected validate options: %+v", gotOpts)
+	}
+
+	var payload struct {
+		IPAPath   string `json:"ipa_path"`
+		PKGPath   string `json:"pkg_path"`
+		Validated bool   `json:"validated"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error: %v\nstdout=%s", err, stdout)
+	}
+	if payload.PKGPath != "Demo.pkg" || payload.IPAPath != "" || !payload.Validated {
+		t.Fatalf("unexpected validate payload: %+v", payload)
+	}
+	rows := validateResultRows(&localxcode.ValidateResult{PKGPath: "Demo.pkg", Validated: true})
+	if len(rows) != 2 || rows[0][0] != "pkg_path" || rows[0][1] != "Demo.pkg" || rows[1][0] != "validated" {
+		t.Fatalf("unexpected rendered PKG rows: %v", rows)
+	}
+}
+
+func TestXcodeValidateRejectsMultipleArtifactPaths(t *testing.T) {
+	restore := overrideXcodeCommandTestHooks(t)
+	defer restore()
+
+	cmd := XcodeValidateCommand()
+	cmd.FlagSet.SetOutput(io.Discard)
+	if err := cmd.FlagSet.Parse([]string{"--ipa", "Demo.ipa", "--pkg", "Demo.pkg"}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	var runErr error
+	_, stderr := captureCommandOutput(t, func() error {
+		runErr = cmd.Exec(context.Background(), nil)
+		return runErr
+	})
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatalf("expected usage error, got %v", runErr)
+	}
+	if !strings.Contains(stderr, "Error: --ipa and --pkg are mutually exclusive") {
+		t.Fatalf("expected mutually exclusive artifact error, got %q", stderr)
+	}
+}
+
+func TestXcodeValidateRejectsExplicitlyEmptyArtifactPath(t *testing.T) {
+	restore := overrideXcodeCommandTestHooks(t)
+	defer restore()
+
+	for _, tc := range []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{name: "empty ipa with pkg", args: []string{"--ipa=", "--pkg", "Demo.pkg"}, wantErr: "--ipa must not be empty"},
+		{name: "empty pkg with ipa", args: []string{"--ipa", "Demo.ipa", "--pkg="}, wantErr: "--pkg must not be empty"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := XcodeValidateCommand()
+			cmd.FlagSet.SetOutput(io.Discard)
+			if err := cmd.FlagSet.Parse(tc.args); err != nil {
+				t.Fatalf("failed to parse flags: %v", err)
+			}
+
+			var runErr error
+			_, stderr := captureCommandOutput(t, func() error {
+				runErr = cmd.Exec(context.Background(), nil)
+				return runErr
+			})
+			if !errors.Is(runErr, flag.ErrHelp) {
+				t.Fatalf("expected usage error, got %v", runErr)
+			}
+			if !strings.Contains(stderr, "Error: "+tc.wantErr) {
+				t.Fatalf("expected %q, got %q", tc.wantErr, stderr)
+			}
+		})
+	}
+}
+
 func TestXcodeArchiveRejectsExplicitlyEmptyConfiguration(t *testing.T) {
 	restore := overrideXcodeCommandTestHooks(t)
 	defer restore()
@@ -840,6 +948,29 @@ func TestXcodeValidateRejectsNonIPAPath(t *testing.T) {
 	}
 	if !strings.Contains(stderr, "Error: --ipa must end with .ipa") {
 		t.Fatalf("expected ipa extension usage error, got %q", stderr)
+	}
+}
+
+func TestXcodeValidateRejectsNonPKGPath(t *testing.T) {
+	restore := overrideXcodeCommandTestHooks(t)
+	defer restore()
+
+	cmd := XcodeValidateCommand()
+	cmd.FlagSet.SetOutput(io.Discard)
+	if err := cmd.FlagSet.Parse([]string{"--pkg", "Demo.txt"}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	var runErr error
+	_, stderr := captureCommandOutput(t, func() error {
+		runErr = cmd.Exec(context.Background(), nil)
+		return runErr
+	})
+	if !errors.Is(runErr, flag.ErrHelp) {
+		t.Fatal("expected flag.ErrHelp for non-.pkg path")
+	}
+	if !strings.Contains(stderr, "Error: --pkg must end with .pkg") {
+		t.Fatalf("expected pkg extension usage error, got %q", stderr)
 	}
 }
 

--- a/internal/xcode/xcode.go
+++ b/internal/xcode/xcode.go
@@ -113,13 +113,15 @@ type ExportResult struct {
 
 type ValidateOptions struct {
 	IPAPath   string
+	PKGPath   string
 	APIKey    string
 	APIIssuer string
 	LogWriter io.Writer
 }
 
 type ValidateResult struct {
-	IPAPath   string `json:"ipa_path"`
+	IPAPath   string `json:"ipa_path,omitempty"`
+	PKGPath   string `json:"pkg_path,omitempty"`
 	Validated bool   `json:"validated"`
 }
 
@@ -361,18 +363,30 @@ func Validate(ctx context.Context, opts ValidateOptions) (*ValidateResult, error
 		}
 		return nil, fmt.Errorf("locate xcrun: %w", err)
 	}
-	if err := validateExistingFile(opts.IPAPath, "--ipa"); err != nil {
+	artifactPath := opts.IPAPath
+	artifactFlag := "--ipa"
+	platform := ""
+	if opts.PKGPath != "" {
+		artifactPath = opts.PKGPath
+		artifactFlag = "--pkg"
+		platform = "macos"
+	}
+	if err := validateExistingFile(artifactPath, artifactFlag); err != nil {
 		return nil, err
 	}
-	platform, err := inferValidatePlatform(opts.IPAPath)
-	if err != nil {
-		return nil, err
+	if platform == "" {
+		var err error
+		platform, err = inferValidatePlatform(opts.IPAPath)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if err := runAltoolValidate(ctx, buildValidateCommand(opts, platform), opts.LogWriter); err != nil {
 		return nil, err
 	}
 	return &ValidateResult{
 		IPAPath:   opts.IPAPath,
+		PKGPath:   opts.PKGPath,
 		Validated: true,
 	}, nil
 }
@@ -533,11 +547,19 @@ func validateExportInputPaths(opts ExportOptions) error {
 }
 
 func validateValidateOptions(opts ValidateOptions) error {
-	if opts.IPAPath == "" {
-		return fmt.Errorf("--ipa is required")
+	hasIPA := opts.IPAPath != ""
+	hasPKG := opts.PKGPath != ""
+	if !hasIPA && !hasPKG {
+		return fmt.Errorf("--ipa or --pkg is required")
 	}
-	if !strings.EqualFold(filepath.Ext(opts.IPAPath), ".ipa") {
+	if hasIPA && hasPKG {
+		return fmt.Errorf("--ipa and --pkg are mutually exclusive")
+	}
+	if hasIPA && !strings.EqualFold(filepath.Ext(opts.IPAPath), ".ipa") {
 		return fmt.Errorf("--ipa must end with .ipa")
+	}
+	if hasPKG && !strings.EqualFold(filepath.Ext(opts.PKGPath), ".pkg") {
+		return fmt.Errorf("--pkg must end with .pkg")
 	}
 	if (opts.APIKey == "") != (opts.APIIssuer == "") {
 		return fmt.Errorf("--api-key and --api-issuer must be provided together")
@@ -586,6 +608,7 @@ func normalizeExportOptions(opts ExportOptions) ExportOptions {
 
 func normalizeValidateOptions(opts ValidateOptions) ValidateOptions {
 	opts.IPAPath = strings.TrimSpace(opts.IPAPath)
+	opts.PKGPath = strings.TrimSpace(opts.PKGPath)
 	opts.APIKey = strings.TrimSpace(opts.APIKey)
 	opts.APIIssuer = strings.TrimSpace(opts.APIIssuer)
 	return opts
@@ -774,10 +797,14 @@ func buildValidateCommand(opts ValidateOptions, platform string) []string {
 	if strings.TrimSpace(platform) == "" {
 		platform = "ios"
 	}
+	artifactPath := opts.IPAPath
+	if opts.PKGPath != "" {
+		artifactPath = opts.PKGPath
+	}
 	args := []string{
 		"altool",
 		"--validate-app",
-		"--file", opts.IPAPath,
+		"--file", artifactPath,
 		"--type", platform,
 	}
 	if opts.APIKey != "" {

--- a/internal/xcode/xcode_test.go
+++ b/internal/xcode/xcode_test.go
@@ -487,6 +487,60 @@ func TestValidateRunsAltoolWithTVOSPlatform(t *testing.T) {
 	}
 }
 
+func TestValidateRunsAltoolWithPKGAndMacOSPlatform(t *testing.T) {
+	tempDir := t.TempDir()
+	pkgPath := filepath.Join(tempDir, "Demo.pkg")
+	if err := os.WriteFile(pkgPath, []byte("pkg"), 0o600); err != nil {
+		t.Fatalf("write PKG fixture: %v", err)
+	}
+	logPath := filepath.Join(tempDir, "commands.log")
+
+	restore := overrideTestEnvironment(t)
+	runtimeGOOS = "darwin"
+	lookPathFn = func(file string) (string, error) {
+		switch file {
+		case "xcodebuild":
+			return "/usr/bin/xcodebuild", nil
+		case "xcrun":
+			return "/usr/bin/xcrun", nil
+		default:
+			return "", exec.ErrNotFound
+		}
+	}
+	commandContextFn = helperCommandContext(t, logPath)
+	t.Cleanup(restore)
+
+	result, err := Validate(context.Background(), ValidateOptions{PKGPath: pkgPath})
+	if err != nil {
+		t.Fatalf("Validate() error: %v", err)
+	}
+	if result.PKGPath != pkgPath || result.IPAPath != "" || !result.Validated {
+		t.Fatalf("unexpected PKG validation result: %+v", result)
+	}
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(logData)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 logged commands, got %d: %q", len(lines), string(logData))
+	}
+	if !strings.Contains(lines[1], "xcrun|altool|--validate-app|--file|"+pkgPath+"|--type|macos") {
+		t.Fatalf("expected PKG validation with macOS type, got %q", lines[1])
+	}
+}
+
+func TestValidateRejectsMultipleArtifactPaths(t *testing.T) {
+	_, err := Validate(context.Background(), ValidateOptions{
+		IPAPath: "Demo.ipa",
+		PKGPath: "Demo.pkg",
+	})
+	if err == nil || !strings.Contains(err.Error(), "--ipa and --pkg are mutually exclusive") {
+		t.Fatalf("expected mutually exclusive artifact error, got %v", err)
+	}
+}
+
 func TestValidateClassifiesAltoolOutputWithZeroExit(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
## Summary
- add --pkg as a mutually exclusive alternative to --ipa for xcode validate
- validate macOS packages with altool platform type macos
- preserve artifact-specific JSON, table, and Markdown output

## Verification
- ASC_BYPASS_KEYCHAIN=1 go test ./internal/xcode ./internal/cli/xcode ./internal/cli/cmdtest
- make build
- make format
- make check-docs
- make lint
- ASC_BYPASS_KEYCHAIN=1 make test
- pre-commit review and final branch review against current origin/main: no actionable findings

Independent validation portion of #2493; the export fix closes that issue.