### PR TITLE
fix(signing): support native macOS profile files

### DIFF
--- a/commands/profiles.mdx
+++ b/commands/profiles.mdx
@@ -170,7 +170,8 @@ asc profiles download --id "PROFILE_ID" \
   --output "./profile.mobileprovision"
 ```
 
-The downloaded `.mobileprovision` file can be:
+Native macOS profiles conventionally use `.provisionprofile`; iOS, tvOS, and
+legacy profiles use `.mobileprovision`. Both extensions can be:
 
 * Installed with `asc profiles local install --path "./profile.mobileprovision"`
 * Opened with Xcode
@@ -178,7 +179,7 @@ The downloaded `.mobileprovision` file can be:
 
 ## Inspect Profile
 
-Inspect a downloaded `.mobileprovision` file:
+Inspect a downloaded provisioning profile file:
 
 ```bash  theme={null}
 asc profiles inspect --path "./profile.mobileprovision"
@@ -197,6 +198,9 @@ asc profiles inspect --path "./profile.mobileprovision" --entitlements
 ```
 
 This command reads local disk only. It decodes the signed provisioning profile payload and reports identifiers, expiration, certificate fingerprints, device counts, and entitlement values.
+
+For a native macOS profile, use the same commands with a `.provisionprofile`
+path. Local list and clean operations recognize both extensions.
 
 ### Install Profile
 

--- a/commands/signing.mdx
+++ b/commands/signing.mdx
@@ -110,7 +110,7 @@ Create a new profile after changing capabilities; App Store Connect profiles are
 
 ## Fetch public signing files
 
-`asc signing fetch` resolves the bundle ID, selects an active profile and its active certificates, then writes the `.mobileprovision` and `.cer` files to the output directory.
+`asc signing fetch` resolves the bundle ID, selects an active profile and its active certificates, then writes the profile and `.cer` files to the output directory. Native macOS profiles use `.provisionprofile`; iOS and tvOS profiles use `.mobileprovision`.
 
 For App Store distribution:
 
@@ -525,7 +525,7 @@ SSH the step runs:
       ' .asc/signing/pull-result.json
     )"
 
-    jq -r '.files[] | select(endswith(".mobileprovision"))' \
+    jq -r '.files[] | select(test("\\.(mobileprovision|provisionprofile)$"))' \
       .asc/signing/pull-result.json \
     | while IFS= read -r profile_path; do
         asc profiles local install \

--- a/docs/design/signing-private-identity-sync.md
+++ b/docs/design/signing-private-identity-sync.md
@@ -48,6 +48,10 @@ The encrypted repository password resolves in this order:
 3. `ASC_SIGNING_SYNC_PASSWORD`.
 4. The legacy `ASC_MATCH_PASSWORD` environment variable, with a deprecation warning.
 
+Profile artifacts use `.provisionprofile.enc` for native macOS profile types
+and `.mobileprovision.enc` for iOS and tvOS profile types. Existing legacy
+profile paths remain readable; sync does not rename them implicitly.
+
 The existing certificate/profile-only invocation remains valid. Its structured
 result reports `identityPresent: false`. Pull results list decrypted identity
 artifacts separately in `sensitiveFiles`. Sensitive identities are new-only and

--- a/docs/design/signing-sync-multi-targets.md
+++ b/docs/design/signing-sync-multi-targets.md
@@ -49,11 +49,16 @@ Certificates are deduplicated by resource ID and written in canonical ID order.
 In batch mode profiles use a target-scoped path:
 
 ```text
-profiles/<profile-type-directory>/<safe-bundle-id>--<safe-profile-resource-id>.mobileprovision.enc
+profiles/<profile-type-directory>/<safe-bundle-id>--<safe-profile-resource-id><profile-extension>.enc
 ```
 
-The existing single-target profile path remains unchanged. Shared identities
-remain one authenticated core per certificate and one current authenticated
+`<profile-extension>` is `.provisionprofile` for native macOS profile types and
+`.mobileprovision` for iOS and tvOS profile types. Existing encrypted files
+with the legacy suffix remain readable and are not renamed automatically.
+
+The existing single-target iOS and tvOS profile paths remain unchanged; native
+macOS single-target paths use the same platform-specific suffix rule. Shared
+identities remain one authenticated core per certificate and one current authenticated
 context per team/bundle/profile-type; each target context binds its exact
 profile path, resource ID, UUID, and content digest.
 

--- a/docs/design/signing-sync-selective-pull.md
+++ b/docs/design/signing-sync-selective-pull.md
@@ -28,6 +28,11 @@ password, repository clone, or output-directory side effects.
 The selected pull is additive. Existing invocations, JSON fields, full-pull
 file selection, decryption limits, and Git behavior do not change.
 
+Both native macOS `.provisionprofile` files and legacy `.mobileprovision`
+profile files are recognized during repository validation and selection. The
+stored relative path remains exact, so pulling a legacy file does not rename or
+overwrite it merely because the preferred macOS suffix is different.
+
 Profile pushes now replace the legacy encrypted profile payload with a
 versioned envelope containing non-secret, authenticated bundle, profile-type,
 resource-ID, and optional UUID metadata. Certificates retain their existing

--- a/guides/code-signing.mdx
+++ b/guides/code-signing.mdx
@@ -206,7 +206,7 @@ asc signing keychain install \
   --confirm \
   --output json
 
-jq -r '.files[] | select(endswith(".mobileprovision"))' \
+jq -r '.files[] | select(test("\\.(mobileprovision|provisionprofile)$"))' \
   .asc/signing/pull-result.json \
 | while IFS= read -r profile_path; do
     asc profiles local install \

--- a/internal/cli/profiles/inspect.go
+++ b/internal/cli/profiles/inspect.go
@@ -52,7 +52,7 @@ type profileInspectResult struct {
 func ProfilesInspectCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("inspect", flag.ExitOnError)
 
-	sourcePath := fs.String("path", "", "Path to a .mobileprovision file to inspect")
+	sourcePath := fs.String("path", "", "Path to a .mobileprovision or .provisionprofile file to inspect")
 	showEntitlements := fs.Bool("entitlements", false, "Include entitlement key/value rows in table or markdown output")
 	output := shared.BindOutputFlags(fs)
 
@@ -62,12 +62,13 @@ func ProfilesInspectCommand() *ffcli.Command {
 		ShortHelp:  "Inspect a local provisioning profile.",
 		LongHelp: `Inspect a local provisioning profile.
 
-This command decodes the embedded plist from a .mobileprovision file and prints
+This command decodes the embedded plist from a provisioning profile file and prints
 the profile identifiers, dates, certificate fingerprints, devices, and
 entitlements.
 
 Examples:
   asc profiles inspect --path "./profile.mobileprovision"
+  asc profiles inspect --path "./profile.provisionprofile"
   asc profiles inspect --path "./profile.mobileprovision" --output json
   asc profiles inspect --path "./profile.mobileprovision" --entitlements`,
 		FlagSet:   fs,

--- a/internal/cli/profiles/local.go
+++ b/internal/cli/profiles/local.go
@@ -29,6 +29,9 @@ When no full Xcode is active (for example a Command Line Tools only host),
 ~/Library/MobileDevice/Provisioning Profiles is used and a note is written to
 stderr. Use --install-dir to choose a directory explicitly.`
 
+const profilesLocalExtensionHelp = `macOS profiles use the .provisionprofile extension;
+iOS, tvOS, and legacy profiles may use .mobileprovision.`
+
 // profileUUIDValidationRegex ensures the UUID from a provisioning profile is safe to use
 // as a filename component (prevents absolute paths / path traversal).
 var profileUUIDValidationRegex = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
@@ -114,8 +117,11 @@ not on App Store Connect API profile resources.
 
 ` + profilesLocalDirectoryHelp + `
 
+` + profilesLocalExtensionHelp + `
+
 Examples:
   asc profiles local install --path "./profile.mobileprovision"
+  asc profiles local install --path "./profile.provisionprofile"
   asc profiles local list
   asc profiles local clean --expired --dry-run
   asc profiles local clean --expired --confirm`,
@@ -136,7 +142,7 @@ Examples:
 func ProfilesLocalInstallCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("install", flag.ExitOnError)
 
-	sourcePath := fs.String("path", "", "Path to a .mobileprovision file to install")
+	sourcePath := fs.String("path", "", "Path to a .mobileprovision or .provisionprofile file to install")
 	profileID := fs.String("id", "", "Profile ID to download and install")
 	installDir := fs.String("install-dir", "", "Directory to use (defaults by active Xcode version on macOS)")
 	force := fs.Bool("force", false, "Overwrite an existing installed profile with the same UUID")
@@ -150,8 +156,11 @@ func ProfilesLocalInstallCommand() *ffcli.Command {
 
 ` + profilesLocalDirectoryHelp + `
 
+` + profilesLocalExtensionHelp + `
+
 Examples:
   asc profiles local install --path "./profile.mobileprovision"
+  asc profiles local install --path "./profile.provisionprofile"
   asc profiles local install --id "PROFILE_ID"
   asc profiles local install --path "./profile.mobileprovision" --force`,
 		FlagSet:   fs,
@@ -226,14 +235,12 @@ Examples:
 				return fmt.Errorf("profiles local install: invalid profile UUID %q", uuid)
 			}
 
-			destPath := filepath.Join(resolvedInstallDir, uuid+".mobileprovision")
-			action := "installed"
-			hadExisting := false
-			if _, err := os.Lstat(destPath); err == nil {
-				hadExisting = true
-			} else if !errors.Is(err, os.ErrNotExist) {
-				return fmt.Errorf("profiles local install: stat output path: %w", err)
+			extension := shared.ProvisioningProfileExtensionForPlatforms(parsed.Platform, "")
+			destPath, hadExisting, err := resolveProfileInstallPath(resolvedInstallDir, uuid, extension)
+			if err != nil {
+				return fmt.Errorf("profiles local install: %w", err)
 			}
+			action := "installed"
 
 			if err := writeProfileFile(destPath, content, *force); err != nil {
 				if errors.Is(err, os.ErrExist) {
@@ -274,6 +281,45 @@ Examples:
 	}
 }
 
+func resolveProfileInstallPath(installDir, uuid, preferredExtension string) (string, bool, error) {
+	preferredPath := filepath.Join(installDir, uuid+preferredExtension)
+	alternateExtension := shared.IOSProvisioningProfileExtension
+	if preferredExtension == shared.IOSProvisioningProfileExtension {
+		alternateExtension = shared.MacOSProvisioningProfileExtension
+	}
+	alternatePath := filepath.Join(installDir, uuid+alternateExtension)
+
+	preferredExists, err := profileInstallPathExists(preferredPath)
+	if err != nil {
+		return "", false, err
+	}
+	alternateExists, err := profileInstallPathExists(alternatePath)
+	if err != nil {
+		return "", false, err
+	}
+	if preferredExists && alternateExists {
+		return "", false, fmt.Errorf("duplicate installed profiles exist for UUID %q at %q and %q", uuid, preferredPath, alternatePath)
+	}
+	if preferredExists {
+		return preferredPath, true, nil
+	}
+	if alternateExists {
+		// Preserve an existing legacy filename instead of creating a second file
+		// for the same profile UUID. A later forced install replaces it in place.
+		return alternatePath, true, nil
+	}
+	return preferredPath, false, nil
+}
+
+func profileInstallPathExists(path string) (bool, error) {
+	if _, err := os.Lstat(path); err == nil {
+		return true, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return false, fmt.Errorf("stat output path: %w", err)
+	}
+	return false, nil
+}
+
 // ProfilesLocalListCommand returns the profiles local list subcommand.
 func ProfilesLocalListCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("list", flag.ExitOnError)
@@ -291,6 +337,8 @@ func ProfilesLocalListCommand() *ffcli.Command {
 		LongHelp: `List locally installed provisioning profiles.
 
 ` + profilesLocalDirectoryHelp + `
+
+` + profilesLocalExtensionHelp + `
 
 Examples:
   asc profiles local list
@@ -372,6 +420,8 @@ func ProfilesLocalCleanCommand() *ffcli.Command {
 		LongHelp: `Clean up locally installed provisioning profiles.
 
 ` + profilesLocalDirectoryHelp + `
+
+` + profilesLocalExtensionHelp + `
 
 Examples:
   asc profiles local clean --expired --dry-run
@@ -533,7 +583,7 @@ func scanLocalProfiles(installDir string, now time.Time) ([]localProfile, []loca
 		if entry.IsDir() {
 			continue
 		}
-		if !strings.HasSuffix(strings.ToLower(entry.Name()), ".mobileprovision") {
+		if !shared.IsProvisioningProfilePath(entry.Name()) {
 			continue
 		}
 

--- a/internal/cli/profiles/local_scan_unix_test.go
+++ b/internal/cli/profiles/local_scan_unix_test.go
@@ -58,3 +58,22 @@ func TestScanLocalProfiles_SkipsNonRegularFiles(t *testing.T) {
 		t.Fatalf("scanLocalProfiles hung on a non-regular file (FIFO)")
 	}
 }
+
+func TestScanLocalProfiles_SkipsNonRegularMacOSProfileFiles(t *testing.T) {
+	installDir := t.TempDir()
+	fifoPath := filepath.Join(installDir, "blocked.provisionprofile")
+	if err := syscall.Mkfifo(fifoPath, 0o600); err != nil {
+		t.Fatalf("Mkfifo(%q) error: %v", fifoPath, err)
+	}
+
+	items, skipped, err := scanLocalProfiles(installDir, time.Now())
+	if err != nil {
+		t.Fatalf("scanLocalProfiles() error: %v", err)
+	}
+	if len(items) != 0 || len(skipped) != 1 {
+		t.Fatalf("scanLocalProfiles() items=%d skipped=%d, want 0 items and 1 skipped", len(items), len(skipped))
+	}
+	if skipped[0].Path != fifoPath || skipped[0].Reason != "refusing to read non-regular file" {
+		t.Fatalf("skipped[0]=%#v, want path %q and non-regular-file reason", skipped[0], fifoPath)
+	}
+}

--- a/internal/cli/profiles/local_test.go
+++ b/internal/cli/profiles/local_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -12,6 +13,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"howett.net/plist"
 )
 
 func TestResolveProfilesInstallDirVersionBoundary(t *testing.T) {
@@ -291,5 +294,213 @@ func TestIsExpired(t *testing.T) {
 				t.Fatalf("isExpired(expiresAt=%s, now=%s)=%t, want %t", tt.expiresAt.Format(time.RFC3339Nano), tt.now.Format(time.RFC3339Nano), got, tt.want)
 			}
 		})
+	}
+}
+
+func TestProfilesLocalInstallUsesMacOSProvisioningProfileExtension(t *testing.T) {
+	root := t.TempDir()
+	sourcePath := filepath.Join(root, "downloaded-profile")
+	installDir := filepath.Join(root, "installed")
+	const uuid = "01234567-89ab-cdef-0123-456789abcdef"
+
+	data, err := plist.Marshal(map[string]any{
+		"UUID":                 uuid,
+		"Name":                 "Mac App Store",
+		"TeamIdentifier":       []string{"TEAM123"},
+		"Platform":             []string{"OSX"},
+		"ExpirationDate":       time.Now().Add(time.Hour),
+		"Entitlements":         map[string]any{"application-identifier": "TEAM123.com.example.mac"},
+		"CreationDate":         time.Now().Add(-time.Hour),
+		"ProvisionsAllDevices": false,
+	}, plist.XMLFormat)
+	if err != nil {
+		t.Fatalf("marshal profile fixture: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, data, 0o600); err != nil {
+		t.Fatalf("write profile fixture: %v", err)
+	}
+
+	cmd := ProfilesLocalInstallCommand()
+	if err := cmd.Parse([]string{"--path", sourcePath, "--install-dir", installDir, "--output", "json"}); err != nil {
+		t.Fatalf("parse install flags: %v", err)
+	}
+	if err := cmd.Run(context.Background()); err != nil {
+		t.Fatalf("install macOS profile: %v", err)
+	}
+
+	modernPath := filepath.Join(installDir, uuid+".provisionprofile")
+	if _, err := os.Stat(modernPath); err != nil {
+		t.Fatalf("macOS profile was not installed at %q: %v", modernPath, err)
+	}
+	legacyPath := filepath.Join(installDir, uuid+".mobileprovision")
+	if _, err := os.Stat(legacyPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("macOS profile unexpectedly used legacy path %q (err=%v)", legacyPath, err)
+	}
+}
+
+func TestProfilesLocalInstallDetectsLegacyPathForMacOSProfile(t *testing.T) {
+	root := t.TempDir()
+	installDir := filepath.Join(root, "installed")
+	const uuid = "01234567-89ab-cdef-0123-456789abcdef"
+	legacyPath := filepath.Join(installDir, uuid+".mobileprovision")
+	if err := os.MkdirAll(installDir, 0o755); err != nil {
+		t.Fatalf("create install dir: %v", err)
+	}
+	if err := os.WriteFile(legacyPath, []byte("legacy"), 0o600); err != nil {
+		t.Fatalf("write legacy profile: %v", err)
+	}
+
+	path, exists, err := resolveProfileInstallPath(installDir, uuid, ".provisionprofile")
+	if err != nil {
+		t.Fatalf("resolve install path: %v", err)
+	}
+	if !exists || path != legacyPath {
+		t.Fatalf("resolve install path = (%q, %t), want (%q, true)", path, exists, legacyPath)
+	}
+}
+
+func TestProfilesLocalInstallRejectsDuplicateExtensionsForSameUUID(t *testing.T) {
+	installDir := t.TempDir()
+	const uuid = "01234567-89ab-cdef-0123-456789abcdef"
+	for _, extension := range []string{".mobileprovision", ".provisionprofile"} {
+		if err := os.WriteFile(filepath.Join(installDir, uuid+extension), []byte("profile"), 0o600); err != nil {
+			t.Fatalf("write %s profile: %v", extension, err)
+		}
+	}
+
+	_, _, err := resolveProfileInstallPath(installDir, uuid, ".provisionprofile")
+	if err == nil || !strings.Contains(err.Error(), "duplicate installed profiles") {
+		t.Fatalf("resolve install path error = %v, want duplicate-path error", err)
+	}
+}
+
+func TestProfilesLocalInstallForceReplacesLegacyPathWithoutDuplicate(t *testing.T) {
+	root := t.TempDir()
+	installDir := filepath.Join(root, "installed")
+	sourcePath := filepath.Join(root, "mac.provisionprofile")
+	const uuid = "01234567-89ab-cdef-0123-456789abcdef"
+	data, err := plist.Marshal(map[string]any{
+		"UUID":           uuid,
+		"Name":           "Mac App Store",
+		"TeamIdentifier": []string{"TEAM123"},
+		"Platform":       []string{"OSX"},
+		"ExpirationDate": time.Now().Add(time.Hour),
+		"Entitlements":   map[string]any{"application-identifier": "TEAM123.com.example.mac"},
+	}, plist.XMLFormat)
+	if err != nil {
+		t.Fatalf("marshal profile fixture: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, data, 0o600); err != nil {
+		t.Fatalf("write profile fixture: %v", err)
+	}
+	if err := os.MkdirAll(installDir, 0o755); err != nil {
+		t.Fatalf("create install dir: %v", err)
+	}
+	legacyPath := filepath.Join(installDir, uuid+".mobileprovision")
+	if err := os.WriteFile(legacyPath, []byte("old profile"), 0o600); err != nil {
+		t.Fatalf("write legacy profile: %v", err)
+	}
+
+	cmd := ProfilesLocalInstallCommand()
+	if err := cmd.Parse([]string{"--path", sourcePath, "--install-dir", installDir, "--force", "--output", "json"}); err != nil {
+		t.Fatalf("parse install flags: %v", err)
+	}
+	if err := cmd.Run(context.Background()); err != nil {
+		t.Fatalf("force-install macOS profile over legacy path: %v", err)
+	}
+	got, err := os.ReadFile(legacyPath)
+	if err != nil {
+		t.Fatalf("read replaced legacy profile: %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatal("legacy profile path was not replaced with the new profile")
+	}
+	modernPath := filepath.Join(installDir, uuid+".provisionprofile")
+	if _, err := os.Stat(modernPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("force install created duplicate path %q (err=%v)", modernPath, err)
+	}
+}
+
+func TestScanLocalProfilesIncludesBothProfileExtensions(t *testing.T) {
+	installDir := t.TempDir()
+	now := time.Now()
+	fixtures := []struct {
+		name     string
+		platform string
+		expires  time.Time
+	}{
+		{name: "mac.provisionprofile", platform: "OSX", expires: now.Add(time.Hour)},
+		{name: "ios.mobileprovision", platform: "iOS", expires: now.Add(time.Hour)},
+	}
+	for index, fixture := range fixtures {
+		data, err := plist.Marshal(map[string]any{
+			"UUID":           fmt.Sprintf("01234567-89ab-cdef-0123-456789abcde%d", index),
+			"Name":           fixture.name,
+			"TeamIdentifier": []string{"TEAM123"},
+			"Platform":       []string{fixture.platform},
+			"ExpirationDate": fixture.expires,
+			"Entitlements":   map[string]any{"application-identifier": fmt.Sprintf("TEAM123.com.example.%d", index)},
+		}, plist.XMLFormat)
+		if err != nil {
+			t.Fatalf("marshal %s: %v", fixture.name, err)
+		}
+		if err := os.WriteFile(filepath.Join(installDir, fixture.name), data, 0o600); err != nil {
+			t.Fatalf("write %s: %v", fixture.name, err)
+		}
+	}
+
+	items, skipped, err := scanLocalProfiles(installDir, now)
+	if err != nil {
+		t.Fatalf("scan local profiles: %v", err)
+	}
+	if len(skipped) != 0 {
+		t.Fatalf("scan skipped valid profiles: %#v", skipped)
+	}
+	if len(items) != len(fixtures) {
+		t.Fatalf("scan returned %d profiles, want %d: %#v", len(items), len(fixtures), items)
+	}
+	paths := map[string]bool{}
+	for _, item := range items {
+		paths[filepath.Base(item.Path)] = true
+	}
+	for _, fixture := range fixtures {
+		if !paths[fixture.name] {
+			t.Fatalf("scan did not return %s: %#v", fixture.name, items)
+		}
+	}
+}
+
+func TestProfilesLocalCleanRemovesExpiredMacOSProfile(t *testing.T) {
+	root := t.TempDir()
+	installDir := filepath.Join(root, "installed")
+	const uuid = "01234567-89ab-cdef-0123-456789abcdef"
+	data, err := plist.Marshal(map[string]any{
+		"UUID":           uuid,
+		"Name":           "Expired Mac App Store",
+		"TeamIdentifier": []string{"TEAM123"},
+		"Platform":       []string{"OSX"},
+		"ExpirationDate": time.Now().Add(-time.Hour),
+		"Entitlements":   map[string]any{"application-identifier": "TEAM123.com.example.mac"},
+	}, plist.XMLFormat)
+	if err != nil {
+		t.Fatalf("marshal profile fixture: %v", err)
+	}
+	profilePath := filepath.Join(installDir, uuid+".provisionprofile")
+	if err := os.MkdirAll(installDir, 0o755); err != nil {
+		t.Fatalf("create install dir: %v", err)
+	}
+	if err := os.WriteFile(profilePath, data, 0o600); err != nil {
+		t.Fatalf("write profile fixture: %v", err)
+	}
+
+	cmd := ProfilesLocalCleanCommand()
+	if err := cmd.Parse([]string{"--install-dir", installDir, "--expired", "--confirm", "--output", "json"}); err != nil {
+		t.Fatalf("parse clean flags: %v", err)
+	}
+	if err := cmd.Run(context.Background()); err != nil {
+		t.Fatalf("clean expired macOS profile: %v", err)
+	}
+	if _, err := os.Stat(profilePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expired macOS profile still exists (err=%v)", err)
 	}
 }

--- a/internal/cli/profiles/profiles.go
+++ b/internal/cli/profiles/profiles.go
@@ -32,7 +32,7 @@ Examples:
   asc profiles create --name "Profile" --profile-type IOS_APP_DEVELOPMENT --bundle "BUNDLE_ID" --certificate "CERT_ID"
   asc profiles delete --id "PROFILE_ID" --confirm
   asc profiles download --id "PROFILE_ID" --output "./profile.mobileprovision"
-  asc profiles inspect --path "./profile.mobileprovision"
+  asc profiles inspect --path "./profile.provisionprofile"
   asc profiles links bundle-id --id "PROFILE_ID"
   asc profiles links certificates --id "PROFILE_ID"
   asc profiles links devices --id "PROFILE_ID"`,
@@ -454,7 +454,7 @@ func ProfilesDownloadCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("download", flag.ExitOnError)
 
 	id := fs.String("id", "", "Profile ID")
-	outputPath := fs.String("output", "", "Output .mobileprovision file path")
+	outputPath := fs.String("output", "", "Output .mobileprovision or .provisionprofile file path")
 	output := shared.BindMetadataOutputFlags(fs)
 
 	return &ffcli.Command{
@@ -464,7 +464,8 @@ func ProfilesDownloadCommand() *ffcli.Command {
 		LongHelp: `Download a provisioning profile.
 
 Examples:
-  asc profiles download --id "PROFILE_ID" --output "./profile.mobileprovision"`,
+  asc profiles download --id "PROFILE_ID" --output "./profile.mobileprovision"
+  asc profiles download --id "PROFILE_ID" --output "./profile.provisionprofile"`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {

--- a/internal/cli/shared/provisioning_profile.go
+++ b/internal/cli/shared/provisioning_profile.go
@@ -1,0 +1,58 @@
+package shared
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+const (
+	// IOSProvisioningProfileExtension is the conventional extension for iOS,
+	// tvOS, and other non-macOS provisioning profiles.
+	IOSProvisioningProfileExtension = ".mobileprovision"
+	// MacOSProvisioningProfileExtension is the conventional extension for
+	// provisioning profiles used by macOS applications.
+	MacOSProvisioningProfileExtension = ".provisionprofile"
+)
+
+// IsProvisioningProfilePath reports whether path has a recognized
+// provisioning-profile extension. The extension is only a file-type hint;
+// callers must still parse and validate the profile contents.
+func IsProvisioningProfilePath(path string) bool {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case IOSProvisioningProfileExtension, MacOSProvisioningProfileExtension:
+		return true
+	default:
+		return false
+	}
+}
+
+// ProvisioningProfileExtension returns the conventional extension for a
+// profile. A known platform takes precedence; the profile type is used as a
+// fallback because profile creation preflight runs before the API returns the
+// created resource's platform attribute.
+func ProvisioningProfileExtension(platform, profileType string) string {
+	switch strings.ToUpper(strings.TrimSpace(platform)) {
+	case "MAC_OS", "OSX", "MACOS", "MACOSX":
+		return MacOSProvisioningProfileExtension
+	case "IOS", "TV_OS", "TVOS", "VISION_OS":
+		return IOSProvisioningProfileExtension
+	}
+
+	if strings.HasPrefix(strings.ToUpper(strings.TrimSpace(profileType)), "MAC_") {
+		return MacOSProvisioningProfileExtension
+	}
+	return IOSProvisioningProfileExtension
+}
+
+// ProvisioningProfileExtensionForPlatforms returns the conventional extension
+// for a profile whose parsed payload may advertise more than one platform.
+// macOS wins when present; an unknown or empty platform preserves the legacy
+// iOS-compatible default.
+func ProvisioningProfileExtensionForPlatforms(platforms []string, profileType string) string {
+	for _, platform := range platforms {
+		if ProvisioningProfileExtension(platform, "") == MacOSProvisioningProfileExtension {
+			return MacOSProvisioningProfileExtension
+		}
+	}
+	return ProvisioningProfileExtension("", profileType)
+}

--- a/internal/cli/shared/provisioning_profile_test.go
+++ b/internal/cli/shared/provisioning_profile_test.go
@@ -1,0 +1,56 @@
+package shared
+
+import "testing"
+
+func TestProvisioningProfileExtension(t *testing.T) {
+	tests := []struct {
+		name        string
+		platform    string
+		profileType string
+		want        string
+	}{
+		{name: "macOS platform", platform: "MAC_OS", profileType: "IOS_APP_STORE", want: ".provisionprofile"},
+		{name: "signed macOS platform", platform: "OSX", profileType: "IOS_APP_STORE", want: ".provisionprofile"},
+		{name: "native Mac fallback", profileType: "MAC_APP_STORE", want: ".provisionprofile"},
+		{name: "Mac Catalyst fallback", profileType: "MAC_CATALYST_APP_STORE", want: ".provisionprofile"},
+		{name: "iOS", platform: "IOS", profileType: "IOS_APP_STORE", want: ".mobileprovision"},
+		{name: "tvOS", platform: "TV_OS", profileType: "TVOS_APP_STORE", want: ".mobileprovision"},
+		{name: "unknown defaults to legacy", platform: "UNKNOWN", profileType: "IOS_APP_STORE", want: ".mobileprovision"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := ProvisioningProfileExtension(test.platform, test.profileType); got != test.want {
+				t.Fatalf("ProvisioningProfileExtension(%q, %q) = %q, want %q", test.platform, test.profileType, got, test.want)
+			}
+		})
+	}
+}
+
+func TestProvisioningProfileExtensionForPlatforms(t *testing.T) {
+	if got := ProvisioningProfileExtensionForPlatforms([]string{"iOS", "macOS"}, ""); got != MacOSProvisioningProfileExtension {
+		t.Fatalf("ProvisioningProfileExtensionForPlatforms() = %q, want %q", got, MacOSProvisioningProfileExtension)
+	}
+	if got := ProvisioningProfileExtensionForPlatforms(nil, "IOS_APP_STORE"); got != IOSProvisioningProfileExtension {
+		t.Fatalf("ProvisioningProfileExtensionForPlatforms(nil) = %q, want %q", got, IOSProvisioningProfileExtension)
+	}
+}
+
+func TestIsProvisioningProfilePath(t *testing.T) {
+	for _, test := range []struct {
+		path string
+		want bool
+	}{
+		{path: "profile.mobileprovision", want: true},
+		{path: "profile.MOBILEPROVISION", want: true},
+		{path: "profile.provisionprofile", want: true},
+		{path: "profile.PROVISIONPROFILE", want: true},
+		{path: "profile.mobileprovision.enc", want: false},
+		{path: "profile.plist", want: false},
+		{path: "profile", want: false},
+	} {
+		if got := IsProvisioningProfilePath(test.path); got != test.want {
+			t.Fatalf("IsProvisioningProfilePath(%q) = %t, want %t", test.path, got, test.want)
+		}
+	}
+}

--- a/internal/cli/signing/signing_fetch.go
+++ b/internal/cli/signing/signing_fetch.go
@@ -50,6 +50,9 @@ func SigningFetchCommand() *ffcli.Command {
 This command resolves the bundle ID, finds matching certificates and profiles,
 and writes them to the output directory.
 
+Native macOS profiles are written as .provisionprofile files. iOS and tvOS
+profiles continue to use .mobileprovision files.
+
 With --create-missing, it will create a new profile if none exist for the
 specified configuration. Devices are only applied to profiles this command
 creates, so --device without --create-missing is rejected with a usage error.
@@ -98,7 +101,7 @@ Examples:
 				if err := prepareOutputDir(); err != nil {
 					return err
 				}
-				return ensureOutputPathsAreFree(signingOutputPaths(outputDir, profileName, profileID, certificates))
+				return ensureOutputPathsAreFree(signingOutputPaths(outputDir, profileName, profileID, profType, certificates))
 			}
 
 			client, err := shared.GetASCClient()
@@ -154,7 +157,7 @@ Examples:
 				return fmt.Errorf("signing fetch: %w", err)
 			}
 
-			profilePath := profileOutputPath(outputDir, profile.Data.Attributes.Name, profile.Data.ID)
+			profilePath := profileOutputPath(outputDir, profile.Data.Attributes.Name, profile.Data.ID, profType)
 			profileContent, err := decodeBase64Content("profile", profile.Data.Attributes.ProfileContent)
 			if err != nil {
 				return fmt.Errorf("signing fetch: decode profile: %w", err)
@@ -642,17 +645,18 @@ func decodeBase64Content(label, content string) ([]byte, error) {
 
 // signingOutputPaths returns every file signing fetch writes for the resolved
 // assets. profileID is empty while the profile is still being planned.
-func signingOutputPaths(outputDir, profileName, profileID string, certificates []asc.Resource[asc.CertificateAttributes]) []string {
+func signingOutputPaths(outputDir, profileName, profileID, profileType string, certificates []asc.Resource[asc.CertificateAttributes]) []string {
 	paths := make([]string, 0, len(certificates)+1)
-	paths = append(paths, profileOutputPath(outputDir, profileName, profileID))
+	paths = append(paths, profileOutputPath(outputDir, profileName, profileID, profileType))
 	for _, certificate := range certificates {
 		paths = append(paths, certificateOutputPath(outputDir, certificate))
 	}
 	return paths
 }
 
-func profileOutputPath(outputDir, profileName, profileID string) string {
-	return filepath.Join(outputDir, safeFileName(profileName, profileID)+".mobileprovision")
+func profileOutputPath(outputDir, profileName, profileID, profileType string) string {
+	extension := shared.ProvisioningProfileExtension("", profileType)
+	return filepath.Join(outputDir, safeFileName(profileName, profileID)+extension)
 }
 
 func certificateOutputPath(outputDir string, certificate asc.Resource[asc.CertificateAttributes]) string {

--- a/internal/cli/signing/signing_fetch_test.go
+++ b/internal/cli/signing/signing_fetch_test.go
@@ -298,7 +298,7 @@ func TestSigningFetchFormatUsesSharedOutputDefault(t *testing.T) {
 
 func TestSigningOutputPathsCoverProfileAndCertificateFiles(t *testing.T) {
 	dir := filepath.Join("tmp", "signing")
-	paths := signingOutputPaths(dir, "Created Profile", "profile-created", []asc.Resource[asc.CertificateAttributes]{
+	paths := signingOutputPaths(dir, "Created Profile", "profile-created", "IOS_APP_STORE", []asc.Resource[asc.CertificateAttributes]{
 		{ID: "cert-1", Attributes: asc.CertificateAttributes{SerialNumber: "CERT1"}},
 		{ID: "cert-2", Attributes: asc.CertificateAttributes{}},
 	})
@@ -310,6 +310,12 @@ func TestSigningOutputPathsCoverProfileAndCertificateFiles(t *testing.T) {
 	}
 	if strings.Join(paths, ",") != strings.Join(want, ",") {
 		t.Fatalf("signingOutputPaths() = %v, want %v", paths, want)
+	}
+
+	macPaths := signingOutputPaths(dir, "Created Profile", "profile-created", "MAC_APP_STORE", nil)
+	macWant := []string{filepath.Join(dir, "Created Profile.provisionprofile")}
+	if strings.Join(macPaths, ",") != strings.Join(macWant, ",") {
+		t.Fatalf("signingOutputPaths() for macOS = %v, want %v", macPaths, macWant)
 	}
 }
 

--- a/internal/cli/signing/signing_identity.go
+++ b/internal/cli/signing/signing_identity.go
@@ -612,13 +612,13 @@ func normalizeIdentityProfileUUID(raw string) (string, error) {
 	return parsed.String(), nil
 }
 
-func signingAssetRepositoryPaths(certificates []asc.Resource[asc.CertificateAttributes], profileType, profileName, profileFallback string, artifacts *signingIdentityArtifacts) []string {
+func signingAssetRepositoryPathsForProfile(certificates []asc.Resource[asc.CertificateAttributes], profileType, profilePath string, artifacts *signingIdentityArtifacts) []string {
 	paths := make([]string, 0, len(certificates)+3)
 	certDir := certDirectoryName(profileType)
 	for _, certificate := range certificates {
 		paths = append(paths, filepath.Join("certs", certDir, safeFileName(certificate.Attributes.SerialNumber, certificate.ID)+".cer"))
 	}
-	paths = append(paths, filepath.Join("profiles", profileDirectoryName(profileType), safeFileName(profileName, profileFallback)+".mobileprovision"))
+	paths = append(paths, profilePath)
 	if artifacts != nil {
 		paths = append(paths, artifacts.IdentityPath, artifacts.BindingPath)
 	}
@@ -626,6 +626,12 @@ func signingAssetRepositoryPaths(certificates []asc.Resource[asc.CertificateAttr
 }
 
 func preflightSigningAssetDestinations(store *signingpkg.GitStore, plan profileCreatePlan, profileType string) error {
+	profileExtension := shared.ProvisioningProfileExtension("", profileType)
+	profilePath := filepath.Join("profiles", profileDirectoryName(profileType), safeFileName(plan.ProfileName, "profile")+profileExtension)
+	return preflightSigningAssetDestinationsForProfile(store, plan, profileType, profilePath)
+}
+
+func preflightSigningAssetDestinationsForProfile(store *signingpkg.GitStore, plan profileCreatePlan, profileType, profilePath string) error {
 	certDir := certDirectoryName(profileType)
 	for _, certificate := range plan.Certificates {
 		relPath := filepath.Join("certs", certDir, safeFileName(certificate.Attributes.SerialNumber, certificate.ID)+".cer")
@@ -633,8 +639,7 @@ func preflightSigningAssetDestinations(store *signingpkg.GitStore, plan profileC
 			return fmt.Errorf("preflight certificate destination: %w", err)
 		}
 	}
-	profileRelPath := filepath.Join("profiles", profileDirectoryName(profileType), safeFileName(plan.ProfileName, "profile")+".mobileprovision")
-	if err := store.CheckWriteEncryptedFile(profileRelPath); err != nil {
+	if err := store.CheckWriteEncryptedFile(profilePath); err != nil {
 		return fmt.Errorf("preflight profile destination: %w", err)
 	}
 	return nil

--- a/internal/cli/signing/signing_profile_artifact.go
+++ b/internal/cli/signing/signing_profile_artifact.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 	signingpkg "github.com/rudrankriyam/App-Store-Connect-CLI/internal/signing"
 )
 
@@ -52,7 +54,7 @@ func validateSigningProfileArtifactMetadata(relPath string, metadata signingpkg.
 	if metadata.Version != 1 || metadata.Kind != signingProfileArtifactKind || metadata.Sensitive {
 		return fmt.Errorf("provisioning profile must use a versioned non-sensitive envelope")
 	}
-	if !strings.HasPrefix(canonicalPath, "profiles/") || !strings.HasSuffix(strings.ToLower(canonicalPath), ".mobileprovision") {
+	if !strings.HasPrefix(canonicalPath, "profiles/") || !shared.IsProvisioningProfilePath(canonicalPath) {
 		return fmt.Errorf("provisioning profile metadata requires a profile repository path")
 	}
 	if strings.TrimSpace(metadata.BundleID) == "" || strings.TrimSpace(metadata.ProfileResourceID) == "" {
@@ -139,4 +141,39 @@ func writeOrReuseSigningProfileArtifact(store *signingpkg.GitStore, relPath stri
 		return err
 	}
 	return store.ReplaceEncryptedFileWithMetadata(relPath, plaintext, password, metadata)
+}
+
+// resolveCompatibleSigningProfilePath keeps using the legacy repository path
+// for a macOS profile when that is the only spelling already present. This
+// prevents an extension upgrade from publishing a second copy of the same
+// profile under .provisionprofile. Repositories that already contain both
+// spellings are ambiguous and must be repaired explicitly.
+func resolveCompatibleSigningProfilePath(store *signingpkg.GitStore, preferredPath string) (string, error) {
+	if store == nil || !strings.EqualFold(filepath.Ext(preferredPath), ".provisionprofile") {
+		return preferredPath, nil
+	}
+	legacyPath := strings.TrimSuffix(preferredPath, filepath.Ext(preferredPath)) + ".mobileprovision"
+	existing, err := store.ListEncryptedFiles()
+	if err != nil {
+		return "", err
+	}
+	preferredCanonical := canonicalSigningPullPath(preferredPath)
+	legacyCanonical := canonicalSigningPullPath(legacyPath)
+	preferredExists := false
+	legacyExists := false
+	for _, path := range existing {
+		switch canonicalSigningPullPath(path) {
+		case preferredCanonical:
+			preferredExists = true
+		case legacyCanonical:
+			legacyExists = true
+		}
+	}
+	if preferredExists && legacyExists {
+		return "", fmt.Errorf("macOS provisioning profile exists at both %s and %s", legacyPath, preferredPath)
+	}
+	if legacyExists {
+		return legacyPath, nil
+	}
+	return preferredPath, nil
 }

--- a/internal/cli/signing/signing_profile_artifact_test.go
+++ b/internal/cli/signing/signing_profile_artifact_test.go
@@ -74,3 +74,71 @@ func TestClassifySigningProfileArtifactRejectsIncompleteMetadata(t *testing.T) {
 		t.Fatalf("error = %v, want incomplete metadata refusal", err)
 	}
 }
+
+func TestValidateSigningProfileArtifactMetadataAcceptsMacOSExtension(t *testing.T) {
+	for _, path := range []string{
+		"profiles/appstore/profile.provisionprofile",
+		"profiles/appstore/profile.mobileprovision",
+	} {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			err := validateSigningProfileArtifactMetadata(path, signingpkg.EncryptedFileMetadata{
+				Version:           1,
+				Kind:              signingProfileArtifactKind,
+				BundleID:          "com.example.mac",
+				ProfileType:       "MAC_APP_STORE",
+				ProfileResourceID: "profile-1",
+			})
+			if err != nil {
+				t.Fatalf("validateSigningProfileArtifactMetadata(%q): %v", path, err)
+			}
+		})
+	}
+}
+
+func TestResolveCompatibleSigningProfilePathPreservesLegacyMacOSArtifact(t *testing.T) {
+	const password = "repository-password"
+	preferred := filepath.Join("profiles", "appstore", "profile.provisionprofile")
+	legacy := filepath.Join("profiles", "appstore", "profile.mobileprovision")
+
+	t.Run("legacy only", func(t *testing.T) {
+		store := &signingpkg.GitStore{LocalDir: t.TempDir()}
+		if err := store.WriteEncryptedFile(legacy, []byte("profile"), password); err != nil {
+			t.Fatal(err)
+		}
+		got, err := resolveCompatibleSigningProfilePath(store, preferred)
+		if err != nil || got != legacy {
+			t.Fatalf("path = %q, error = %v, want legacy path %q", got, err, legacy)
+		}
+	})
+
+	t.Run("preferred only", func(t *testing.T) {
+		store := &signingpkg.GitStore{LocalDir: t.TempDir()}
+		if err := store.WriteEncryptedFile(preferred, []byte("profile"), password); err != nil {
+			t.Fatal(err)
+		}
+		got, err := resolveCompatibleSigningProfilePath(store, preferred)
+		if err != nil || got != preferred {
+			t.Fatalf("path = %q, error = %v, want preferred path %q", got, err, preferred)
+		}
+	})
+
+	t.Run("both spellings", func(t *testing.T) {
+		store := &signingpkg.GitStore{LocalDir: t.TempDir()}
+		for _, path := range []string{legacy, preferred} {
+			if err := store.WriteEncryptedFile(path, []byte("profile"), password); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if _, err := resolveCompatibleSigningProfilePath(store, preferred); err == nil || !strings.Contains(err.Error(), "exists at both") {
+			t.Fatalf("error = %v, want ambiguous repository refusal", err)
+		}
+	})
+
+	t.Run("iOS path is unchanged", func(t *testing.T) {
+		store := &signingpkg.GitStore{LocalDir: t.TempDir()}
+		got, err := resolveCompatibleSigningProfilePath(store, legacy)
+		if err != nil || got != legacy {
+			t.Fatalf("path = %q, error = %v, want %q", got, err, legacy)
+		}
+	})
+}

--- a/internal/cli/signing/signing_sync.go
+++ b/internal/cli/signing/signing_sync.go
@@ -61,6 +61,9 @@ Fetches signing assets from App Store Connect, encrypts them, and stores them
 in a shared git repository. Team members and CI workers can pull and decrypt
 the same verified signing files.
 
+Native macOS profile types use .provisionprofile paths; iOS and tvOS profile
+types retain .mobileprovision. Existing legacy profile paths remain readable.
+
 Examples:
   asc signing sync push --bundle-id com.example.app --profile-type IOS_APP_STORE \
     --repo git@github.com:team/certs.git --password-file ~/.config/asc/signing-sync-password
@@ -331,11 +334,17 @@ func syncPushCommand() *ffcli.Command {
 								return err
 							}
 						}
-						plannedPaths := signingAssetRepositoryPaths(plan.Certificates, profType, plan.ProfileName, "profile", identityArtifacts)
+						profileExtension := shared.ProvisioningProfileExtension("", profType)
+						preferredProfilePath := filepath.Join("profiles", profileDirectoryName(profType), safeFileName(plan.ProfileName, "profile")+profileExtension)
+						profilePath, err := resolveCompatibleSigningProfilePath(store, preferredProfilePath)
+						if err != nil {
+							return err
+						}
+						plannedPaths := signingAssetRepositoryPathsForProfile(plan.Certificates, profType, profilePath, identityArtifacts)
 						if err := store.CheckEncryptedRepositoryPaths(plannedPaths); err != nil {
 							return err
 						}
-						if err := preflightSigningAssetDestinations(store, plan, profType); err != nil {
+						if err := preflightSigningAssetDestinationsForProfile(store, plan, profType, profilePath); err != nil {
 							return err
 						}
 						if identity != nil {
@@ -370,7 +379,12 @@ func syncPushCommand() *ffcli.Command {
 				return fmt.Errorf("signing sync push: decode profile: %w", err)
 			}
 			profileDir := profileDirectoryName(profType)
-			profileRelPath := filepath.Join("profiles", profileDir, safeFileName(profile.Data.Attributes.Name, profile.Data.ID)+".mobileprovision")
+			profileExtension := shared.ProvisioningProfileExtension(string(profile.Data.Attributes.Platform), profType)
+			profileRelPath := filepath.Join("profiles", profileDir, safeFileName(profile.Data.Attributes.Name, profile.Data.ID)+profileExtension)
+			profileRelPath, err = resolveCompatibleSigningProfilePath(store, profileRelPath)
+			if err != nil {
+				return fmt.Errorf("signing sync push: resolve profile repository path: %w", err)
+			}
 			profileMetadata, err := signingProfileArtifactMetadata(profile, bundle, profType)
 			if err != nil {
 				return fmt.Errorf("signing sync push: prepare profile metadata: %w", err)
@@ -386,7 +400,7 @@ func syncPushCommand() *ffcli.Command {
 					return fmt.Errorf("signing sync push: bind signing identity profile: %w", err)
 				}
 			}
-			plannedPaths := signingAssetRepositoryPaths(certs.Data, profType, profile.Data.Attributes.Name, profile.Data.ID, identityArtifacts)
+			plannedPaths := signingAssetRepositoryPathsForProfile(certs.Data, profType, profileRelPath, identityArtifacts)
 			if err := store.CheckEncryptedRepositoryPaths(plannedPaths); err != nil {
 				return fmt.Errorf("signing sync push: preflight repository paths: %w", err)
 			}

--- a/internal/cli/signing/signing_sync_batch.go
+++ b/internal/cli/signing/signing_sync_batch.go
@@ -320,6 +320,10 @@ func prepareSigningSyncBatchFiles(store *signingpkg.GitStore, targets []signingS
 		}
 		target.ProfileContent = profileContent
 		target.ProfilePath = signingSyncBatchProfilePath(target.BundleID, target.ProfileType, target.Profile.Data.ID)
+		target.ProfilePath, err = resolveCompatibleSigningProfilePath(store, target.ProfilePath)
+		if err != nil {
+			return nil, "", fmt.Errorf("resolve profile repository path for %s: %w", target.BundleID, err)
+		}
 		profileMetadata, err := signingProfileArtifactMetadata(target.Profile, target.BundleID, target.ProfileType)
 		if err != nil {
 			return nil, "", fmt.Errorf("profile for %s metadata: %w", target.BundleID, err)
@@ -433,7 +437,8 @@ func preflightSigningSyncBatchProfileCreate(store *signingpkg.GitStore, plan pro
 			return fmt.Errorf("preflight certificate destination: %w", err)
 		}
 	}
-	placeholder := filepath.Join("profiles", profileDirectoryName(profileType), "target-placeholder.mobileprovision")
+	profileExtension := shared.ProvisioningProfileExtension("", profileType)
+	placeholder := filepath.Join("profiles", profileDirectoryName(profileType), "target-placeholder"+profileExtension)
 	if err := store.CheckEncryptedFileParent(placeholder); err != nil {
 		return fmt.Errorf("preflight profile destination: %w", err)
 	}
@@ -472,10 +477,11 @@ func writeOrReuseSigningSyncLegacyArtifact(store *signingpkg.GitStore, relPath s
 }
 
 func signingSyncBatchProfilePath(bundleID, profileType, profileID string) string {
+	profileExtension := shared.ProvisioningProfileExtension("", profileType)
 	return filepath.Join(
 		"profiles",
 		profileDirectoryName(profileType),
-		safeFileName(bundleID, "bundle")+"--"+safeFileName(profileID, "profile")+".mobileprovision",
+		safeFileName(bundleID, "bundle")+"--"+safeFileName(profileID, "profile")+profileExtension,
 	)
 }
 

--- a/internal/cli/signing/signing_sync_batch_test.go
+++ b/internal/cli/signing/signing_sync_batch_test.go
@@ -31,6 +31,40 @@ func TestSigningSyncBatchProfilePathIsTargetScoped(t *testing.T) {
 	if got != want {
 		t.Fatalf("signingSyncBatchProfilePath() = %q, want %q", got, want)
 	}
+
+	macGot := signingSyncBatchProfilePath("com.example.mac", "MAC_APP_STORE", "profile-123")
+	macWant := filepath.Join("profiles", "appstore", "com.example.mac--profile-123.provisionprofile")
+	if macGot != macWant {
+		t.Fatalf("signingSyncBatchProfilePath() for macOS = %q, want %q", macGot, macWant)
+	}
+}
+
+func TestPrepareSigningSyncBatchFilesReusesLegacyMacOSProfilePath(t *testing.T) {
+	store := &signingpkg.GitStore{LocalDir: t.TempDir()}
+	const password = "repository-password"
+	legacyPath := filepath.Join("profiles", "appstore", "com.example.mac--profile-123.mobileprovision")
+	if err := store.WriteEncryptedFile(legacyPath, []byte("old-profile"), password); err != nil {
+		t.Fatal(err)
+	}
+	targets := []signingSyncBatchTarget{{
+		BundleID:    "com.example.mac",
+		ProfileType: "MAC_APP_STORE",
+		Profile: &asc.ProfileResponse{Data: asc.Resource[asc.ProfileAttributes]{
+			ID: "profile-123",
+			Attributes: asc.ProfileAttributes{
+				ProfileType:    "MAC_APP_STORE",
+				ProfileContent: base64.StdEncoding.EncodeToString([]byte("new-profile")),
+			},
+		}},
+	}}
+
+	files, _, err := prepareSigningSyncBatchFiles(store, targets, nil, password)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 1 || files[0].RelativePath != legacyPath || targets[0].ProfilePath != legacyPath {
+		t.Fatalf("files = %#v, target path = %q, want legacy path %q", files, targets[0].ProfilePath, legacyPath)
+	}
 }
 
 func TestProfileCreateNameForTargetAcceptsOperationDateBoundary(t *testing.T) {

--- a/internal/cli/signing/signing_sync_pull_select.go
+++ b/internal/cli/signing/signing_sync_pull_select.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
 )
 
@@ -86,7 +87,7 @@ func selectSigningPullFiles(files []decryptedSigningFile, bundleIDs []string, pr
 				return nil, nil, fmt.Errorf("stored certificate fingerprint appears at multiple repository paths")
 			}
 			certificatesByFingerprint[fingerprint] = file
-		case strings.HasSuffix(strings.ToLower(path), ".mobileprovision"):
+		case shared.IsProvisioningProfilePath(path):
 			profile, err := parseIdentityMobileProvision(file.Plaintext)
 			if err != nil {
 				return nil, nil, fmt.Errorf("stored profile %s is invalid: %w", path, err)

--- a/internal/cli/signing/signing_sync_selective_pull_test.go
+++ b/internal/cli/signing/signing_sync_selective_pull_test.go
@@ -91,7 +91,7 @@ func TestSelectSigningPullFilesChoosesDirectDistributionTarget(t *testing.T) {
 	files := []decryptedSigningFile{
 		{RelativePath: "certs/distribution/direct.cer", Plaintext: certificate.Raw},
 		{
-			RelativePath: "profiles/direct/direct.mobileprovision",
+			RelativePath: "profiles/direct/direct.provisionprofile",
 			Plaintext:    profile,
 			Metadata: signingpkg.EncryptedFileMetadata{
 				Version:           1,
@@ -107,7 +107,7 @@ func TestSelectSigningPullFilesChoosesDirectDistributionTarget(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := signingPullRelativePaths(selected); !slices.Equal(got, []string{"certs/distribution/direct.cer", "profiles/direct/direct.mobileprovision"}) {
+	if got := signingPullRelativePaths(selected); !slices.Equal(got, []string{"certs/distribution/direct.cer", "profiles/direct/direct.provisionprofile"}) {
 		t.Fatalf("selected paths = %v", got)
 	}
 	if len(targets) != 1 || targets[0].ProfileType != "MAC_APP_DIRECT" {

--- a/internal/cli/signing/signing_sync_test.go
+++ b/internal/cli/signing/signing_sync_test.go
@@ -269,7 +269,8 @@ func TestSigningSyncCaseCollisionFailsBeforeProfileCreatePOST(t *testing.T) {
 			if err := os.WriteFile(path, []byte("existing"), 0o600); err != nil {
 				return err
 			}
-			planned := signingAssetRepositoryPaths(plan.Certificates, "IOS_APP_ADHOC", plan.ProfileName, "profile", nil)
+			profilePath := filepath.Join("profiles", profileDirectoryName("IOS_APP_ADHOC"), safeFileName(plan.ProfileName, "profile")+shared.ProvisioningProfileExtension("", "IOS_APP_ADHOC"))
+			planned := signingAssetRepositoryPathsForProfile(plan.Certificates, "IOS_APP_ADHOC", profilePath, nil)
 			return store.CheckEncryptedRepositoryPaths(planned)
 		},
 	})


### PR DESCRIPTION
## Summary
- use `.provisionprofile` for native macOS profile downloads, installs, and signing repositories
- recognize both native and legacy profile extensions across local management and selective sync
- preserve existing legacy repository/install paths and fail closed on ambiguous duplicates
- document macOS profile handling in signing workflows

## Verification
- `make generate-command-docs`
- `make format`
- `make build`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- clean pre-commit `/review`
- clean full-branch `/review` against current `origin/main`