### PR TITLE
feat(publish): support prebuilt macOS PKG uploads

### DIFF
--- a/commands/publish.mdx
+++ b/commands/publish.mdx
@@ -21,6 +21,10 @@ Use these top-level workflows deliberately:
 
 In 1.0, the deprecated `asc release run` path was removed.
 
+`--ipa --platform MAC_OS` remains available for compatibility but is
+deprecated. Migrate macOS publishing to `--pkg` with explicit `--version` and
+`--build-number` values before the next major release.
+
 ## Workflows
 
 ### TestFlight workflow
@@ -40,6 +44,18 @@ This workflow:
 2. Distributes to specified beta groups
 
 Add `--wait` to wait for build processing before distribution.
+
+For a macOS PKG, provide the version and build number explicitly. The platform
+defaults to `MAC_OS` when `--pkg` is used:
+
+```bash  theme={null}
+asc publish testflight \
+  --app APP_ID \
+  --pkg /path/to/MacApp.pkg \
+  --version 1.2.0 \
+  --build-number 42 \
+  --group "External Testers"
+```
 
 For archive/export/upload/wait without distribution, use the upload-only mode.
 It returns the uploaded build ID without requiring or
@@ -74,11 +90,24 @@ asc publish appstore \
 
 This workflow:
 
-1. Uploads the IPA
+1. Uploads the IPA or PKG
 2. Finds or creates the matching App Store version
 3. Attaches the processed build
 4. Optionally submits for review with `--submit`
 5. Prints the resulting build/version/submission identifiers
+
+Use `--pkg` for a prebuilt macOS installer. PKG uploads require explicit
+`--version` and `--build-number` values and use `MAC_OS` automatically:
+
+```bash  theme={null}
+asc publish appstore \
+  --app APP_ID \
+  --pkg /path/to/MacApp.pkg \
+  --version 1.2.0 \
+  --build-number 42 \
+  --submit \
+  --confirm
+```
 
 ## TestFlight flags
 
@@ -87,7 +116,11 @@ This workflow:
 </ParamField>
 
 <ParamField path="--ipa" type="string">
-  Path to IPA file
+  Path to an iOS, tvOS, or visionOS IPA file
+</ParamField>
+
+<ParamField path="--pkg" type="string">
+  Path to a macOS PKG file
 </ParamField>
 
 <ParamField path="--group" type="string">
@@ -134,6 +167,16 @@ asc publish appstore \
   --confirm
 ```
 
+### Publish a macOS PKG
+
+```bash  theme={null}
+asc publish appstore \
+  --app 123456789 \
+  --pkg build/MacApp.pkg \
+  --version 1.2.0 \
+  --build-number 42
+```
+
 ### CI/CD integration
 
 ```yaml  theme={null}
@@ -163,6 +206,8 @@ Upload-only JSON can be extracted by workflows:
   "processingState": "VALID"
 }
 ```
+
+PKG uploads report `"mode": "pkg_upload"`.
 
 If `--wait` fails after the build record is known, the command still prints
 canonical partial structured output and exits nonzero:

--- a/docs/release-notes-publish-macos-pkg.md
+++ b/docs/release-notes-publish-macos-pkg.md
@@ -1,0 +1,20 @@
+# Prebuilt macOS PKG publishing
+
+`asc publish testflight` and `asc publish appstore` now accept a prebuilt macOS
+installer through `--pkg`. PKG uploads select `MAC_OS` automatically and
+require explicit `--version` and `--build-number` values.
+
+The existing `--ipa --platform MAC_OS` combination remains available during a
+compatibility window, but now prints a deprecation warning. Migrate those
+invocations to:
+
+```bash
+asc publish appstore \
+  --app "APP_ID" \
+  --pkg "MacApp.pkg" \
+  --version "1.2.3" \
+  --build-number "42"
+```
+
+The deprecated macOS IPA publishing combination will be removed in a future
+major release. IPA publishing for iOS, tvOS, and visionOS is unchanged.

--- a/internal/asc/publish.go
+++ b/internal/asc/publish.go
@@ -6,6 +6,7 @@ type PublishMode string
 const (
 	PublishModeExistingBuild PublishMode = "existing_build"
 	PublishModeIPAUpload     PublishMode = "ipa_upload"
+	PublishModePKGUpload     PublishMode = "pkg_upload"
 	PublishModeLocalBuild    PublishMode = "local_build"
 )
 

--- a/internal/cli/cmdtest/commands_test.go
+++ b/internal/cli/cmdtest/commands_test.go
@@ -3706,7 +3706,7 @@ func TestPublishValidationErrors(t *testing.T) {
 		{
 			name:    "publish testflight missing ipa",
 			args:    []string{"publish", "testflight", "--app", "APP_123", "--group", "GROUP_ID"},
-			wantErr: "--ipa is required unless --build-id or --build-number is provided",
+			wantErr: "--ipa or --pkg is required unless --build-id or --build-number is provided",
 		},
 		{
 			name:    "publish testflight missing group",
@@ -3726,7 +3726,7 @@ func TestPublishValidationErrors(t *testing.T) {
 		{
 			name:    "publish testflight upload only requires upload source",
 			args:    []string{"publish", "testflight", "--app", "APP_123", "--build-number", "42", "--upload-only"},
-			wantErr: "--upload-only requires --ipa, --workspace, or --project",
+			wantErr: "--upload-only requires --ipa, --pkg, --workspace, or --project",
 		},
 		{
 			name:     "publish testflight upload only invalid value",
@@ -3774,7 +3774,7 @@ func TestPublishValidationErrors(t *testing.T) {
 		{
 			name:    "publish appstore missing ipa",
 			args:    []string{"publish", "appstore", "--app", "APP_123", "--version", "1.0.0"},
-			wantErr: "Error: --ipa is required",
+			wantErr: "Error: --ipa or --pkg is required",
 		},
 		{
 			name:    "publish appstore submit missing confirm",

--- a/internal/cli/cmdtest/publishing_canonical_surface_test.go
+++ b/internal/cli/cmdtest/publishing_canonical_surface_test.go
@@ -70,6 +70,9 @@ func TestPublishAppStoreHelpShowsCanonicalWorkflowGuidance(t *testing.T) {
 	if !strings.Contains(usage, "--ipa") {
 		t.Fatalf("expected publish appstore help to show flag details, got %q", usage)
 	}
+	if !strings.Contains(usage, "--pkg") {
+		t.Fatalf("expected publish appstore help to show macOS package uploads, got %q", usage)
+	}
 }
 
 func TestPublishAppStoreInvocationDoesNotWarn(t *testing.T) {
@@ -81,8 +84,8 @@ func TestPublishAppStoreInvocationDoesNotWarn(t *testing.T) {
 	if stdout != "" {
 		t.Fatalf("expected empty stdout, got %q", stdout)
 	}
-	if !strings.Contains(stderr, "Error: --ipa is required") {
-		t.Fatalf("expected validation error for missing ipa, got %q", stderr)
+	if !strings.Contains(stderr, "Error: --ipa or --pkg is required") {
+		t.Fatalf("expected validation error for missing upload artifact, got %q", stderr)
 	}
 	if strings.Contains(stderr, "deprecated") {
 		t.Fatalf("expected canonical publish appstore path to avoid deprecation warnings, got %q", stderr)

--- a/internal/cli/publish/publish.go
+++ b/internal/cli/publish/publish.go
@@ -75,10 +75,11 @@ func PublishTestFlightCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("publish testflight", flag.ExitOnError)
 
 	appID := fs.String("app", "", "App Store Connect app ID (required, or ASC_APP_ID env)")
-	ipaPath := fs.String("ipa", "", "Path to .ipa file (required unless --build-id/--build-number is provided)")
+	ipaPath := fs.String("ipa", "", "Path to prebuilt .ipa file")
+	pkgPath := fs.String("pkg", "", "Path to prebuilt macOS .pkg file (requires --version and --build-number)")
 	buildID := fs.String("build-id", "", "Existing build ID to distribute (skip upload)")
-	version := fs.String("version", "", "CFBundleShortVersionString (auto-extracted from IPA if not provided)")
-	buildNumber := fs.String("build-number", "", "CFBundleVersion (used for upload metadata with --ipa, or build lookup when --ipa is omitted)")
+	version := fs.String("version", "", "CFBundleShortVersionString (auto-extracted from IPA if not provided; required with --pkg)")
+	buildNumber := fs.String("build-number", "", "CFBundleVersion (required with --pkg; used for build lookup when no artifact is provided)")
 	platform := fs.String("platform", "IOS", "Platform: IOS, MAC_OS, TV_OS, VISION_OS")
 	groupIDs := fs.String("group", "", "Beta group ID(s) or name(s), comma-separated")
 	uploadOnly := fs.Bool("upload-only", false, "Upload the build without adding it to beta groups or submitting beta review")
@@ -100,7 +101,7 @@ func PublishTestFlightCommand() *ffcli.Command {
 		LongHelp: `Upload or local-build a binary, then optionally distribute it to TestFlight beta groups.
 
 Steps:
-1. Build locally with Xcode or upload an IPA (unless --build-id/--build-number is provided); macOS local builds export a PKG
+1. Build locally with Xcode or upload an IPA or macOS PKG (unless --build-id/--build-number is provided)
 2. Wait for processing when needed (--wait, --test-notes, or --submit)
 3. Stop and return the build metadata with --upload-only, or add the build to specified beta groups
 4. Optionally notify testers
@@ -108,6 +109,7 @@ Steps:
 
 Examples:
   asc publish testflight --app "123" --ipa app.ipa --upload-only --output json
+  asc publish testflight --app "123" --pkg MacApp.pkg --version 1.2.3 --build-number 42 --upload-only --output json
   asc publish testflight --app "123" --ipa app.ipa --upload-only --wait --output json
   asc publish testflight --app "123" --ipa app.ipa --group "GROUP_ID"
   asc publish testflight --app "123" --workspace App.xcworkspace --scheme App --version 1.2.3 --group "GROUP_ID"
@@ -130,6 +132,7 @@ Examples:
 
 			setFlags := collectSetFlags(fs)
 			ipaValue := strings.TrimSpace(*ipaPath)
+			pkgValue := strings.TrimSpace(*pkgPath)
 			buildIDValue := strings.TrimSpace(*buildID)
 			buildNumberValue := strings.TrimSpace(*buildNumber)
 			versionValue := strings.TrimSpace(*version)
@@ -158,14 +161,20 @@ Examples:
 				}
 			}
 
-			uploadMode := ipaValue != ""
+			if ipaValue != "" && pkgValue != "" {
+				return shared.UsageError("--ipa and --pkg are mutually exclusive")
+			}
+			uploadMode := ipaValue != "" || pkgValue != ""
 			switch {
 			case localBuildMode:
 				if err := validateLocalBuildSelectors(localBuild); err != nil {
 					return err
 				}
-				if uploadMode {
+				if ipaValue != "" {
 					return shared.UsageError("--ipa cannot be combined with --workspace or --project")
+				}
+				if pkgValue != "" {
+					return shared.UsageError("--pkg cannot be combined with --workspace or --project")
 				}
 				if buildIDValue != "" {
 					return shared.UsageError("--build-id cannot be combined with --workspace or --project")
@@ -175,14 +184,22 @@ Examples:
 				}
 			case uploadMode:
 				if buildIDValue != "" {
-					return shared.UsageError("--ipa and --build-id are mutually exclusive")
+					if ipaValue != "" {
+						return shared.UsageError("--ipa and --build-id are mutually exclusive")
+					}
+					return shared.UsageError("--pkg and --build-id are mutually exclusive")
+				}
+				if pkgValue != "" {
+					if err := validatePublishPKGMetadata(versionValue, buildNumberValue); err != nil {
+						return err
+					}
 				}
 			default:
 				if *uploadOnly {
-					return shared.UsageError("--upload-only requires --ipa, --workspace, or --project")
+					return shared.UsageError("--upload-only requires --ipa, --pkg, --workspace, or --project")
 				}
 				if buildIDValue == "" && buildNumberValue == "" {
-					return shared.UsageError("--ipa is required unless --build-id or --build-number is provided")
+					return shared.UsageError("--ipa or --pkg is required unless --build-id or --build-number is provided")
 				}
 				if buildIDValue != "" && buildNumberValue != "" {
 					return shared.UsageError("--build-id and --build-number are mutually exclusive when --ipa is not provided")
@@ -233,6 +250,10 @@ Examples:
 			if err != nil {
 				return shared.UsageError(err.Error())
 			}
+			normalizedPlatform, err = validatePublishPrebuiltArtifactPlatform(ipaValue, pkgValue, normalizedPlatform, setFlags["platform"])
+			if err != nil {
+				return err
+			}
 			if localBuildMode {
 				if err := validateLocalBuildArtifactFlags(localBuild, setFlags, normalizedPlatform); err != nil {
 					return err
@@ -243,12 +264,15 @@ Examples:
 			uploadVersionValue := ""
 			uploadBuildNumberValue := ""
 			if uploadMode {
-				uploadFileInfo, err = validatePublishIPAPathFn(ipaValue)
-				if err != nil {
-					return fmt.Errorf("publish testflight: %w", err)
+				if pkgValue != "" {
+					uploadFileInfo, err = validatePublishPKGPathFn(pkgValue)
+					uploadVersionValue, uploadBuildNumberValue = versionValue, buildNumberValue
+				} else {
+					uploadFileInfo, err = validatePublishIPAPathFn(ipaValue)
+					if err == nil {
+						uploadVersionValue, uploadBuildNumberValue, err = shared.ResolveBundleInfoForIPA(ipaValue, *version, *buildNumber)
+					}
 				}
-
-				uploadVersionValue, uploadBuildNumberValue, err = shared.ResolveBundleInfoForIPA(ipaValue, *version, *buildNumber)
 				if err != nil {
 					return fmt.Errorf("publish testflight: %w", err)
 				}
@@ -319,11 +343,19 @@ Examples:
 				resolvedBuildNumberValue = localBuildResult.BuildNumber
 				mode = asc.PublishModeLocalBuild
 			} else if uploadMode {
-				uploadResult, err := uploadBuildAndWaitForIDFn(
+				uploadArtifact := uploadBuildAndWaitForIDFn
+				artifactPath := ipaValue
+				mode = asc.PublishModeIPAUpload
+				if pkgValue != "" {
+					uploadArtifact = uploadPKGBuildAndWaitForIDFn
+					artifactPath = pkgValue
+					mode = asc.PublishModePKGUpload
+				}
+				uploadResult, err := uploadArtifact(
 					requestCtx,
 					client,
 					resolvedPublishAppID,
-					ipaValue,
+					artifactPath,
 					uploadFileInfo,
 					uploadVersionValue,
 					uploadBuildNumberValue,
@@ -340,7 +372,6 @@ Examples:
 				uploaded = true
 				resolvedVersionValue = uploadResult.Version
 				resolvedBuildNumberValue = uploadResult.BuildNumber
-				mode = asc.PublishModeIPAUpload
 			} else if buildIDValue != "" {
 				buildResp, err = client.GetBuild(requestCtx, buildIDValue)
 				if err != nil {
@@ -482,14 +513,15 @@ Examples:
 	}
 }
 
-// PublishAppStoreCommand uploads an IPA, attaches it to an App Store version, and optionally submits it.
+// PublishAppStoreCommand uploads a prebuilt artifact or local build, attaches it to an App Store version, and optionally submits it.
 func PublishAppStoreCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("publish appstore", flag.ExitOnError)
 
 	appID := fs.String("app", "", "App Store Connect app ID (required, or ASC_APP_ID env)")
-	ipaPath := fs.String("ipa", "", "Path to .ipa file (required unless local-build mode is used)")
-	version := fs.String("version", "", "App Store version string (defaults to IPA version)")
-	buildNumber := fs.String("build-number", "", "CFBundleVersion (auto-extracted from IPA if not provided)")
+	ipaPath := fs.String("ipa", "", "Path to prebuilt .ipa file")
+	pkgPath := fs.String("pkg", "", "Path to prebuilt macOS .pkg file (requires --version and --build-number)")
+	version := fs.String("version", "", "App Store version string (defaults to IPA version; required with --pkg)")
+	buildNumber := fs.String("build-number", "", "CFBundleVersion (auto-extracted from IPA; required with --pkg)")
 	platform := fs.String("platform", "IOS", "Platform: IOS, MAC_OS, TV_OS, VISION_OS")
 	metadataDir := fs.String("metadata-dir", "", "Metadata directory with version/<version>/*.json files to apply after ensuring the App Store version")
 	submit := fs.Bool("submit", false, "Submit for review after attaching build")
@@ -508,7 +540,7 @@ func PublishAppStoreCommand() *ffcli.Command {
 		LongHelp: `Use this as the canonical high-level App Store publish command.
 
 Workflow:
-1. Build locally with Xcode or upload an IPA; macOS local builds export a PKG
+1. Build locally with Xcode or upload an IPA or macOS PKG
 2. Wait for build processing (if --wait)
 3. Find or create the App Store version
 4. Apply version localization metadata (if --metadata-dir)
@@ -522,6 +554,7 @@ sequence without uploading or submitting.
 
 Examples:
   asc publish appstore --app "123" --ipa app.ipa --version 1.2.3
+  asc publish appstore --app "123" --pkg MacApp.pkg --version 1.2.3 --build-number 42
   asc publish appstore --app "123" --ipa app.ipa --version 1.2.3 --metadata-dir ./metadata --submit --confirm
   asc publish appstore --app "123" --ipa app.ipa --version 1.2.3 --submit --dry-run
   asc publish appstore --app "123" --workspace App.xcworkspace --scheme App --version 1.2.3
@@ -544,6 +577,7 @@ Examples:
 
 			setFlags := collectSetFlags(fs)
 			ipaValue := strings.TrimSpace(*ipaPath)
+			pkgValue := strings.TrimSpace(*pkgPath)
 			versionValue := strings.TrimSpace(*version)
 			buildNumberValue := strings.TrimSpace(*buildNumber)
 			metadataDirValue := strings.TrimSpace(*metadataDir)
@@ -562,6 +596,9 @@ Examples:
 			if setFlags["metadata-dir"] && metadataDirValue == "" {
 				return shared.UsageError("--metadata-dir cannot be empty")
 			}
+			if ipaValue != "" && pkgValue != "" {
+				return shared.UsageError("--ipa and --pkg are mutually exclusive")
+			}
 			switch {
 			case localBuildMode:
 				if err := validateLocalBuildSelectors(localBuild); err != nil {
@@ -570,12 +607,19 @@ Examples:
 				if ipaValue != "" {
 					return shared.UsageError("--ipa cannot be combined with --workspace or --project")
 				}
+				if pkgValue != "" {
+					return shared.UsageError("--pkg cannot be combined with --workspace or --project")
+				}
 				if versionValue == "" {
 					return shared.UsageError("--version is required")
 				}
-			case ipaValue == "":
-				fmt.Fprintf(os.Stderr, "Error: --ipa is required\n\n")
-				return shared.MissingRequiredUsageError("--ipa")
+			case ipaValue == "" && pkgValue == "":
+				fmt.Fprintf(os.Stderr, "Error: --ipa or --pkg is required\n\n")
+				return shared.MissingRequiredUsageError("")
+			case pkgValue != "":
+				if err := validatePublishPKGMetadata(versionValue, buildNumberValue); err != nil {
+					return err
+				}
 			}
 			if *pollInterval <= 0 {
 				return shared.UsageError("--poll-interval must be greater than 0")
@@ -588,6 +632,10 @@ Examples:
 			if err != nil {
 				return shared.UsageError(err.Error())
 			}
+			normalizedPlatform, err = validatePublishPrebuiltArtifactPlatform(ipaValue, pkgValue, normalizedPlatform, setFlags["platform"])
+			if err != nil {
+				return err
+			}
 			if localBuildMode {
 				if err := validateLocalBuildArtifactFlags(localBuild, setFlags, normalizedPlatform); err != nil {
 					return err
@@ -595,13 +643,15 @@ Examples:
 			}
 
 			var fileInfo os.FileInfo
-			if ipaValue != "" {
-				fileInfo, err = validatePublishIPAPathFn(ipaValue)
-				if err != nil {
-					return fmt.Errorf("publish appstore: %w", err)
+			if ipaValue != "" || pkgValue != "" {
+				if pkgValue != "" {
+					fileInfo, err = validatePublishPKGPathFn(pkgValue)
+				} else {
+					fileInfo, err = validatePublishIPAPathFn(ipaValue)
+					if err == nil {
+						versionValue, buildNumberValue, err = shared.ResolveBundleInfoForIPA(ipaValue, *version, *buildNumber)
+					}
 				}
-
-				versionValue, buildNumberValue, err = shared.ResolveBundleInfoForIPA(ipaValue, *version, *buildNumber)
 				if err != nil {
 					return fmt.Errorf("publish appstore: %w", err)
 				}
@@ -621,6 +671,9 @@ Examples:
 			platformValue := asc.Platform(normalizedPlatform)
 			timeoutOverride := *timeout > 0
 			mode := asc.PublishModeIPAUpload
+			if pkgValue != "" {
+				mode = asc.PublishModePKGUpload
+			}
 			var localBuildConfig publishLocalBuildConfig
 			timeoutValue := resolvePublishTimeout(*timeout)
 			newPublishRequestCtx := func() (context.Context, context.CancelFunc) {
@@ -693,7 +746,13 @@ Examples:
 				buildNumberValue = localBuildResult.BuildNumber
 				uploaded = localBuildResult.Uploaded
 			} else {
-				uploadResult, err := uploadBuildAndWaitForIDFn(requestCtx, client, resolvedPublishAppID, ipaValue, fileInfo, versionValue, buildNumberValue, platformValue, *pollInterval, timeoutValue, timeoutOverride)
+				uploadArtifact := uploadBuildAndWaitForIDFn
+				artifactPath := ipaValue
+				if pkgValue != "" {
+					uploadArtifact = uploadPKGBuildAndWaitForIDFn
+					artifactPath = pkgValue
+				}
+				uploadResult, err := uploadArtifact(requestCtx, client, resolvedPublishAppID, artifactPath, fileInfo, versionValue, buildNumberValue, platformValue, *pollInterval, timeoutValue, timeoutOverride)
 				if err != nil {
 					return fmt.Errorf("publish appstore: %w", err)
 				}
@@ -879,7 +938,7 @@ func plannedAppStorePublishResult(mode asc.PublishMode, version, buildNumber str
 		Uploaded:     false,
 		Attached:     false,
 		Submitted:    false,
-		Plan:         plannedAppStorePublishSteps(localBuildMode, localBuildConfig.PKGPath != "", wait, submit, applyMetadata),
+		Plan:         plannedAppStorePublishSteps(localBuildMode, mode == asc.PublishModePKGUpload || localBuildConfig.PKGPath != "", wait, submit, applyMetadata),
 	}
 
 	if !localBuildMode {
@@ -906,11 +965,11 @@ func plannedAppStorePublishResult(mode asc.PublishMode, version, buildNumber str
 	return result
 }
 
-func plannedAppStorePublishSteps(localBuildMode, pkgLocalBuild, wait, submit, applyMetadata bool) []asc.PublishPlanStep {
+func plannedAppStorePublishSteps(localBuildMode, pkgArtifact, wait, submit, applyMetadata bool) []asc.PublishPlanStep {
 	steps := make([]asc.PublishPlanStep, 0, 8)
 	if localBuildMode {
 		artifactName := "IPA"
-		if pkgLocalBuild {
+		if pkgArtifact {
 			artifactName = "PKG"
 		}
 		steps = append(
@@ -921,7 +980,7 @@ func plannedAppStorePublishSteps(localBuildMode, pkgLocalBuild, wait, submit, ap
 	}
 
 	artifactName := "IPA"
-	if pkgLocalBuild {
+	if pkgArtifact {
 		artifactName = "PKG"
 	}
 	steps = append(steps, newPublishPlanStep(publishPlanStepUploadBuild, "Upload the "+artifactName+" to App Store Connect and wait for the build record to appear."))
@@ -1066,6 +1125,34 @@ func findPublishBuildByNumber(ctx context.Context, client *asc.Client, appID, bu
 	}
 
 	return &asc.BuildResponse{Data: buildsResp.Data[0], Links: buildsResp.Links}, nil
+}
+
+func validatePublishPKGMetadata(version, buildNumber string) error {
+	missingFlags := make([]string, 0, 2)
+	if strings.TrimSpace(version) == "" {
+		missingFlags = append(missingFlags, "--version")
+	}
+	if strings.TrimSpace(buildNumber) == "" {
+		missingFlags = append(missingFlags, "--build-number")
+	}
+	if len(missingFlags) > 0 {
+		return shared.UsageErrorf("%s required for PKG uploads", strings.Join(missingFlags, " and "))
+	}
+	return nil
+}
+
+func validatePublishPrebuiltArtifactPlatform(ipaPath, pkgPath, platform string, platformWasSet bool) (string, error) {
+	if strings.TrimSpace(ipaPath) != "" && platform == string(asc.PlatformMacOS) {
+		fmt.Fprintln(os.Stderr, "Warning: --ipa with --platform MAC_OS is deprecated and will be removed in a future major release. Use --pkg with --version and --build-number for macOS uploads.")
+		return platform, nil
+	}
+	if strings.TrimSpace(pkgPath) == "" {
+		return platform, nil
+	}
+	if platformWasSet && platform != string(asc.PlatformMacOS) {
+		return "", shared.UsageErrorf("--platform %s does not match PKG platform MAC_OS", platform)
+	}
+	return string(asc.PlatformMacOS), nil
 }
 
 func resolvePublishTimeout(timeout time.Duration) time.Duration {

--- a/internal/cli/publish/publish_prebuilt_pkg_test.go
+++ b/internal/cli/publish/publish_prebuilt_pkg_test.go
@@ -1,0 +1,363 @@
+package publish
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+func TestPublishTestFlightPrebuiltPKGUploadOnly(t *testing.T) {
+	restore := overridePublishCommandTestHooks(t)
+	defer restore()
+
+	getPublishASCClientFn = func(time.Duration) (*asc.Client, error) { return newPublishCommandTestClient(t), nil }
+	resolvePublishAppIDWithLookupFn = func(_ context.Context, _ *asc.Client, appID string) (string, error) {
+		if appID != "friendly-app" {
+			t.Fatalf("expected friendly-app lookup, got %q", appID)
+		}
+		return "app-123", nil
+	}
+	validatePublishPKGPathFn = func(path string) (os.FileInfo, error) {
+		if path != "Demo.pkg" {
+			t.Fatalf("expected Demo.pkg validation, got %q", path)
+		}
+		return newPublishTestFileInfo(t)
+	}
+	uploadCalls := 0
+	uploadPKGBuildAndWaitForIDFn = func(_ context.Context, _ *asc.Client, appID, path string, _ os.FileInfo, version, buildNumber string, platform asc.Platform, _ time.Duration, _ time.Duration, _ bool) (*publishUploadResult, error) {
+		uploadCalls++
+		if appID != "app-123" || path != "Demo.pkg" {
+			t.Fatalf("unexpected PKG upload target: app=%q path=%q", appID, path)
+		}
+		if version != "1.2.3" || buildNumber != "42" || platform != asc.PlatformMacOS {
+			t.Fatalf("unexpected PKG upload metadata: version=%q build=%q platform=%q", version, buildNumber, platform)
+		}
+		return publishUploadOnlyResult(version, buildNumber, asc.BuildProcessingStateProcessing), nil
+	}
+	requestCalls := rejectPublishUploadOnlyHTTP(t)
+
+	cmd := PublishTestFlightCommand()
+	cmd.FlagSet.SetOutput(io.Discard)
+	if err := cmd.FlagSet.Parse([]string{
+		"--app", "friendly-app",
+		"--pkg", "Demo.pkg",
+		"--version", "1.2.3",
+		"--build-number", "42",
+		"--upload-only",
+		"--output", "json",
+	}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+
+	stdout, stderr := capturePublishCommandOutput(t, func() error {
+		return cmd.Exec(context.Background(), nil)
+	})
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected no stderr output, got %q", stderr)
+	}
+	if uploadCalls != 1 || *requestCalls != 0 {
+		t.Fatalf("expected one PKG upload and no distribution calls; uploads=%d requests=%d", uploadCalls, *requestCalls)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error: %v\nstdout=%s", err, stdout)
+	}
+	if payload["mode"] != string(asc.PublishModePKGUpload) || payload["uploaded"] != true {
+		t.Fatalf("unexpected PKG upload result: %#v", payload)
+	}
+}
+
+func TestPublishAppStorePrebuiltPKGDryRun(t *testing.T) {
+	restore := overridePublishCommandTestHooks(t)
+	defer restore()
+
+	validatePublishPKGPathFn = func(path string) (os.FileInfo, error) {
+		if path != "Demo.pkg" {
+			t.Fatalf("expected Demo.pkg validation, got %q", path)
+		}
+		return newPublishTestFileInfo(t)
+	}
+
+	cmd := PublishAppStoreCommand()
+	cmd.FlagSet.SetOutput(io.Discard)
+	if err := cmd.FlagSet.Parse([]string{
+		"--app", "123456789",
+		"--pkg", "Demo.pkg",
+		"--version", "1.2.3",
+		"--build-number", "42",
+		"--dry-run",
+		"--output", "json",
+	}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+
+	stdout, stderr := capturePublishCommandOutput(t, func() error {
+		return cmd.Exec(context.Background(), nil)
+	})
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected no stderr output, got %q", stderr)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error: %v\nstdout=%s", err, stdout)
+	}
+	if payload["mode"] != string(asc.PublishModePKGUpload) {
+		t.Fatalf("expected pkg_upload mode, got %#v", payload["mode"])
+	}
+	plan, ok := payload["plan"].([]any)
+	if !ok || len(plan) == 0 {
+		t.Fatalf("expected publish plan, got %#v", payload["plan"])
+	}
+	uploadStep, ok := plan[0].(map[string]any)
+	if !ok || !strings.Contains(uploadStep["message"].(string), "PKG") {
+		t.Fatalf("expected PKG upload step, got %#v", plan[0])
+	}
+}
+
+func TestPublishAppStorePrebuiltPKGUploadsAndAttaches(t *testing.T) {
+	restore := overridePublishCommandTestHooks(t)
+	defer restore()
+
+	getPublishASCClientFn = func(time.Duration) (*asc.Client, error) { return newPublishCommandTestClient(t), nil }
+	validatePublishPKGPathFn = func(path string) (os.FileInfo, error) {
+		if path != "Demo.pkg" {
+			t.Fatalf("expected Demo.pkg validation, got %q", path)
+		}
+		return newPublishTestFileInfo(t)
+	}
+	resolvePublishAppIDWithLookupFn = func(_ context.Context, _ *asc.Client, appID string) (string, error) {
+		if appID != "friendly-app" {
+			t.Fatalf("expected friendly-app lookup, got %q", appID)
+		}
+		return "app-123", nil
+	}
+	uploadCalls := 0
+	uploadPKGBuildAndWaitForIDFn = func(_ context.Context, _ *asc.Client, appID, path string, _ os.FileInfo, version, buildNumber string, platform asc.Platform, pollInterval, _ time.Duration, _ bool) (*publishUploadResult, error) {
+		uploadCalls++
+		if appID != "app-123" || path != "Demo.pkg" || version != "1.2.3" || buildNumber != "42" {
+			t.Fatalf("unexpected PKG upload: app=%q path=%q version=%q build=%q", appID, path, version, buildNumber)
+		}
+		if platform != asc.PlatformMacOS || pollInterval != 5*time.Second {
+			t.Fatalf("unexpected PKG upload options: platform=%q poll=%s", platform, pollInterval)
+		}
+		return publishUploadOnlyResult(version, buildNumber, asc.BuildProcessingStateValid), nil
+	}
+
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+	requestCount := 0
+	http.DefaultTransport = publishCommandRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/apps/app-123/appStoreVersions" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return publishCommandJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"version-1","attributes":{"versionString":"1.2.3","platform":"MAC_OS","appStoreState":"PREPARE_FOR_SUBMISSION"}}]}`)
+		case 2:
+			if req.Method != http.MethodGet || req.URL.Path != "/v1/appStoreVersions/version-1/build" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return publishCommandJSONResponse(http.StatusNotFound, `{"errors":[{"status":"404","code":"NOT_FOUND","title":"Not Found"}]}`)
+		case 3:
+			if req.Method != http.MethodPatch || req.URL.Path != "/v1/appStoreVersions/version-1/relationships/build" {
+				t.Fatalf("unexpected request %d: %s %s", requestCount, req.Method, req.URL.String())
+			}
+			return publishCommandJSONResponse(http.StatusNoContent, "")
+		default:
+			t.Fatalf("unexpected request count %d", requestCount)
+			return nil, nil
+		}
+	})
+
+	cmd := PublishAppStoreCommand()
+	cmd.FlagSet.SetOutput(io.Discard)
+	if err := cmd.FlagSet.Parse([]string{
+		"--app", "friendly-app",
+		"--pkg", "Demo.pkg",
+		"--version", "1.2.3",
+		"--build-number", "42",
+		"--poll-interval", "5s",
+		"--output", "json",
+	}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+
+	stdout, stderr := capturePublishCommandOutput(t, func() error {
+		return cmd.Exec(context.Background(), nil)
+	})
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("expected no stderr output, got %q", stderr)
+	}
+	if uploadCalls != 1 || requestCount != 3 {
+		t.Fatalf("expected one PKG upload and three App Store requests; uploads=%d requests=%d", uploadCalls, requestCount)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error: %v\nstdout=%s", err, stdout)
+	}
+	if payload["mode"] != string(asc.PublishModePKGUpload) || payload["uploaded"] != true || payload["attached"] != true {
+		t.Fatalf("unexpected PKG App Store result: %#v", payload)
+	}
+}
+
+func TestPublishCommandsRejectPKGPlatformMismatches(t *testing.T) {
+	tests := []struct {
+		name    string
+		command func() *ffcli.Command
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "testflight PKG",
+			command: PublishTestFlightCommand,
+			args:    []string{"--app", "123", "--pkg", "Demo.pkg", "--version", "1.2.3", "--build-number", "42", "--platform", "IOS", "--upload-only"},
+			wantErr: "--platform IOS does not match PKG platform MAC_OS",
+		},
+		{
+			name:    "appstore PKG",
+			command: PublishAppStoreCommand,
+			args:    []string{"--app", "123", "--pkg", "Demo.pkg", "--version", "1.2.3", "--build-number", "42", "--platform", "IOS", "--dry-run"},
+			wantErr: "--platform IOS does not match PKG platform MAC_OS",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			restore := overridePublishCommandTestHooks(t)
+			defer restore()
+			validatePublishIPAPathFn = func(path string) (os.FileInfo, error) { return os.Stat(path) }
+			validatePublishPKGPathFn = func(string) (os.FileInfo, error) { return newPublishTestFileInfo(t) }
+
+			cmd := test.command()
+			cmd.FlagSet.SetOutput(io.Discard)
+			if err := cmd.FlagSet.Parse(test.args); err != nil {
+				t.Fatalf("parse flags: %v", err)
+			}
+			err := cmd.Exec(context.Background(), nil)
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("expected %q, got %v", test.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestPublishMacOSIPARemainsAvailableWithDeprecationWarning(t *testing.T) {
+	stdout, stderr := capturePublishCommandOutput(t, func() error {
+		platform, err := validatePublishPrebuiltArtifactPlatform("Demo.ipa", "", string(asc.PlatformMacOS), true)
+		if err != nil {
+			return err
+		}
+		if platform != string(asc.PlatformMacOS) {
+			t.Fatalf("expected MAC_OS platform, got %q", platform)
+		}
+		return nil
+	})
+	if stdout != "" {
+		t.Fatalf("expected no stdout, got %q", stdout)
+	}
+	for _, want := range []string{"Warning:", "--ipa with --platform MAC_OS is deprecated", "Use --pkg with --version and --build-number"} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("expected warning to contain %q, got %q", want, stderr)
+		}
+	}
+}
+
+func TestPublishPrebuiltPKGRequiresVersionAndBuildNumber(t *testing.T) {
+	tests := []struct {
+		name    string
+		command func() *ffcli.Command
+		args    []string
+		wantErr string
+	}{
+		{name: "testflight both", command: PublishTestFlightCommand, args: []string{"--app", "123", "--pkg", "Demo.pkg", "--upload-only"}, wantErr: "--version and --build-number required for PKG uploads"},
+		{name: "testflight version", command: PublishTestFlightCommand, args: []string{"--app", "123", "--pkg", "Demo.pkg", "--version", "1.2.3", "--upload-only"}, wantErr: "--build-number required for PKG uploads"},
+		{name: "testflight build", command: PublishTestFlightCommand, args: []string{"--app", "123", "--pkg", "Demo.pkg", "--build-number", "42", "--upload-only"}, wantErr: "--version required for PKG uploads"},
+		{name: "appstore both", command: PublishAppStoreCommand, args: []string{"--app", "123", "--pkg", "Demo.pkg", "--dry-run"}, wantErr: "--version and --build-number required for PKG uploads"},
+		{name: "appstore version", command: PublishAppStoreCommand, args: []string{"--app", "123", "--pkg", "Demo.pkg", "--version", "1.2.3", "--dry-run"}, wantErr: "--build-number required for PKG uploads"},
+		{name: "appstore build", command: PublishAppStoreCommand, args: []string{"--app", "123", "--pkg", "Demo.pkg", "--build-number", "42", "--dry-run"}, wantErr: "--version required for PKG uploads"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := test.command()
+			cmd.FlagSet.SetOutput(io.Discard)
+			if err := cmd.FlagSet.Parse(test.args); err != nil {
+				t.Fatalf("parse flags: %v", err)
+			}
+			err := cmd.Exec(context.Background(), nil)
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("expected %q, got %v", test.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestPublishPrebuiltArtifactsAreMutuallyExclusive(t *testing.T) {
+	tests := []struct {
+		name    string
+		command func() *ffcli.Command
+		args    []string
+	}{
+		{name: "testflight", command: PublishTestFlightCommand, args: []string{"--app", "123", "--ipa", "Demo.ipa", "--pkg", "Demo.pkg", "--version", "1.2.3", "--build-number", "42", "--upload-only"}},
+		{name: "appstore", command: PublishAppStoreCommand, args: []string{"--app", "123", "--ipa", "Demo.ipa", "--pkg", "Demo.pkg", "--version", "1.2.3", "--build-number", "42", "--dry-run"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := test.command()
+			cmd.FlagSet.SetOutput(io.Discard)
+			if err := cmd.FlagSet.Parse(test.args); err != nil {
+				t.Fatalf("parse flags: %v", err)
+			}
+			err := cmd.Exec(context.Background(), nil)
+			if err == nil || !strings.Contains(err.Error(), "--ipa and --pkg are mutually exclusive") {
+				t.Fatalf("expected mutually exclusive artifact error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestPublishPrebuiltPKGConflictsWithLocalBuild(t *testing.T) {
+	tests := []struct {
+		name    string
+		command func() *ffcli.Command
+		args    []string
+	}{
+		{name: "testflight", command: PublishTestFlightCommand, args: []string{"--app", "123", "--pkg", "Demo.pkg", "--workspace", "Demo.xcworkspace", "--scheme", "Demo", "--version", "1.2.3", "--build-number", "42", "--upload-only"}},
+		{name: "appstore", command: PublishAppStoreCommand, args: []string{"--app", "123", "--pkg", "Demo.pkg", "--project", "Demo.xcodeproj", "--scheme", "Demo", "--version", "1.2.3", "--build-number", "42", "--dry-run"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := test.command()
+			cmd.FlagSet.SetOutput(io.Discard)
+			if err := cmd.FlagSet.Parse(test.args); err != nil {
+				t.Fatalf("parse flags: %v", err)
+			}
+			err := cmd.Exec(context.Background(), nil)
+			if err == nil || !strings.Contains(err.Error(), "--pkg cannot be combined with --workspace or --project") {
+				t.Fatalf("expected local-build conflict, got %v", err)
+			}
+		})
+	}
+}
+
+func TestPublishPKGFlagsAreDiscoverable(t *testing.T) {
+	for _, command := range []*ffcli.Command{PublishTestFlightCommand(), PublishAppStoreCommand()} {
+		pkgFlag := command.FlagSet.Lookup("pkg")
+		if pkgFlag == nil {
+			t.Fatalf("%s: expected --pkg flag", command.Name)
+		}
+		if !strings.Contains(pkgFlag.Usage, "macOS") || !strings.Contains(pkgFlag.Usage, "--version") || !strings.Contains(pkgFlag.Usage, "--build-number") {
+			t.Fatalf("%s: expected PKG metadata help, got %q", command.Name, pkgFlag.Usage)
+		}
+	}
+}

--- a/internal/cli/publish/publish_upload_only_test.go
+++ b/internal/cli/publish/publish_upload_only_test.go
@@ -258,7 +258,7 @@ func TestPublishTestFlightUploadOnlyRequiresUploadSource(t *testing.T) {
 	if !errors.Is(runErr, flag.ErrHelp) {
 		t.Fatalf("expected usage error, got %v", runErr)
 	}
-	const wantErr = "--upload-only requires --ipa, --workspace, or --project"
+	const wantErr = "--upload-only requires --ipa, --pkg, --workspace, or --project"
 	if got := runErr.Error(); got != wantErr {
 		t.Fatalf("expected returned error %q, got %q", wantErr, got)
 	}


### PR DESCRIPTION
## Summary
- add --pkg to publish testflight and publish appstore
- route prebuilt macOS artifacts through the existing com.apple.pkg uploader
- require explicit version/build metadata and infer MAC_OS for PKG uploads
- preserve macOS IPA compatibility with a deprecation warning and migration guidance

## Verification
- make build
- make format
- make check-docs
- make lint
- ASC_BYPASS_KEYCHAIN=1 make test
- clean local pre-commit review
- clean final branch review against current origin/main