### PR TITLE
fix(notarization): snapshot artifacts before upload

### DIFF
--- a/internal/cli/notarization/notarization.go
+++ b/internal/cli/notarization/notarization.go
@@ -1510,6 +1510,9 @@ Examples:
 			if err != nil {
 				return fmt.Errorf("notarization submit: failed to stat opened file: %w", err)
 			}
+			if err := validateOpenedNotarizationArtifactIdentity(pathInfo, info); err != nil {
+				return fmt.Errorf("notarization submit: %w", err)
+			}
 			if info.IsDir() {
 				return fmt.Errorf("notarization submit: %q is a directory", pathValue)
 			}
@@ -1525,14 +1528,16 @@ Examples:
 				return fmt.Errorf("notarization submit: unsupported file type %q (must be .zip, .dmg, or .pkg)", ext)
 			}
 
-			// Compute SHA-256
+			// Snapshot and compute SHA-256 before any remote mutation. The upload
+			// must consume the same operation-owned bytes as the submitted hash.
 			if shared.ProgressEnabled() {
 				fmt.Fprintf(os.Stderr, "Computing SHA-256 hash of %s...\n", pathValue)
 			}
-			sha256Hash, err := asc.ComputeFileSHA256(fileHandle)
+			snapshot, snapshotSize, sha256Hash, cleanupSnapshot, err := snapshotNotarizationArtifact(ctx, fileHandle, info.Size())
 			if err != nil {
-				return fmt.Errorf("notarization submit: failed to compute SHA-256: %w", err)
+				return fmt.Errorf("notarization submit: failed to snapshot and compute SHA-256: %w", err)
 			}
+			defer cleanupSnapshot()
 
 			client, err := shared.GetASCClient()
 			if err != nil {
@@ -1575,7 +1580,7 @@ Examples:
 			}
 
 			contentType := notaryContentType(pathValue)
-			if err := asc.UploadToS3(uploadCtx, creds, fileHandle, sha256Hash, info.Size(), contentType); err != nil {
+			if err := asc.UploadToS3(uploadCtx, creds, snapshot, sha256Hash, snapshotSize, contentType); err != nil {
 				return fmt.Errorf("notarization submit: upload failed: %w", err)
 			}
 
@@ -1636,6 +1641,13 @@ Examples:
 			}
 		},
 	}
+}
+
+func validateOpenedNotarizationArtifactIdentity(pathInfo, openedInfo os.FileInfo) error {
+	if pathInfo == nil || openedInfo == nil || !os.SameFile(pathInfo, openedInfo) {
+		return fmt.Errorf("file changed while being opened")
+	}
+	return nil
 }
 
 // statusCommand returns the status subcommand.

--- a/internal/cli/notarization/notarization.go
+++ b/internal/cli/notarization/notarization.go
@@ -1537,7 +1537,15 @@ Examples:
 			if err != nil {
 				return fmt.Errorf("notarization submit: failed to snapshot and compute SHA-256: %w", err)
 			}
-			defer cleanupSnapshot()
+			snapshotReleased := false
+			releaseSnapshot := func() {
+				if snapshotReleased {
+					return
+				}
+				snapshotReleased = true
+				cleanupSnapshot()
+			}
+			defer releaseSnapshot()
 
 			client, err := shared.GetASCClient()
 			if err != nil {
@@ -1583,6 +1591,7 @@ Examples:
 			if err := asc.UploadToS3(uploadCtx, creds, snapshot, sha256Hash, snapshotSize, contentType); err != nil {
 				return fmt.Errorf("notarization submit: upload failed: %w", err)
 			}
+			releaseSnapshot()
 
 			if shared.ProgressEnabled() {
 				fmt.Fprintln(os.Stderr, "Upload complete.")

--- a/internal/cli/notarization/notarization_test.go
+++ b/internal/cli/notarization/notarization_test.go
@@ -212,8 +212,9 @@ func TestNotarizationSubmitDetectsReplacementBetweenLstatAndOpen(t *testing.T) {
 	if err != nil {
 		t.Fatalf("lstat original: %v", err)
 	}
-	if err := os.Remove(path); err != nil {
-		t.Fatalf("remove original: %v", err)
+	preservedPath := filepath.Join(dir, "original.zip")
+	if err := os.Rename(path, preservedPath); err != nil {
+		t.Fatalf("preserve original: %v", err)
 	}
 	if err := os.WriteFile(path, []byte("replacement"), 0o600); err != nil {
 		t.Fatalf("write replacement: %v", err)

--- a/internal/cli/notarization/notarization_test.go
+++ b/internal/cli/notarization/notarization_test.go
@@ -19,10 +19,12 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/secureopen"
 )
 
 type notaryRoundTripper func(*http.Request) (*http.Response, error)
@@ -84,6 +86,23 @@ func TestNotarizationSubmitUploadsOpenedArchiveAfterPathReplacement(t *testing.T
 				}
 			},
 		},
+		{
+			name: "same-inode rewrite",
+			replacePath: func(t *testing.T, archivePath, preservedPath string, replacement []byte) {
+				t.Helper()
+				file, err := os.OpenFile(archivePath, os.O_WRONLY|os.O_TRUNC, 0o600)
+				if err != nil {
+					t.Errorf("open archive for same-inode rewrite: %v", err)
+					return
+				}
+				if _, err := file.Write(replacement); err != nil {
+					t.Errorf("rewrite archive in place: %v", err)
+				}
+				if err := file.Close(); err != nil {
+					t.Errorf("close rewritten archive: %v", err)
+				}
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -141,6 +160,8 @@ func TestNotarizationSubmitUploadsOpenedArchiveAfterPathReplacement(t *testing.T
 			}))
 
 			var uploadedContents []byte
+			var uploadedHash string
+			var uploadedLength int64
 			originalTransport := http.DefaultClient.Transport
 			http.DefaultClient.Transport = notaryRoundTripper(func(req *http.Request) (*http.Response, error) {
 				body, err := io.ReadAll(req.Body)
@@ -148,6 +169,8 @@ func TestNotarizationSubmitUploadsOpenedArchiveAfterPathReplacement(t *testing.T
 					return nil, err
 				}
 				uploadedContents = body
+				uploadedHash = req.Header.Get("X-Amz-Content-Sha256")
+				uploadedLength = req.ContentLength
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Header:     make(http.Header),
@@ -169,7 +192,45 @@ func TestNotarizationSubmitUploadsOpenedArchiveAfterPathReplacement(t *testing.T
 			if !bytes.Equal(uploadedContents, originalContents) {
 				t.Fatalf("uploaded contents = %q, want originally opened archive %q", uploadedContents, originalContents)
 			}
+			if uploadedHash != expectedHash {
+				t.Fatalf("uploaded hash = %q, want %q", uploadedHash, expectedHash)
+			}
+			if uploadedLength != int64(len(originalContents)) {
+				t.Fatalf("uploaded content length = %d, want %d", uploadedLength, len(originalContents))
+			}
 		})
+	}
+}
+
+func TestNotarizationSubmitDetectsReplacementBetweenLstatAndOpen(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "App.zip")
+	if err := os.WriteFile(path, []byte("original"), 0o600); err != nil {
+		t.Fatalf("write original: %v", err)
+	}
+	originalInfo, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("lstat original: %v", err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove original: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("replacement"), 0o600); err != nil {
+		t.Fatalf("write replacement: %v", err)
+	}
+	opened, err := secureopen.OpenExistingNoFollow(path)
+	if err != nil {
+		t.Fatalf("open replacement: %v", err)
+	}
+	defer opened.Close()
+	openedInfo, err := opened.Stat()
+	if err != nil {
+		t.Fatalf("stat replacement: %v", err)
+	}
+	if err := validateOpenedNotarizationArtifactIdentity(originalInfo, openedInfo); err == nil {
+		t.Fatal("expected replacement identity failure")
+	} else if !strings.Contains(err.Error(), "changed while being opened") {
+		t.Fatalf("unexpected replacement error: %v", err)
 	}
 }
 

--- a/internal/cli/notarization/snapshot.go
+++ b/internal/cli/notarization/snapshot.go
@@ -1,0 +1,210 @@
+package notarization
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/secureopen"
+)
+
+var (
+	snapshotCreatedForTest    func(string)
+	duringSnapshotCopyForTest func()
+)
+
+// snapshotNotarizationArtifact copies the opened source into a private,
+// operation-owned file and hashes the bytes written to that file. The caller
+// must call the returned cleanup function after it is done with the snapshot.
+// Subsequent changes to the source path or inode cannot change the bytes used
+// for the submission hash or S3 upload.
+func snapshotNotarizationArtifact(ctx context.Context, source *os.File, size int64) (*os.File, int64, string, func(), error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, 0, "", nil, err
+	}
+	if source == nil {
+		return nil, 0, "", nil, fmt.Errorf("notarization source is nil")
+	}
+	if size <= 0 {
+		return nil, 0, "", nil, fmt.Errorf("notarization source size must be positive")
+	}
+
+	info, err := source.Stat()
+	if err != nil {
+		return nil, 0, "", nil, fmt.Errorf("inspect notarization source: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, 0, "", nil, fmt.Errorf("notarization source is not a regular file")
+	}
+	if info.Size() != size {
+		return nil, 0, "", nil, fmt.Errorf("notarization source size changed before snapshot")
+	}
+
+	directory, err := os.MkdirTemp("", ".asc-notarization-snapshot-*")
+	if err != nil {
+		return nil, 0, "", nil, fmt.Errorf("create notarization snapshot directory: %w", err)
+	}
+	cleanupDirectory := func() { _ = os.Remove(directory) }
+	if snapshotCreatedForTest != nil {
+		snapshotCreatedForTest(directory)
+	}
+
+	trustedDirectory, err := rootfs.New(directory)
+	if err != nil {
+		cleanupDirectory()
+		return nil, 0, "", nil, fmt.Errorf("anchor notarization snapshot directory: %w", err)
+	}
+	openedDirectory, err := trustedDirectory.OpenRoot()
+	if err != nil {
+		_ = trustedDirectory.Close()
+		cleanupDirectory()
+		return nil, 0, "", nil, fmt.Errorf("open notarization snapshot directory: %w", err)
+	}
+
+	snapshot, snapshotName, err := secureopen.CreateTempNoFollowInRootWithCreator(
+		openedDirectory,
+		".",
+		".artifact-*.snapshot",
+		0o600,
+		secureopen.OpenNewPrivateFileNoFollowInRoot,
+	)
+	if err != nil {
+		_ = openedDirectory.Close()
+		_ = trustedDirectory.Close()
+		cleanupDirectory()
+		return nil, 0, "", nil, fmt.Errorf("create notarization snapshot: %w", err)
+	}
+	closeAndRemove := func() {
+		_ = snapshot.Close()
+		_ = openedDirectory.Remove(snapshotName)
+		_ = openedDirectory.Close()
+		_ = trustedDirectory.Close()
+		cleanupDirectory()
+	}
+
+	if err := secureopen.PreparePrivateFile(snapshot, 0o600); err != nil {
+		closeAndRemove()
+		return nil, 0, "", nil, fmt.Errorf("secure notarization snapshot: %w", err)
+	}
+
+	hash := sha256.New()
+	written, err := copySnapshotWithContext(
+		ctx,
+		io.MultiWriter(snapshot, hash),
+		io.NewSectionReader(source, 0, size),
+		duringSnapshotCopyForTest,
+	)
+	if err != nil {
+		closeAndRemove()
+		return nil, 0, "", nil, fmt.Errorf("copy notarization snapshot: %w", err)
+	}
+	if written != size {
+		closeAndRemove()
+		return nil, 0, "", nil, fmt.Errorf("copy notarization snapshot: copied %d of %d bytes", written, size)
+	}
+
+	// A size change during the copy means the source was not a stable input for
+	// this operation. Same-size rewrites remain harmless because all later
+	// stages consume the completed snapshot rather than the source descriptor.
+	afterInfo, err := source.Stat()
+	if err != nil {
+		closeAndRemove()
+		return nil, 0, "", nil, fmt.Errorf("reinspect notarization source after snapshot: %w", err)
+	}
+	if !afterInfo.Mode().IsRegular() || afterInfo.Size() != size {
+		closeAndRemove()
+		return nil, 0, "", nil, fmt.Errorf("notarization source size changed during snapshot")
+	}
+
+	if err := snapshot.Sync(); err != nil {
+		closeAndRemove()
+		return nil, 0, "", nil, fmt.Errorf("sync notarization snapshot: %w", err)
+	}
+	snapshotInfo, err := snapshot.Stat()
+	if err != nil {
+		closeAndRemove()
+		return nil, 0, "", nil, fmt.Errorf("inspect notarization snapshot: %w", err)
+	}
+	if !snapshotInfo.Mode().IsRegular() || snapshotInfo.Size() != size {
+		closeAndRemove()
+		return nil, 0, "", nil, fmt.Errorf("notarization snapshot size is invalid")
+	}
+	if err := snapshot.Close(); err != nil {
+		_ = openedDirectory.Remove(snapshotName)
+		_ = openedDirectory.Close()
+		_ = trustedDirectory.Close()
+		cleanupDirectory()
+		return nil, 0, "", nil, fmt.Errorf("close notarization snapshot: %w", err)
+	}
+
+	snapshot, err = secureopen.OpenExistingNoFollowInRoot(openedDirectory, snapshotName)
+	if err != nil {
+		_ = openedDirectory.Remove(snapshotName)
+		_ = openedDirectory.Close()
+		_ = trustedDirectory.Close()
+		cleanupDirectory()
+		return nil, 0, "", nil, fmt.Errorf("reopen notarization snapshot: %w", err)
+	}
+	reopenedInfo, err := snapshot.Stat()
+	if err != nil {
+		closeAndRemove()
+		return nil, 0, "", nil, fmt.Errorf("inspect reopened notarization snapshot: %w", err)
+	}
+	if !os.SameFile(snapshotInfo, reopenedInfo) || !reopenedInfo.Mode().IsRegular() || reopenedInfo.Size() != size {
+		closeAndRemove()
+		return nil, 0, "", nil, fmt.Errorf("notarization snapshot changed while reopening")
+	}
+
+	cleanup := func() {
+		_ = snapshot.Close()
+		_ = openedDirectory.Remove(snapshotName)
+		_ = openedDirectory.Close()
+		_ = trustedDirectory.Close()
+		cleanupDirectory()
+	}
+	return snapshot, size, hex.EncodeToString(hash.Sum(nil)), cleanup, nil
+}
+
+func copySnapshotWithContext(ctx context.Context, destination io.Writer, source io.Reader, hook func()) (int64, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	buffer := make([]byte, 64<<10)
+	var written int64
+	for {
+		if hook != nil {
+			hook()
+		}
+		if err := ctx.Err(); err != nil {
+			return written, err
+		}
+
+		read, readErr := source.Read(buffer)
+		if read > 0 {
+			if err := ctx.Err(); err != nil {
+				return written, err
+			}
+			count, writeErr := destination.Write(buffer[:read])
+			written += int64(count)
+			if writeErr != nil {
+				return written, writeErr
+			}
+			if count != read {
+				return written, io.ErrShortWrite
+			}
+		}
+		if readErr != nil {
+			if readErr == io.EOF {
+				return written, nil
+			}
+			return written, readErr
+		}
+	}
+}

--- a/internal/cli/notarization/snapshot.go
+++ b/internal/cli/notarization/snapshot.go
@@ -161,10 +161,13 @@ func snapshotNotarizationArtifact(ctx context.Context, source *os.File, size int
 		closeAndRemove()
 		return nil, 0, "", nil, fmt.Errorf("notarization snapshot changed while reopening")
 	}
+	if err := openedDirectory.Remove(snapshotName); err != nil {
+		closeAndRemove()
+		return nil, 0, "", nil, fmt.Errorf("unlink notarization snapshot: %w", err)
+	}
 
 	cleanup := func() {
 		_ = snapshot.Close()
-		_ = openedDirectory.Remove(snapshotName)
 		_ = openedDirectory.Close()
 		_ = trustedDirectory.Close()
 		cleanupDirectory()

--- a/internal/cli/notarization/snapshot_test.go
+++ b/internal/cli/notarization/snapshot_test.go
@@ -1,0 +1,212 @@
+package notarization
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestSnapshotNotarizationArtifactPreservesBytesAndCleansUp(t *testing.T) {
+	directory := t.TempDir()
+	sourcePath := filepath.Join(directory, "artifact.zip")
+	original := bytes.Repeat([]byte{'A'}, 256<<10)
+	replacement := bytes.Repeat([]byte{'B'}, 256<<10)
+	if len(original) != len(replacement) {
+		t.Fatalf("test contents differ in size: %d and %d", len(original), len(replacement))
+	}
+	if err := os.WriteFile(sourcePath, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer source.Close()
+	info, err := source.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var snapshotDirectory string
+	previousCreatedHook := snapshotCreatedForTest
+	snapshotCreatedForTest = func(path string) { snapshotDirectory = path }
+	t.Cleanup(func() { snapshotCreatedForTest = previousCreatedHook })
+
+	snapshot, size, gotHash, cleanup, err := snapshotNotarizationArtifact(context.Background(), source, info.Size())
+	if err != nil {
+		t.Fatalf("snapshotNotarizationArtifact() error: %v", err)
+	}
+	if cleanup == nil {
+		t.Fatal("snapshotNotarizationArtifact() cleanup = nil")
+	}
+	if snapshotDirectory == "" {
+		t.Fatal("snapshot directory hook was not called")
+	}
+
+	if runtime.GOOS != "windows" {
+		if info, err := os.Stat(snapshotDirectory); err != nil {
+			t.Fatalf("snapshot directory stat: %v", err)
+		} else if info.Mode().Perm()&0o077 != 0 {
+			t.Fatalf("snapshot directory permissions = %#o, want owner-only", info.Mode().Perm())
+		}
+		if info, err := snapshot.Stat(); err != nil {
+			t.Fatalf("snapshot stat: %v", err)
+		} else if info.Mode().Perm()&0o077 != 0 {
+			t.Fatalf("snapshot permissions = %#o, want owner-only", info.Mode().Perm())
+		}
+	}
+
+	if err := rewriteFileInPlace(sourcePath, replacement); err != nil {
+		t.Fatal(err)
+	}
+	gotContents, err := io.ReadAll(snapshot)
+	if err != nil {
+		t.Fatalf("read snapshot: %v", err)
+	}
+	if !bytes.Equal(gotContents, original) {
+		t.Fatalf("snapshot contents = %q, want original contents", gotContents[:min(len(gotContents), 64)])
+	}
+	if size != int64(len(original)) {
+		t.Fatalf("snapshot size = %d, want %d", size, len(original))
+	}
+	wantDigest := sha256.Sum256(original)
+	if gotHash != hex.EncodeToString(wantDigest[:]) {
+		t.Fatalf("snapshot hash = %q, want %q", gotHash, hex.EncodeToString(wantDigest[:]))
+	}
+
+	cleanup()
+	if _, err := os.Lstat(snapshotDirectory); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("snapshot directory after cleanup: %v, want not found", err)
+	}
+}
+
+func TestSnapshotNotarizationArtifactCancellationCleansUp(t *testing.T) {
+	directory := t.TempDir()
+	sourcePath := filepath.Join(directory, "artifact.zip")
+	if err := os.WriteFile(sourcePath, bytes.Repeat([]byte("snapshot bytes\n"), 8<<10), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer source.Close()
+	info, err := source.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var snapshotDirectory string
+	previousCreatedHook := snapshotCreatedForTest
+	previousCopyHook := duringSnapshotCopyForTest
+	snapshotCreatedForTest = func(path string) { snapshotDirectory = path }
+	duringSnapshotCopyForTest = cancel
+	t.Cleanup(func() {
+		snapshotCreatedForTest = previousCreatedHook
+		duringSnapshotCopyForTest = previousCopyHook
+	})
+
+	snapshot, _, _, cleanup, err := snapshotNotarizationArtifact(ctx, source, info.Size())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("snapshotNotarizationArtifact() error = %v, want context.Canceled", err)
+	}
+	if snapshot != nil || cleanup != nil {
+		t.Fatalf("snapshotNotarizationArtifact() returned snapshot=%v cleanup=%v after cancellation", snapshot, cleanup != nil)
+	}
+	if snapshotDirectory == "" {
+		t.Fatal("snapshot directory hook was not called")
+	}
+	if _, err := os.Lstat(snapshotDirectory); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("snapshot directory after cancellation: %v, want not found", err)
+	}
+}
+
+func TestSnapshotNotarizationArtifactRejectsSourceSizeChangeDuringCopy(t *testing.T) {
+	directory := t.TempDir()
+	sourcePath := filepath.Join(directory, "artifact.zip")
+	if err := os.WriteFile(sourcePath, bytes.Repeat([]byte("snapshot bytes\n"), 8<<10), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer source.Close()
+	info, err := source.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var snapshotDirectory string
+	previousCreatedHook := snapshotCreatedForTest
+	previousCopyHook := duringSnapshotCopyForTest
+	snapshotCreatedForTest = func(path string) { snapshotDirectory = path }
+	duringSnapshotCopyForTest = func() {
+		if err := os.Truncate(sourcePath, 0); err != nil {
+			t.Errorf("truncate source during snapshot: %v", err)
+		}
+		duringSnapshotCopyForTest = nil
+	}
+	t.Cleanup(func() {
+		snapshotCreatedForTest = previousCreatedHook
+		duringSnapshotCopyForTest = previousCopyHook
+	})
+
+	snapshot, _, _, cleanup, err := snapshotNotarizationArtifact(context.Background(), source, info.Size())
+	if err == nil {
+		t.Fatal("snapshotNotarizationArtifact() error = nil, want source size failure")
+	}
+	if snapshot != nil || cleanup != nil {
+		t.Fatalf("snapshotNotarizationArtifact() returned snapshot=%v cleanup=%v after size failure", snapshot, cleanup != nil)
+	}
+	if snapshotDirectory == "" {
+		t.Fatal("snapshot directory hook was not called")
+	}
+	if _, err := os.Lstat(snapshotDirectory); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("snapshot directory after size failure: %v, want not found", err)
+	}
+}
+
+func TestSnapshotNotarizationArtifactRejectsSourceSizeChange(t *testing.T) {
+	directory := t.TempDir()
+	sourcePath := filepath.Join(directory, "artifact.zip")
+	if err := os.WriteFile(sourcePath, []byte("snapshot bytes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer source.Close()
+	info, err := source.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, _, cleanup, err := snapshotNotarizationArtifact(context.Background(), source, info.Size()+1); err == nil {
+		t.Fatal("snapshotNotarizationArtifact() error = nil, want size mismatch")
+	} else if cleanup != nil {
+		t.Fatal("snapshotNotarizationArtifact() returned cleanup after size mismatch")
+	}
+}
+
+func rewriteFileInPlace(path string, contents []byte) error {
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	if _, err := file.Write(contents); err != nil {
+		_ = file.Close()
+		return err
+	}
+	return file.Close()
+}

--- a/internal/cli/notarization/snapshot_test.go
+++ b/internal/cli/notarization/snapshot_test.go
@@ -62,6 +62,13 @@ func TestSnapshotNotarizationArtifactPreservesBytesAndCleansUp(t *testing.T) {
 			t.Fatalf("snapshot permissions = %#o, want owner-only", info.Mode().Perm())
 		}
 	}
+	entries, err := os.ReadDir(snapshotDirectory)
+	if err != nil {
+		t.Fatalf("read snapshot directory: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("snapshot directory entries = %d, want unlinked snapshot", len(entries))
+	}
 
 	if err := rewriteFileInPlace(sourcePath, replacement); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary

- snapshot each notarization artifact into an operation-owned private file
- hash and upload the same immutable snapshot
- reject path or inode replacement races and clean up snapshots on every exit path

## Tests

- make build
- make format
- make check-docs
- make lint
- ASC_BYPASS_KEYCHAIN=1 make test
- pre-commit Codex review: clean
- final full-branch Codex review against origin/main: clean