### PR TITLE
fix(release): validate build platform before staging

### DIFF
--- a/commands/release.mdx
+++ b/commands/release.mdx
@@ -21,7 +21,7 @@ asc release <subcommand> [flags]
 
 Run a deterministic pre-submit staging pipeline:
 
-1. Verify `--build-id` exists and belongs to `--app`
+1. Verify `--build-id` exists, belongs to `--app`, and matches `--platform`
 2. Ensure or create the version
 3. Apply metadata/localizations or copy from another version
 4. Reconcile routing app coverage when `--routing-coverage-file` is set

--- a/internal/cli/cmdtest/release_stage_test.go
+++ b/internal/cli/cmdtest/release_stage_test.go
@@ -79,6 +79,8 @@ func TestReleaseStage_DryRunCopyMetadataFromVersion(t *testing.T) {
 		switch {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/builds/BUILD_123/relationships/app":
 			body = `{"data":{"type":"apps","id":"APP_123"}}`
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/builds/BUILD_123/preReleaseVersion":
+			body = `{"data":{"type":"preReleaseVersions","id":"PRE_RELEASE_123","attributes":{"version":"1.2.3","platform":"IOS"}}}`
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/APP_123/appStoreVersions":
 			body = `{"data":[]}`
 		default:
@@ -130,8 +132,8 @@ func TestReleaseStage_DryRunCopyMetadataFromVersion(t *testing.T) {
 	if !strings.Contains(stdout, `"name":"validate_build","status":"dry-run"`) {
 		t.Fatalf("expected the build precondition check in the plan, got %q", stdout)
 	}
-	if requestCount != 2 {
-		t.Fatalf("expected the build check and the version lookup, got %d requests", requestCount)
+	if requestCount != 3 {
+		t.Fatalf("expected the build ownership and platform checks plus the version lookup, got %d requests", requestCount)
 	}
 }
 
@@ -153,6 +155,8 @@ func TestReleaseStage_ResolvesTrimmedCheckpointFile(t *testing.T) {
 		switch {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/builds/BUILD_123/relationships/app":
 			body = `{"data":{"type":"apps","id":"APP_123"}}`
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/builds/BUILD_123/preReleaseVersion":
+			body = `{"data":{"type":"preReleaseVersions","id":"PRE_RELEASE_123","attributes":{"version":"1.2.3","platform":"IOS"}}}`
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/APP_123/appStoreVersions":
 			body = `{"data":[]}`
 		default:

--- a/internal/cli/release/release.go
+++ b/internal/cli/release/release.go
@@ -20,7 +20,7 @@ func ReleaseCommand() *ffcli.Command {
 		LongHelp: `Run high-level App Store release workflows.
 
 release stage prepares a version for review without submitting it. It orchestrates:
-  1. Verify the selected build belongs to the app
+  1. Verify the selected build belongs to the app and matches the requested platform
   2. Ensure/create version
   3. Apply metadata and localizations
   4. Reconcile optional routing app coverage

--- a/internal/cli/release/release_test.go
+++ b/internal/cli/release/release_test.go
@@ -110,14 +110,25 @@ func newReleaseTestServerClient(t *testing.T, handler http.Handler) (*asc.Client
 	return client, server.URL
 }
 
-// releaseBuildAppLinkageResponse answers the build ownership precondition read
-// the pipeline performs before any mutation, for the BUILD_123/APP_123 fixture
-// pair the pipeline tests share.
+// releaseBuildAppLinkageResponse answers the build ownership and platform
+// preconditions the pipeline performs before any mutation, for the
+// BUILD_123/APP_123 fixture pair the pipeline tests share.
 func releaseBuildAppLinkageResponse(req *http.Request) (*http.Response, bool) {
-	if req.Method != http.MethodGet || req.URL.Path != "/v1/builds/BUILD_123/relationships/app" {
+	if req.Method != http.MethodGet {
 		return nil, false
 	}
-	resp, err := releaseJSONResponse(http.StatusOK, `{"data":{"type":"apps","id":"APP_123"}}`)
+
+	var body string
+	switch req.URL.Path {
+	case "/v1/builds/BUILD_123/relationships/app":
+		body = `{"data":{"type":"apps","id":"APP_123"}}`
+	case "/v1/builds/BUILD_123/preReleaseVersion":
+		body = `{"data":{"type":"preReleaseVersions","id":"PRE_RELEASE_123","attributes":{"version":"2.4.0","platform":"IOS"}}}`
+	default:
+		return nil, false
+	}
+
+	resp, err := releaseJSONResponse(http.StatusOK, body)
 	if err != nil {
 		return nil, false
 	}

--- a/internal/cli/release/run.go
+++ b/internal/cli/release/run.go
@@ -302,9 +302,10 @@ func executePipeline(ctx context.Context, opts runOptions) (runResult, error) {
 
 	// attach_build runs after the metadata and routing coverage steps, both of
 	// which mutate. Resolve the requested build before any of them so a build
-	// that does not exist, or belongs to another app, fails the run (and the
-	// dry-run preview) instead of the version being left half-updated.
-	if err := runStep(stepValidateBuild, "Pass a --build-id that exists and belongs to --app (try `asc builds list --app <id>`).", func() (stepOutcome, error) {
+	// that does not exist, belongs to another app, or targets another platform
+	// fails the run (and the dry-run preview) instead of the version being left
+	// half-updated.
+	if err := runStep(stepValidateBuild, "Pass a --build-id that exists, belongs to --app, and matches --platform (try `asc builds list --app <id>`).", func() (stepOutcome, error) {
 		buildAppID, buildErr := resolveBuildOwningApp(requestCtx, client, opts.BuildID)
 		if buildErr != nil {
 			return stepOutcome{}, fmt.Errorf("validate build: %w", buildErr)
@@ -318,16 +319,39 @@ func executePipeline(ctx context.Context, opts runOptions) (runResult, error) {
 			)
 		}
 
+		buildPlatform, platformErr := resolveBuildPlatform(requestCtx, client, opts.BuildID)
+		if platformErr != nil {
+			return stepOutcome{}, fmt.Errorf("validate build: %w", platformErr)
+		}
+		if !strings.EqualFold(buildPlatform, strings.TrimSpace(opts.Platform)) {
+			buildDetails := map[string]any{
+				"buildId":           strings.TrimSpace(opts.BuildID),
+				"appId":             buildAppID,
+				"buildPlatform":     buildPlatform,
+				"requestedPlatform": strings.TrimSpace(opts.Platform),
+			}
+			return stepOutcome{Details: buildDetails}, fmt.Errorf(
+				"validate build: build %s is on platform %q, not %q",
+				strings.TrimSpace(opts.BuildID),
+				buildPlatform,
+				strings.TrimSpace(opts.Platform),
+			)
+		}
+
 		status := "ok"
-		message := "build belongs to app"
+		message := "build belongs to app and matches platform"
 		if opts.DryRun {
 			status = "dry-run"
-			message = "build belongs to app (no action needed)"
+			message = "build belongs to app and matches platform (no action needed)"
 		}
 		return stepOutcome{
 			Status:  status,
 			Message: message,
-			Details: map[string]any{"buildId": strings.TrimSpace(opts.BuildID), "appId": buildAppID},
+			Details: map[string]any{
+				"buildId":       strings.TrimSpace(opts.BuildID),
+				"appId":         buildAppID,
+				"buildPlatform": buildPlatform,
+			},
 			Persist: false,
 		}, nil
 	}); err != nil {
@@ -634,6 +658,31 @@ func resolveBuildOwningApp(ctx context.Context, client *asc.Client, buildID stri
 		return "", fmt.Errorf("build %s is missing a related app ID", trimmedBuildID)
 	}
 	return strings.TrimSpace(linkage.Data.ID), nil
+}
+
+// resolveBuildPlatform reads the build's pre-release version metadata so the
+// selected build cannot be staged into a version for another platform.
+func resolveBuildPlatform(ctx context.Context, client *asc.Client, buildID string) (string, error) {
+	trimmedBuildID := strings.TrimSpace(buildID)
+	if trimmedBuildID == "" {
+		return "", fmt.Errorf("build ID is required")
+	}
+
+	preReleaseVersion, err := client.GetBuildPreReleaseVersion(ctx, trimmedBuildID)
+	if err != nil {
+		if asc.IsNotFound(err) {
+			return "", fmt.Errorf("build %s pre-release version was not found", trimmedBuildID)
+		}
+		return "", fmt.Errorf("resolve platform for build %s: %w", trimmedBuildID, err)
+	}
+	if preReleaseVersion == nil {
+		return "", fmt.Errorf("build %s returned an empty pre-release version", trimmedBuildID)
+	}
+	platform := strings.TrimSpace(string(preReleaseVersion.Data.Attributes.Platform))
+	if platform == "" {
+		return "", fmt.Errorf("build %s pre-release version has no platform", trimmedBuildID)
+	}
+	return platform, nil
 }
 
 func releaseReadinessSuccessMessage(report validation.Report, dryRun bool) string {

--- a/internal/cli/release/stage.go
+++ b/internal/cli/release/stage.go
@@ -39,7 +39,7 @@ func ReleaseStageCommand() *ffcli.Command {
 		ShortUsage: "asc release stage --app \"APP_ID\" --version \"2.4.0\" --build-id \"BUILD_ID\" (--metadata-dir \"./metadata/version/2.4.0\" | --copy-metadata-from \"2.3.2\") [--routing-coverage-file \"./coverage.geojson\"] [flags]",
 		ShortHelp:  "Run version + metadata + attach + validate.",
 		LongHelp: `Run a deterministic pre-submit App Store staging pipeline:
-1. Verify --build-id exists and belongs to --app
+1. Verify --build-id exists, belongs to --app, and matches --platform
 2. Ensure/create version
 3. Apply metadata/localizations or copy metadata from another version
 4. Reconcile routing app coverage when --routing-coverage-file is set

--- a/internal/cli/release/validate_build_test.go
+++ b/internal/cli/release/validate_build_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -80,6 +81,249 @@ func TestExecuteStageRejectsBuildOwnedByAnotherAppBeforeMutating(t *testing.T) {
 	}
 	if len(mutations) != 0 {
 		t.Fatalf("expected no mutating requests, got %v", mutations)
+	}
+}
+
+// TestExecuteStageRejectsBuildPlatformMismatchBeforeMutating proves the build
+// preflight checks the selected build's platform before the version, metadata,
+// or attachment steps can mutate App Store Connect.
+func TestExecuteStageRejectsBuildPlatformMismatchBeforeMutating(t *testing.T) {
+	origClientFactory := releaseClientFactory
+	origMetadataExecutor := metadataPushExecutor
+	origReadinessBuilder := readinessReportBuilder
+	origTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		releaseClientFactory = origClientFactory
+		metadataPushExecutor = origMetadataExecutor
+		readinessReportBuilder = origReadinessBuilder
+		http.DefaultTransport = origTransport
+	})
+
+	metadataCalled := false
+	metadataPushExecutor = func(context.Context, metadata.PushExecutionOptions) (metadata.PushPlanResult, error) {
+		metadataCalled = true
+		return metadata.PushPlanResult{VersionID: "VERSION_123"}, nil
+	}
+	readinessCalled := false
+	readinessReportBuilder = func(context.Context, validatecli.ReadinessOptions) (validation.Report, error) {
+		readinessCalled = true
+		return validation.Report{Summary: validation.Summary{}}, nil
+	}
+
+	var requestOrder []string
+	var mutations []string
+	http.DefaultTransport = releaseRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestOrder = append(requestOrder, req.Method+" "+req.URL.Path)
+		if req.Method != http.MethodGet {
+			mutations = append(mutations, req.Method+" "+req.URL.Path)
+		}
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/builds/BUILD_123/relationships/app":
+			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"apps","id":"APP_123"}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/builds/BUILD_123/preReleaseVersion":
+			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"preReleaseVersions","id":"PRE_RELEASE_123","attributes":{"version":"2.4.0","platform":"IOS"}}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/APP_123/appStoreVersions":
+			return releaseJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"VERSION_123","attributes":{"versionString":"2.4.0","platform":"MAC_OS","appStoreState":"PREPARE_FOR_SUBMISSION"}}]}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_123/build":
+			return releaseJSONResponse(http.StatusNotFound, `{"errors":[{"status":"404","code":"NOT_FOUND","title":"Not Found"}]}`)
+		case req.Method == http.MethodPatch && req.URL.Path == "/v1/appStoreVersions/VERSION_123/relationships/build":
+			return releaseJSONResponse(http.StatusNoContent, "")
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+	})
+	testClient := newReleaseTestClient(t)
+	releaseClientFactory = func() (*asc.Client, error) { return testClient, nil }
+
+	result, err := executeStage(context.Background(), runOptions{
+		AppID:          "APP_123",
+		Version:        "2.4.0",
+		BuildID:        "BUILD_123",
+		MetadataDir:    "./metadata/version/2.4.0",
+		Platform:       "MAC_OS",
+		Timeout:        releaseRunTimeout,
+		Confirm:        true,
+		CheckpointFile: filepath.Join(t.TempDir(), "stage-checkpoint.json"),
+	})
+	if err == nil {
+		t.Fatal("executeStage() error = nil, want a rejected platform mismatch")
+	}
+	if !strings.Contains(err.Error(), "BUILD_123") || !strings.Contains(err.Error(), "IOS") || !strings.Contains(err.Error(), "MAC_OS") {
+		t.Fatalf("expected an error naming the build and both platforms, got %v", err)
+	}
+	if result.FailedStep != stepValidateBuild {
+		t.Fatalf("expected the %s step to fail, got %q", stepValidateBuild, result.FailedStep)
+	}
+	if len(result.Steps) != 1 {
+		t.Fatalf("expected the pipeline to stop at the build check, got %#v", result.Steps)
+	}
+	if metadataCalled {
+		t.Fatal("metadata must not run for a build on another platform")
+	}
+	if readinessCalled {
+		t.Fatal("readiness must not run for a build on another platform")
+	}
+	if len(mutations) != 0 {
+		t.Fatalf("expected no mutating requests, got %v (requests: %v)", mutations, requestOrder)
+	}
+	if len(requestOrder) < 2 || requestOrder[0] != "GET /v1/builds/BUILD_123/relationships/app" || requestOrder[1] != "GET /v1/builds/BUILD_123/preReleaseVersion" {
+		t.Fatalf("expected app ownership then platform preflight, got %v", requestOrder)
+	}
+}
+
+// TestExecuteStageDryRunRejectsBuildPlatformMismatchBeforeMutating proves a
+// dry-run uses the same platform preflight rather than presenting a plan for a
+// build that cannot be attached to the requested platform.
+func TestExecuteStageDryRunRejectsBuildPlatformMismatchBeforeMutating(t *testing.T) {
+	origClientFactory := releaseClientFactory
+	origMetadataExecutor := metadataPushExecutor
+	origReadinessBuilder := readinessReportBuilder
+	origTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		releaseClientFactory = origClientFactory
+		metadataPushExecutor = origMetadataExecutor
+		readinessReportBuilder = origReadinessBuilder
+		http.DefaultTransport = origTransport
+	})
+
+	metadataCalled := false
+	metadataPushExecutor = func(context.Context, metadata.PushExecutionOptions) (metadata.PushPlanResult, error) {
+		metadataCalled = true
+		return metadata.PushPlanResult{VersionID: "VERSION_123"}, nil
+	}
+	readinessCalled := false
+	readinessReportBuilder = func(context.Context, validatecli.ReadinessOptions) (validation.Report, error) {
+		readinessCalled = true
+		return validation.Report{Summary: validation.Summary{}}, nil
+	}
+
+	var requestOrder []string
+	http.DefaultTransport = releaseRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestOrder = append(requestOrder, req.Method+" "+req.URL.Path)
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/builds/BUILD_123/relationships/app":
+			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"apps","id":"APP_123"}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/builds/BUILD_123/preReleaseVersion":
+			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"preReleaseVersions","id":"PRE_RELEASE_123","attributes":{"version":"2.4.0","platform":"IOS"}}}`)
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+	})
+	testClient := newReleaseTestClient(t)
+	releaseClientFactory = func() (*asc.Client, error) { return testClient, nil }
+
+	checkpointPath := filepath.Join(t.TempDir(), "stage-checkpoint.json")
+	result, err := executeStage(context.Background(), runOptions{
+		AppID:          "APP_123",
+		Version:        "2.4.0",
+		BuildID:        "BUILD_123",
+		MetadataDir:    "./metadata/version/2.4.0",
+		Platform:       "MAC_OS",
+		Timeout:        releaseRunTimeout,
+		DryRun:         true,
+		CheckpointFile: checkpointPath,
+	})
+	if err == nil {
+		t.Fatal("executeStage() error = nil, want a rejected platform mismatch")
+	}
+	if !strings.Contains(err.Error(), "BUILD_123") || !strings.Contains(err.Error(), "IOS") || !strings.Contains(err.Error(), "MAC_OS") {
+		t.Fatalf("expected an error naming the build and both platforms, got %v", err)
+	}
+	if result.Status != "error" || result.FailedStep != stepValidateBuild {
+		t.Fatalf("expected the dry-run to fail at the build check, got status %q step %q", result.Status, result.FailedStep)
+	}
+	if len(result.Steps) != 1 {
+		t.Fatalf("expected the dry-run to stop at the build check, got %#v", result.Steps)
+	}
+	if metadataCalled {
+		t.Fatal("metadata must not be planned for a build on another platform")
+	}
+	if readinessCalled {
+		t.Fatal("readiness must not run for a build on another platform")
+	}
+	if _, statErr := os.Stat(checkpointPath); !os.IsNotExist(statErr) {
+		t.Fatalf("dry-run should not create a checkpoint, stat error = %v", statErr)
+	}
+	if len(requestOrder) != 2 || requestOrder[0] != "GET /v1/builds/BUILD_123/relationships/app" || requestOrder[1] != "GET /v1/builds/BUILD_123/preReleaseVersion" {
+		t.Fatalf("expected only the ownership and platform reads, got %v", requestOrder)
+	}
+}
+
+// TestExecuteStageRejectsBuildPlatformLookupErrorBeforeMutating proves an
+// error while resolving the build platform is reported by validate_build and
+// cannot fall through to version or metadata mutations.
+func TestExecuteStageRejectsBuildPlatformLookupErrorBeforeMutating(t *testing.T) {
+	origClientFactory := releaseClientFactory
+	origMetadataExecutor := metadataPushExecutor
+	origReadinessBuilder := readinessReportBuilder
+	origTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		releaseClientFactory = origClientFactory
+		metadataPushExecutor = origMetadataExecutor
+		readinessReportBuilder = origReadinessBuilder
+		http.DefaultTransport = origTransport
+	})
+
+	metadataCalled := false
+	metadataPushExecutor = func(context.Context, metadata.PushExecutionOptions) (metadata.PushPlanResult, error) {
+		metadataCalled = true
+		return metadata.PushPlanResult{VersionID: "VERSION_123"}, nil
+	}
+	readinessCalled := false
+	readinessReportBuilder = func(context.Context, validatecli.ReadinessOptions) (validation.Report, error) {
+		readinessCalled = true
+		return validation.Report{Summary: validation.Summary{}}, nil
+	}
+
+	var requestOrder []string
+	var mutations []string
+	http.DefaultTransport = releaseRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestOrder = append(requestOrder, req.Method+" "+req.URL.Path)
+		if req.Method != http.MethodGet {
+			mutations = append(mutations, req.Method+" "+req.URL.Path)
+		}
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/builds/BUILD_123/relationships/app":
+			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"apps","id":"APP_123"}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/builds/BUILD_123/preReleaseVersion":
+			return releaseJSONResponse(http.StatusBadRequest, `{"errors":[{"status":"400","code":"BAD_REQUEST","title":"Bad Request"}]}`)
+		default:
+			return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+	})
+	testClient := newReleaseTestClient(t)
+	releaseClientFactory = func() (*asc.Client, error) { return testClient, nil }
+
+	result, err := executeStage(context.Background(), runOptions{
+		AppID:          "APP_123",
+		Version:        "2.4.0",
+		BuildID:        "BUILD_123",
+		MetadataDir:    "./metadata/version/2.4.0",
+		Platform:       "MAC_OS",
+		Timeout:        releaseRunTimeout,
+		Confirm:        true,
+		CheckpointFile: filepath.Join(t.TempDir(), "stage-checkpoint.json"),
+	})
+	if err == nil {
+		t.Fatal("executeStage() error = nil, want a platform lookup error")
+	}
+	if !strings.Contains(err.Error(), "validate build") || !strings.Contains(err.Error(), "BUILD_123") {
+		t.Fatalf("expected a validate-build platform lookup error, got %v", err)
+	}
+	if result.FailedStep != stepValidateBuild || len(result.Steps) != 1 {
+		t.Fatalf("expected the pipeline to stop at the build check, got status %q step %q steps %#v", result.Status, result.FailedStep, result.Steps)
+	}
+	if metadataCalled {
+		t.Fatal("metadata must not run when build platform lookup fails")
+	}
+	if readinessCalled {
+		t.Fatal("readiness must not run when build platform lookup fails")
+	}
+	if len(mutations) != 0 {
+		t.Fatalf("expected no mutating requests, got %v (requests: %v)", mutations, requestOrder)
+	}
+	if len(requestOrder) != 2 || requestOrder[0] != "GET /v1/builds/BUILD_123/relationships/app" || requestOrder[1] != "GET /v1/builds/BUILD_123/preReleaseVersion" {
+		t.Fatalf("expected app ownership then platform reads, got %v", requestOrder)
 	}
 }
 
@@ -162,6 +406,8 @@ func TestExecuteStageValidatesBuildOnceBeforeAttaching(t *testing.T) {
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/builds/BUILD_123/relationships/app":
 			buildLookups++
 			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"apps","id":"APP_123"}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/builds/BUILD_123/preReleaseVersion":
+			return releaseJSONResponse(http.StatusOK, `{"data":{"type":"preReleaseVersions","id":"PRE_RELEASE_123","attributes":{"version":"2.4.0","platform":"IOS"}}}`)
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/apps/APP_123/appStoreVersions":
 			return releaseJSONResponse(http.StatusOK, `{"data":[{"type":"appStoreVersions","id":"VERSION_123","attributes":{"versionString":"2.4.0","platform":"IOS"}}]}`)
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/appStoreVersions/VERSION_123/build":
@@ -194,6 +440,10 @@ func TestExecuteStageValidatesBuildOnceBeforeAttaching(t *testing.T) {
 	}
 	if len(result.Steps) != 5 || result.Steps[0].Name != stepValidateBuild {
 		t.Fatalf("expected the build check to be reported first, got %#v", result.Steps)
+	}
+	details, ok := result.Steps[0].Details.(map[string]any)
+	if !ok || details["buildPlatform"] != "IOS" {
+		t.Fatalf("expected build platform in validation details, got %#v", result.Steps[0].Details)
 	}
 	if requestOrder[0] != "GET /v1/builds/BUILD_123/relationships/app" {
 		t.Fatalf("expected the build to be resolved before anything else, got %v", requestOrder)


### PR DESCRIPTION
## Summary
- verify a staged build belongs to the requested platform before any metadata mutation
- preserve ownership-first validation and surface platform lookup failures
- document the expanded build preflight and cover success, mismatch, dry-run, and error paths

## Tests
- make build
- make format
- make check-docs
- make lint
- ASC_BYPASS_KEYCHAIN=1 make test
- final full-branch Codex review against origin/main: no actionable findings