### PR TITLE
fix(xcode): validate immutable regular artifacts

### DIFF
--- a/internal/cli/shared/ipa.go
+++ b/internal/cli/shared/ipa.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/infoplist"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/secureopen"
 )
 
 type IPABundleInfo struct {
@@ -46,65 +47,13 @@ func ValidatePKGPath(pkgPath string) (os.FileInfo, error) {
 // OpenValidatedIPAPath opens and validates an IPA without following a symlink.
 // The returned handle pins the validated file across the upload lifecycle.
 func OpenValidatedIPAPath(ipaPath string) (*os.File, os.FileInfo, error) {
-	return openValidatedBuildArtifactPath(ipaPath, "IPA", "--ipa")
+	return secureopen.OpenExistingRegularFileNoFollow(ipaPath, "IPA", "--ipa")
 }
 
 // OpenValidatedPKGPath opens and validates a PKG without following a symlink.
 // The returned handle pins the validated file across the upload lifecycle.
 func OpenValidatedPKGPath(pkgPath string) (*os.File, os.FileInfo, error) {
-	return openValidatedBuildArtifactPath(pkgPath, "PKG", "--pkg")
-}
-
-func openValidatedBuildArtifactPath(filePath, artifactName, flagName string) (*os.File, os.FileInfo, error) {
-	pathInfo, err := os.Lstat(filePath)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to stat %s: %w", artifactName, err)
-	}
-	if pathInfo.Mode()&os.ModeSymlink != 0 {
-		return nil, nil, buildArtifactSymlinkError(filePath, flagName)
-	}
-	if err := validateBuildArtifactInfo(pathInfo, flagName); err != nil {
-		return nil, nil, err
-	}
-
-	file, err := OpenExistingNoFollow(filePath)
-	if err != nil {
-		if latestInfo, statErr := os.Lstat(filePath); statErr == nil && latestInfo.Mode()&os.ModeSymlink != 0 {
-			return nil, nil, buildArtifactSymlinkError(filePath, flagName)
-		}
-		return nil, nil, fmt.Errorf("failed to open %s: %w", artifactName, err)
-	}
-	fileInfo, err := file.Stat()
-	if err != nil {
-		_ = file.Close()
-		return nil, nil, fmt.Errorf("failed to stat opened %s: %w", artifactName, err)
-	}
-	if !os.SameFile(pathInfo, fileInfo) {
-		_ = file.Close()
-		return nil, nil, fmt.Errorf("%s changed while being opened", flagName)
-	}
-	if err := validateBuildArtifactInfo(fileInfo, flagName); err != nil {
-		_ = file.Close()
-		return nil, nil, err
-	}
-	return file, fileInfo, nil
-}
-
-func validateBuildArtifactInfo(fileInfo os.FileInfo, flagName string) error {
-	if fileInfo.IsDir() {
-		return fmt.Errorf("%s must be a file", flagName)
-	}
-	if !fileInfo.Mode().IsRegular() {
-		return fmt.Errorf("%s must be a regular file", flagName)
-	}
-	if fileInfo.Size() == 0 {
-		return fmt.Errorf("%s must not be empty", flagName)
-	}
-	return nil
-}
-
-func buildArtifactSymlinkError(filePath, flagName string) error {
-	return fmt.Errorf("refusing to read symlink %q from %s", filePath, flagName)
+	return secureopen.OpenExistingRegularFileNoFollow(pkgPath, "PKG", "--pkg")
 }
 
 // ExtractBundleInfoFromIPA reads the top-level app's bundle identifier and

--- a/internal/secureopen/regular_file.go
+++ b/internal/secureopen/regular_file.go
@@ -1,0 +1,64 @@
+package secureopen
+
+import (
+	"fmt"
+	"os"
+)
+
+// OpenExistingRegularFileNoFollow opens an existing non-empty regular file
+// without following a symlink in its final path component. The returned file
+// handle pins the inode checked during validation; callers own the handle.
+//
+// artifactName is used in errors that describe stat/open failures, while
+// flagName is used for command-facing validation errors.
+func OpenExistingRegularFileNoFollow(path, artifactName, flagName string) (*os.File, os.FileInfo, error) {
+	pathInfo, err := os.Lstat(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to stat %s: %w", artifactName, err)
+	}
+	if pathInfo.Mode()&os.ModeSymlink != 0 {
+		return nil, nil, regularFileSymlinkError(path, flagName)
+	}
+	if err := validateNonEmptyRegularFile(pathInfo, flagName); err != nil {
+		return nil, nil, err
+	}
+
+	file, err := OpenExistingNoFollow(path)
+	if err != nil {
+		if latestInfo, statErr := os.Lstat(path); statErr == nil && latestInfo.Mode()&os.ModeSymlink != 0 {
+			return nil, nil, regularFileSymlinkError(path, flagName)
+		}
+		return nil, nil, fmt.Errorf("failed to open %s: %w", artifactName, err)
+	}
+	fileInfo, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, nil, fmt.Errorf("failed to stat opened %s: %w", artifactName, err)
+	}
+	if !os.SameFile(pathInfo, fileInfo) {
+		_ = file.Close()
+		return nil, nil, fmt.Errorf("%s changed while being opened", flagName)
+	}
+	if err := validateNonEmptyRegularFile(fileInfo, flagName); err != nil {
+		_ = file.Close()
+		return nil, nil, err
+	}
+	return file, fileInfo, nil
+}
+
+func validateNonEmptyRegularFile(fileInfo os.FileInfo, flagName string) error {
+	if fileInfo.IsDir() {
+		return fmt.Errorf("%s must be a file", flagName)
+	}
+	if !fileInfo.Mode().IsRegular() {
+		return fmt.Errorf("%s must be a regular file", flagName)
+	}
+	if fileInfo.Size() == 0 {
+		return fmt.Errorf("%s must not be empty", flagName)
+	}
+	return nil
+}
+
+func regularFileSymlinkError(path, flagName string) error {
+	return fmt.Errorf("refusing to read symlink %q from %s", path, flagName)
+}

--- a/internal/secureopen/regular_file_test.go
+++ b/internal/secureopen/regular_file_test.go
@@ -1,0 +1,94 @@
+package secureopen
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestOpenExistingRegularFileNoFollow(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "artifact")
+	const contents = "artifact"
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	file, info, err := OpenExistingRegularFileNoFollow(path, "artifact", "--artifact")
+	if err != nil {
+		t.Fatalf("OpenExistingRegularFileNoFollow() error: %v", err)
+	}
+	defer file.Close()
+	if info.Size() != int64(len(contents)) {
+		t.Fatalf("returned size = %d, want %d", info.Size(), len(contents))
+	}
+	data, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatalf("ReadAll() error: %v", err)
+	}
+	if string(data) != contents {
+		t.Fatalf("returned file contents = %q, want %q", data, contents)
+	}
+}
+
+func TestOpenExistingRegularFileNoFollowRejectsUnsafePaths(t *testing.T) {
+	tests := []struct {
+		name    string
+		prepare func(t *testing.T, path string)
+		wantErr string
+	}{
+		{
+			name: "empty",
+			prepare: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.WriteFile(path, nil, 0o600); err != nil {
+					t.Fatalf("WriteFile() error: %v", err)
+				}
+			},
+			wantErr: "--artifact must not be empty",
+		},
+		{
+			name: "directory",
+			prepare: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.Mkdir(path, 0o755); err != nil {
+					t.Fatalf("Mkdir() error: %v", err)
+				}
+			},
+			wantErr: "--artifact must be a file",
+		},
+		{
+			name: "symlink",
+			prepare: func(t *testing.T, path string) {
+				t.Helper()
+				target := filepath.Join(filepath.Dir(path), "target")
+				if err := os.WriteFile(target, []byte("target"), 0o600); err != nil {
+					t.Fatalf("WriteFile() error: %v", err)
+				}
+				if err := os.Symlink(target, path); err != nil {
+					t.Skipf("Symlink() unavailable: %v", err)
+				}
+			},
+			wantErr: "refusing to read symlink",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "artifact")
+			tt.prepare(t, path)
+
+			file, _, err := OpenExistingRegularFileNoFollow(path, "artifact", "--artifact")
+			if file != nil {
+				file.Close()
+			}
+			if err == nil {
+				t.Fatal("expected unsafe path error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/secureopen/regular_file_unix_test.go
+++ b/internal/secureopen/regular_file_unix_test.go
@@ -1,0 +1,85 @@
+//go:build darwin || linux || freebsd || netbsd || openbsd || dragonfly
+
+package secureopen
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestOpenExistingRegularFileNoFollowRejectsUnixSpecialFiles(t *testing.T) {
+	tests := []struct {
+		name    string
+		prepare func(t *testing.T, path string)
+	}{
+		{
+			name: "FIFO",
+			prepare: func(t *testing.T, path string) {
+				t.Helper()
+				if err := unix.Mkfifo(path, 0o600); err != nil {
+					t.Fatalf("Mkfifo() error: %v", err)
+				}
+			},
+		},
+		{
+			name: "Unix socket",
+			prepare: func(t *testing.T, path string) {
+				t.Helper()
+				listener, err := net.Listen("unix", path)
+				if err != nil {
+					t.Fatalf("Listen() error: %v", err)
+				}
+				t.Cleanup(func() { _ = listener.Close() })
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixtureDir, err := os.MkdirTemp("", "ascsf")
+			if err != nil {
+				t.Fatalf("MkdirTemp() error: %v", err)
+			}
+			t.Cleanup(func() { _ = os.RemoveAll(fixtureDir) })
+			path := filepath.Join(fixtureDir, "artifact")
+			tt.prepare(t, path)
+
+			file, _, err := OpenExistingRegularFileNoFollow(path, "artifact", "--artifact")
+			if file != nil {
+				file.Close()
+			}
+			if err == nil {
+				t.Fatal("expected special-file error, got nil")
+			}
+			if !strings.Contains(err.Error(), "--artifact must be a regular file") {
+				t.Fatalf("error = %v, want regular-file rejection", err)
+			}
+		})
+	}
+}
+
+func TestOpenExistingRegularFileNoFollowRejectsDevice(t *testing.T) {
+	info, err := os.Lstat("/dev/null")
+	if err != nil {
+		t.Skipf("/dev/null unavailable: %v", err)
+	}
+	if info.Mode().IsRegular() {
+		t.Skip("/dev/null is unexpectedly a regular file")
+	}
+
+	file, _, err := OpenExistingRegularFileNoFollow("/dev/null", "device", "--artifact")
+	if file != nil {
+		file.Close()
+	}
+	if err == nil {
+		t.Fatal("expected device rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "--artifact must be a regular file") {
+		t.Fatalf("error = %v, want regular-file rejection", err)
+	}
+}

--- a/internal/xcode/validation_snapshot.go
+++ b/internal/xcode/validation_snapshot.go
@@ -1,0 +1,166 @@
+package xcode
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/secureopen"
+)
+
+// snapshotValidationArtifact copies a safely opened artifact into a private,
+// correctly suffixed path for altool. Apple's validation stack identifies the
+// archive from its pathname and may open it from a child process, so an
+// inherited descriptor path such as /dev/fd/3 is not sufficient.
+func snapshotValidationArtifact(ctx context.Context, source *os.File, size int64, suffix string) (string, func(), error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return "", nil, err
+	}
+	if source == nil {
+		return "", nil, fmt.Errorf("validation source is nil")
+	}
+	if size <= 0 {
+		return "", nil, fmt.Errorf("validation source size must be positive")
+	}
+	if suffix != ".ipa" && suffix != ".pkg" {
+		return "", nil, fmt.Errorf("unsupported validation artifact suffix %q", suffix)
+	}
+
+	sourceInfo, err := source.Stat()
+	if err != nil {
+		return "", nil, fmt.Errorf("inspect validation source: %w", err)
+	}
+	if !sourceInfo.Mode().IsRegular() || sourceInfo.Size() != size {
+		return "", nil, fmt.Errorf("validation source changed before snapshot")
+	}
+
+	directory, err := os.MkdirTemp("", ".asc-xcode-validate-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("create validation snapshot directory: %w", err)
+	}
+	removeDirectory := func() { _ = os.Remove(directory) }
+
+	trustedDirectory, err := rootfs.New(directory)
+	if err != nil {
+		removeDirectory()
+		return "", nil, fmt.Errorf("anchor validation snapshot directory: %w", err)
+	}
+	openedDirectory, err := trustedDirectory.OpenRoot()
+	if err != nil {
+		_ = trustedDirectory.Close()
+		removeDirectory()
+		return "", nil, fmt.Errorf("open validation snapshot directory: %w", err)
+	}
+
+	snapshot, snapshotName, err := secureopen.CreateTempNoFollowInRootWithCreator(
+		openedDirectory,
+		".",
+		".artifact-*"+suffix,
+		0o600,
+		secureopen.OpenNewPrivateFileNoFollowInRoot,
+	)
+	if err != nil {
+		_ = openedDirectory.Close()
+		_ = trustedDirectory.Close()
+		removeDirectory()
+		return "", nil, fmt.Errorf("create validation snapshot: %w", err)
+	}
+	cleanup := func() {
+		_ = snapshot.Close()
+		_ = openedDirectory.Remove(snapshotName)
+		_ = openedDirectory.Close()
+		_ = trustedDirectory.Close()
+		removeDirectory()
+	}
+
+	if err := secureopen.PreparePrivateFile(snapshot, 0o600); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("secure validation snapshot: %w", err)
+	}
+
+	written, err := copyValidationSnapshotWithContext(ctx, snapshot, io.NewSectionReader(source, 0, size))
+	if err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("copy validation snapshot: %w", err)
+	}
+	if written != size {
+		cleanup()
+		return "", nil, fmt.Errorf("copy validation snapshot: copied %d of %d bytes", written, size)
+	}
+
+	afterSourceInfo, err := source.Stat()
+	if err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("reinspect validation source: %w", err)
+	}
+	if !afterSourceInfo.Mode().IsRegular() || afterSourceInfo.Size() != size {
+		cleanup()
+		return "", nil, fmt.Errorf("validation source changed during snapshot")
+	}
+	if err := snapshot.Sync(); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("sync validation snapshot: %w", err)
+	}
+	snapshotInfo, err := snapshot.Stat()
+	if err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("inspect validation snapshot: %w", err)
+	}
+	if !snapshotInfo.Mode().IsRegular() || snapshotInfo.Size() != size {
+		cleanup()
+		return "", nil, fmt.Errorf("validation snapshot size is invalid")
+	}
+	if err := snapshot.Close(); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("close validation snapshot: %w", err)
+	}
+
+	snapshotPath := filepath.Join(directory, snapshotName)
+	namedInfo, err := os.Lstat(snapshotPath)
+	if err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("inspect named validation snapshot: %w", err)
+	}
+	if namedInfo.Mode()&os.ModeSymlink != 0 || !os.SameFile(snapshotInfo, namedInfo) || !namedInfo.Mode().IsRegular() || namedInfo.Size() != size {
+		cleanup()
+		return "", nil, fmt.Errorf("validation snapshot changed before use")
+	}
+
+	return snapshotPath, cleanup, nil
+}
+
+func copyValidationSnapshotWithContext(ctx context.Context, destination io.Writer, source io.Reader) (int64, error) {
+	buffer := make([]byte, 64<<10)
+	var written int64
+	for {
+		if err := ctx.Err(); err != nil {
+			return written, err
+		}
+		read, readErr := source.Read(buffer)
+		if read > 0 {
+			if err := ctx.Err(); err != nil {
+				return written, err
+			}
+			count, writeErr := destination.Write(buffer[:read])
+			written += int64(count)
+			if writeErr != nil {
+				return written, writeErr
+			}
+			if count != read {
+				return written, io.ErrShortWrite
+			}
+		}
+		if readErr != nil {
+			if readErr == io.EOF {
+				return written, nil
+			}
+			return written, readErr
+		}
+	}
+}

--- a/internal/xcode/validation_snapshot.go
+++ b/internal/xcode/validation_snapshot.go
@@ -1,7 +1,9 @@
 package xcode
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"os"
@@ -10,6 +12,8 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/secureopen"
 )
+
+var afterValidationSnapshotCopyForTest func()
 
 // snapshotValidationArtifact copies a safely opened artifact into a private,
 // correctly suffixed path for altool. Apple's validation stack identifies the
@@ -84,7 +88,8 @@ func snapshotValidationArtifact(ctx context.Context, source *os.File, size int64
 		return "", nil, fmt.Errorf("secure validation snapshot: %w", err)
 	}
 
-	written, err := copyValidationSnapshotWithContext(ctx, snapshot, io.NewSectionReader(source, 0, size))
+	copiedHash := sha256.New()
+	written, err := copyValidationSnapshotWithContext(ctx, io.MultiWriter(snapshot, copiedHash), io.NewSectionReader(source, 0, size))
 	if err != nil {
 		cleanup()
 		return "", nil, fmt.Errorf("copy validation snapshot: %w", err)
@@ -92,6 +97,19 @@ func snapshotValidationArtifact(ctx context.Context, source *os.File, size int64
 	if written != size {
 		cleanup()
 		return "", nil, fmt.Errorf("copy validation snapshot: copied %d of %d bytes", written, size)
+	}
+	if afterValidationSnapshotCopyForTest != nil {
+		afterValidationSnapshotCopyForTest()
+	}
+	verifiedHash := sha256.New()
+	verified, err := copyValidationSnapshotWithContext(ctx, verifiedHash, io.NewSectionReader(source, 0, size))
+	if err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("verify validation source after snapshot: %w", err)
+	}
+	if verified != size || !bytes.Equal(copiedHash.Sum(nil), verifiedHash.Sum(nil)) {
+		cleanup()
+		return "", nil, fmt.Errorf("validation source changed during snapshot")
 	}
 
 	afterSourceInfo, err := source.Stat()

--- a/internal/xcode/validation_snapshot_test.go
+++ b/internal/xcode/validation_snapshot_test.go
@@ -1,0 +1,48 @@
+package xcode
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSnapshotValidationArtifactRejectsSameSizeSourceMutation(t *testing.T) {
+	directory := t.TempDir()
+	sourcePath := filepath.Join(directory, "Demo.ipa")
+	original := bytes.Repeat([]byte{'A'}, 128<<10)
+	replacement := bytes.Repeat([]byte{'B'}, len(original))
+	if err := os.WriteFile(sourcePath, original, 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		t.Fatalf("open source: %v", err)
+	}
+	defer source.Close()
+	info, err := source.Stat()
+	if err != nil {
+		t.Fatalf("stat source: %v", err)
+	}
+
+	previousHook := afterValidationSnapshotCopyForTest
+	afterValidationSnapshotCopyForTest = func() {
+		if err := os.WriteFile(sourcePath, replacement, 0o600); err != nil {
+			t.Fatalf("rewrite source: %v", err)
+		}
+	}
+	t.Cleanup(func() { afterValidationSnapshotCopyForTest = previousHook })
+
+	snapshotPath, cleanup, err := snapshotValidationArtifact(context.Background(), source, info.Size(), ".ipa")
+	if cleanup != nil {
+		cleanup()
+	}
+	if err == nil {
+		t.Fatalf("snapshotValidationArtifact() path = %q, want mutation error", snapshotPath)
+	}
+	if !strings.Contains(err.Error(), "validation source changed during snapshot") {
+		t.Fatalf("snapshotValidationArtifact() error = %v, want source mutation error", err)
+	}
+}

--- a/internal/xcode/xcode.go
+++ b/internal/xcode/xcode.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/infoplist"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/secureopen"
 )
 
 var (
@@ -425,23 +426,35 @@ func Validate(ctx context.Context, opts ValidateOptions) (*ValidateResult, error
 	}
 	artifactPath := opts.IPAPath
 	artifactFlag := "--ipa"
+	artifactName := "IPA"
 	platform := ""
 	if opts.PKGPath != "" {
 		artifactPath = opts.PKGPath
 		artifactFlag = "--pkg"
+		artifactName = "PKG"
 		platform = "macos"
 	}
-	if err := validateExistingFile(artifactPath, artifactFlag); err != nil {
+	validatedArtifact, _, err := secureopen.OpenExistingRegularFileNoFollow(artifactPath, artifactName, artifactFlag)
+	if err != nil {
 		return nil, err
 	}
+	defer validatedArtifact.Close()
+	validatedInfo, err := validatedArtifact.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("inspect validated %s: %w", artifactName, err)
+	}
 	if platform == "" {
-		var err error
-		platform, err = inferValidatePlatform(opts.IPAPath)
+		platform, err = inferValidatePlatformFromFile(validatedArtifact, validatedInfo.Size())
 		if err != nil {
 			return nil, err
 		}
 	}
-	if err := runAltoolValidate(ctx, buildValidateCommand(opts, platform), opts.LogWriter); err != nil {
+	snapshotPath, cleanupSnapshot, err := snapshotValidationArtifact(ctx, validatedArtifact, validatedInfo.Size(), strings.ToLower(filepath.Ext(artifactPath)))
+	if err != nil {
+		return nil, fmt.Errorf("prepare %s for validation: %w", artifactName, err)
+	}
+	defer cleanupSnapshot()
+	if err := runAltoolValidate(ctx, buildValidateCommand(opts, platform, snapshotPath), opts.LogWriter); err != nil {
 		return nil, err
 	}
 	return &ValidateResult{
@@ -846,8 +859,8 @@ func buildExportCommand(opts ExportOptions, exportDir string) []string {
 	return args
 }
 
-func inferValidatePlatform(ipaPath string) (string, error) {
-	info, err := readIPABundleInfo(ipaPath)
+func inferValidatePlatformFromFile(ipa *os.File, size int64) (string, error) {
+	info, err := readIPABundleInfoFromReaderAt(ipa, size)
 	if err != nil {
 		return "", fmt.Errorf("inspect IPA metadata before validation: %w", err)
 	}
@@ -857,13 +870,9 @@ func inferValidatePlatform(ipaPath string) (string, error) {
 	return "ios", nil
 }
 
-func buildValidateCommand(opts ValidateOptions, platform string) []string {
+func buildValidateCommand(opts ValidateOptions, platform, artifactPath string) []string {
 	if strings.TrimSpace(platform) == "" {
 		platform = "ios"
-	}
-	artifactPath := opts.IPAPath
-	if opts.PKGPath != "" {
-		artifactPath = opts.PKGPath
 	}
 	args := []string{
 		"altool",

--- a/internal/xcode/xcode.go
+++ b/internal/xcode/xcode.go
@@ -443,17 +443,22 @@ func Validate(ctx context.Context, opts ValidateOptions) (*ValidateResult, error
 	if err != nil {
 		return nil, fmt.Errorf("inspect validated %s: %w", artifactName, err)
 	}
-	if platform == "" {
-		platform, err = inferValidatePlatformFromFile(validatedArtifact, validatedInfo.Size())
-		if err != nil {
-			return nil, err
-		}
-	}
 	snapshotPath, cleanupSnapshot, err := snapshotValidationArtifact(ctx, validatedArtifact, validatedInfo.Size(), strings.ToLower(filepath.Ext(artifactPath)))
 	if err != nil {
 		return nil, fmt.Errorf("prepare %s for validation: %w", artifactName, err)
 	}
 	defer cleanupSnapshot()
+	snapshotArtifact, snapshotInfo, err := secureopen.OpenExistingRegularFileNoFollow(snapshotPath, artifactName+" validation snapshot", artifactFlag)
+	if err != nil {
+		return nil, fmt.Errorf("open %s validation snapshot: %w", artifactName, err)
+	}
+	defer snapshotArtifact.Close()
+	if platform == "" {
+		platform, err = inferValidatePlatformFromFile(snapshotArtifact, snapshotInfo.Size())
+		if err != nil {
+			return nil, err
+		}
+	}
 	if err := runAltoolValidate(ctx, buildValidateCommand(opts, platform, snapshotPath), opts.LogWriter); err != nil {
 		return nil, err
 	}

--- a/internal/xcode/xcode_artifact_validation_unix_test.go
+++ b/internal/xcode/xcode_artifact_validation_unix_test.go
@@ -1,0 +1,85 @@
+//go:build darwin || linux || freebsd || netbsd || openbsd || dragonfly
+
+package xcode
+
+import (
+	"context"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestValidateRejectsNonRegularArtifactsBeforeAltool(t *testing.T) {
+	tests := []struct {
+		name    string
+		create  func(t *testing.T, path string)
+		wantErr string
+	}{
+		{
+			name: "FIFO",
+			create: func(t *testing.T, path string) {
+				t.Helper()
+				if err := unix.Mkfifo(path, 0o600); err != nil {
+					t.Fatalf("Mkfifo() error: %v", err)
+				}
+			},
+			wantErr: "--pkg must be a regular file",
+		},
+		{
+			name: "Unix socket",
+			create: func(t *testing.T, path string) {
+				t.Helper()
+				listener, err := net.Listen("unix", path)
+				if err != nil {
+					t.Fatalf("Listen() error: %v", err)
+				}
+				t.Cleanup(func() { _ = listener.Close() })
+			},
+			wantErr: "--pkg must be a regular file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir, err := os.MkdirTemp("", "ascx")
+			if err != nil {
+				t.Fatalf("MkdirTemp() error: %v", err)
+			}
+			t.Cleanup(func() { _ = os.RemoveAll(tempDir) })
+			pkgPath := filepath.Join(tempDir, "Demo.pkg")
+			tt.create(t, pkgPath)
+			logPath := filepath.Join(tempDir, "commands.log")
+
+			restore := overrideTestEnvironment(t)
+			runtimeGOOS = "darwin"
+			lookPathFn = func(file string) (string, error) {
+				switch file {
+				case "xcodebuild", "xcrun":
+					return "/usr/bin/" + file, nil
+				default:
+					return "", exec.ErrNotFound
+				}
+			}
+			commandContextFn = helperCommandContext(t, logPath)
+			t.Cleanup(restore)
+
+			_, err = Validate(context.Background(), ValidateOptions{PKGPath: pkgPath})
+			if err == nil {
+				t.Fatal("expected non-regular artifact error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("Validate() error = %v, want substring %q", err, tt.wantErr)
+			}
+
+			logData, readErr := os.ReadFile(logPath)
+			if readErr == nil && strings.Contains(string(logData), "|--validate-app|") {
+				t.Fatalf("altool validation ran for non-regular artifact: %q", string(logData))
+			}
+		})
+	}
+}

--- a/internal/xcode/xcode_test.go
+++ b/internal/xcode/xcode_test.go
@@ -433,8 +433,20 @@ func TestValidateRunsAltoolWithAuthFlags(t *testing.T) {
 	if lines[0] != "xcodebuild|-version" {
 		t.Fatalf("expected version probe, got %q", lines[0])
 	}
-	if !strings.Contains(lines[1], "xcrun|altool|--validate-app|--file|"+ipaPath+"|--type|ios|--apiKey|KEY123ABC|--apiIssuer|issuer-123") {
+	if !strings.Contains(lines[1], "xcrun|altool|--validate-app|--file|") ||
+		!strings.Contains(lines[1], ".ipa|--type|ios|--apiKey|KEY123ABC|--apiIssuer|issuer-123") {
 		t.Fatalf("expected validate invocation with auth flags, got %q", lines[1])
+	}
+	commandArgs := strings.Split(lines[1], "|")
+	snapshotPath, err := valueAfter(commandArgs, "--file")
+	if err != nil {
+		t.Fatalf("validation command: %v", err)
+	}
+	if snapshotPath == ipaPath || filepath.Ext(snapshotPath) != ".ipa" {
+		t.Fatalf("validation path = %q, want a private .ipa snapshot", snapshotPath)
+	}
+	if _, err := os.Stat(snapshotPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("validation snapshot was not cleaned up: %v", err)
 	}
 }
 
@@ -482,7 +494,8 @@ func TestValidateRunsAltoolWithTVOSPlatform(t *testing.T) {
 	if len(lines) != 2 {
 		t.Fatalf("expected 2 logged commands, got %d: %q", len(lines), string(logData))
 	}
-	if !strings.Contains(lines[1], "xcrun|altool|--validate-app|--file|"+ipaPath+"|--type|appletvos") {
+	if !strings.Contains(lines[1], "xcrun|altool|--validate-app|--file|") ||
+		!strings.Contains(lines[1], ".ipa|--type|appletvos") {
 		t.Fatalf("expected validate invocation with tvOS platform, got %q", lines[1])
 	}
 }
@@ -526,8 +539,197 @@ func TestValidateRunsAltoolWithPKGAndMacOSPlatform(t *testing.T) {
 	if len(lines) != 2 {
 		t.Fatalf("expected 2 logged commands, got %d: %q", len(lines), string(logData))
 	}
-	if !strings.Contains(lines[1], "xcrun|altool|--validate-app|--file|"+pkgPath+"|--type|macos") {
+	if !strings.Contains(lines[1], "xcrun|altool|--validate-app|--file|") ||
+		!strings.Contains(lines[1], ".pkg|--type|macos") {
 		t.Fatalf("expected PKG validation with macOS type, got %q", lines[1])
+	}
+}
+
+func TestValidatePinsArtifactAcrossPathReplacement(t *testing.T) {
+	tempDir := t.TempDir()
+	ipaPath := filepath.Join(tempDir, "Demo.ipa")
+	if err := writeTestIPA(ipaPath); err != nil {
+		t.Fatalf("writeTestIPA() error: %v", err)
+	}
+	original, err := os.ReadFile(ipaPath)
+	if err != nil {
+		t.Fatalf("read original IPA: %v", err)
+	}
+	capturedPath := filepath.Join(tempDir, "captured.ipa")
+	logPath := filepath.Join(tempDir, "commands.log")
+
+	restore := overrideTestEnvironment(t)
+	runtimeGOOS = "darwin"
+	lookPathFn = func(file string) (string, error) {
+		switch file {
+		case "xcodebuild", "xcrun":
+			return "/usr/bin/" + file, nil
+		default:
+			return "", exec.ErrNotFound
+		}
+	}
+	baseCommandContext := helperCommandContext(t, logPath)
+	replaced := false
+	commandContextFn = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		cmd := baseCommandContext(ctx, name, args...)
+		if name == "xcrun" && len(args) > 0 && args[0] == "altool" {
+			preservedPath := filepath.Join(tempDir, "original.ipa")
+			if err := os.Rename(ipaPath, preservedPath); err != nil {
+				t.Fatalf("preserve original IPA: %v", err)
+			}
+			if err := os.WriteFile(ipaPath, []byte("replacement"), 0o600); err != nil {
+				t.Fatalf("write replacement IPA: %v", err)
+			}
+			cmd.Env = append(cmd.Env, "ASC_XCODE_HELPER_VALIDATE_CAPTURE_FILE="+capturedPath)
+			replaced = true
+		}
+		return cmd
+	}
+	t.Cleanup(restore)
+
+	result, err := Validate(context.Background(), ValidateOptions{IPAPath: ipaPath})
+	if err != nil {
+		t.Fatalf("Validate() error: %v", err)
+	}
+	if !result.Validated || !replaced {
+		t.Fatalf("unexpected validation state: result=%+v replaced=%t", result, replaced)
+	}
+	captured, err := os.ReadFile(capturedPath)
+	if err != nil {
+		t.Fatalf("read captured validation input: %v", err)
+	}
+	if !bytes.Equal(captured, original) {
+		t.Fatal("altool did not receive the originally validated IPA bytes")
+	}
+	replacement, err := os.ReadFile(ipaPath)
+	if err != nil {
+		t.Fatalf("read replacement IPA: %v", err)
+	}
+	if string(replacement) != "replacement" {
+		t.Fatalf("replacement IPA was modified: %q", replacement)
+	}
+}
+
+func TestValidateRejectsUnsafeArtifactsBeforeAltool(t *testing.T) {
+	tests := []struct {
+		name      string
+		extension string
+		prepare   func(t *testing.T, path string)
+		wantErr   string
+	}{
+		{
+			name:      "empty IPA",
+			extension: ".ipa",
+			prepare: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.WriteFile(path, nil, 0o600); err != nil {
+					t.Fatalf("write empty IPA: %v", err)
+				}
+			},
+			wantErr: "--ipa must not be empty",
+		},
+		{
+			name:      "IPA directory",
+			extension: ".ipa",
+			prepare: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.Mkdir(path, 0o755); err != nil {
+					t.Fatalf("create IPA directory: %v", err)
+				}
+			},
+			wantErr: "--ipa must be a file",
+		},
+		{
+			name:      "IPA symlink",
+			extension: ".ipa",
+			prepare: func(t *testing.T, path string) {
+				t.Helper()
+				target := filepath.Join(filepath.Dir(path), "Target.ipa")
+				if err := writeTestIPA(target); err != nil {
+					t.Fatalf("write IPA target: %v", err)
+				}
+				if err := os.Symlink(target, path); err != nil {
+					t.Skipf("symlink not supported: %v", err)
+				}
+			},
+			wantErr: "refusing to read symlink",
+		},
+		{
+			name:      "empty PKG",
+			extension: ".pkg",
+			prepare: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.WriteFile(path, nil, 0o600); err != nil {
+					t.Fatalf("write empty PKG: %v", err)
+				}
+			},
+			wantErr: "--pkg must not be empty",
+		},
+		{
+			name:      "PKG directory",
+			extension: ".pkg",
+			prepare: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.Mkdir(path, 0o755); err != nil {
+					t.Fatalf("create PKG directory: %v", err)
+				}
+			},
+			wantErr: "--pkg must be a file",
+		},
+		{
+			name:      "PKG symlink",
+			extension: ".pkg",
+			prepare: func(t *testing.T, path string) {
+				t.Helper()
+				target := filepath.Join(filepath.Dir(path), "Target.pkg")
+				if err := os.WriteFile(target, []byte("pkg"), 0o600); err != nil {
+					t.Fatalf("write PKG target: %v", err)
+				}
+				if err := os.Symlink(target, path); err != nil {
+					t.Skipf("symlink not supported: %v", err)
+				}
+			},
+			wantErr: "refusing to read symlink",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			artifactPath := filepath.Join(tempDir, "Demo"+tt.extension)
+			tt.prepare(t, artifactPath)
+			logPath := filepath.Join(tempDir, "commands.log")
+
+			restore := overrideTestEnvironment(t)
+			runtimeGOOS = "darwin"
+			lookPathFn = func(file string) (string, error) {
+				switch file {
+				case "xcodebuild", "xcrun":
+					return "/usr/bin/" + file, nil
+				default:
+					return "", exec.ErrNotFound
+				}
+			}
+			commandContextFn = helperCommandContext(t, logPath)
+			t.Cleanup(restore)
+
+			opts := ValidateOptions{IPAPath: artifactPath}
+			if tt.extension == ".pkg" {
+				opts = ValidateOptions{PKGPath: artifactPath}
+			}
+			_, err := Validate(context.Background(), opts)
+			if err == nil {
+				t.Fatal("expected unsafe artifact error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("Validate() error = %v, want substring %q", err, tt.wantErr)
+			}
+
+			logData, readErr := os.ReadFile(logPath)
+			if readErr == nil && strings.Contains(string(logData), "|--validate-app|") {
+				t.Fatalf("altool validation ran for unsafe artifact: %q", string(logData))
+			}
+		})
 	}
 }
 
@@ -2235,9 +2437,21 @@ func TestXcodeHelperProcess(t *testing.T) {
 			fmt.Fprintln(os.Stderr, "missing --validate-app")
 			os.Exit(2)
 		}
-		if _, err := valueAfter(commandArgs[2:], "--file"); err != nil {
+		artifactPath, err := valueAfter(commandArgs[2:], "--file")
+		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(2)
+		}
+		if capturePath := os.Getenv("ASC_XCODE_HELPER_VALIDATE_CAPTURE_FILE"); capturePath != "" {
+			contents, err := os.ReadFile(artifactPath)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(2)
+			}
+			if err := os.WriteFile(capturePath, contents, 0o600); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(2)
+			}
 		}
 		if output := os.Getenv("ASC_XCODE_HELPER_VALIDATE_STDOUT"); output != "" {
 			fmt.Fprint(os.Stdout, output)


### PR DESCRIPTION
## Summary
- reject symlinks, empty files, directories, and special files before Xcode validation
- validate a private immutable IPA or PKG snapshot and infer IPA platform from those exact bytes
- detect same-size source mutations while creating the validation snapshot

## Tests
- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- full-branch Codex review against current `origin/main` (no actionable findings)