### PR TITLE
fix(validate): verify explicit version ownership

### DIFF
--- a/commands/validate.mdx
+++ b/commands/validate.mdx
@@ -148,7 +148,8 @@ table or Markdown output. The ordinary output shape doesn't change when
 
 <ParamField path="--platform" type="string">
   Platform used with `--version` when an app has the same version on more than
-  one platform
+  one platform. When used with `--version-id`, the selected version must match
+  this platform.
 </ParamField>
 
 <ParamField path="--output" type="string">

--- a/internal/cli/cmdtest/validate_test.go
+++ b/internal/cli/cmdtest/validate_test.go
@@ -340,6 +340,66 @@ func validValidateFixture() validateFixture {
 	}
 }
 
+func TestValidateRejectsExplicitVersionBindingMismatch(t *testing.T) {
+	tests := []struct {
+		name      string
+		mutate    func(*validateFixture)
+		args      []string
+		wantError string
+	}{
+		{
+			name: "version belongs to another app",
+			mutate: func(fixture *validateFixture) {
+				fixture.version = strings.Replace(fixture.version, `"id":"app-1"`, `"id":"app-2"`, 1)
+			},
+			args:      []string{"validate", "--app", "app-1", "--version-id", "ver-1"},
+			wantError: `version "ver-1" belongs to app "app-2", not "app-1"`,
+		},
+		{
+			name: "version platform does not match",
+			mutate: func(fixture *validateFixture) {
+				fixture.version = strings.Replace(fixture.version, `"platform":"IOS"`, `"platform":"MAC_OS"`, 1)
+			},
+			args:      []string{"validate", "--app", "app-1", "--version-id", "ver-1", "--platform", "IOS"},
+			wantError: `version "ver-1" is on platform "MAC_OS", not "IOS"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := validValidateFixture()
+			test.mutate(&fixture)
+			client := newValidateTestClient(t, fixture)
+			restore := validate.SetClientFactory(func() (*asc.Client, error) {
+				return client, nil
+			})
+			t.Cleanup(restore)
+
+			root := RootCommand("1.2.3")
+			var runErr error
+			stdout, stderr := captureOutput(t, func() {
+				if err := root.Parse(test.args); err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				runErr = root.Run(context.Background())
+			})
+
+			if runErr == nil || errors.Is(runErr, flag.ErrHelp) || !strings.Contains(runErr.Error(), test.wantError) {
+				t.Fatalf("Run() error = %v, want runtime error containing %q", runErr, test.wantError)
+			}
+			if got := rootcmd.ExitCodeFromError(runErr); got != rootcmd.ExitError {
+				t.Fatalf("exit code = %d, want %d", got, rootcmd.ExitError)
+			}
+			if stdout != "" {
+				t.Fatalf("expected no readiness report on binding failure, got stdout %q", stdout)
+			}
+			if stderr != "" {
+				t.Fatalf("expected direct command run to leave stderr empty, got %q", stderr)
+			}
+		})
+	}
+}
+
 func TestValidateRequiresAppAndVersionSelector(t *testing.T) {
 	t.Setenv("ASC_APP_ID", "")
 

--- a/internal/cli/validate/concurrency_test.go
+++ b/internal/cli/validate/concurrency_test.go
@@ -138,6 +138,7 @@ func TestBuildReadinessReport_OverlapsSixIndependentReadGroups(t *testing.T) {
 		case "/v1/appStoreVersions/ver-1":
 			fmt.Fprint(w, `{
 				"data":{"type":"appStoreVersions","id":"ver-1","attributes":{"platform":"IOS","versionString":"1.0"},"relationships":{
+					"app":{"data":{"type":"apps","id":"app-1"}},
 					"appStoreVersionLocalizations":{"data":[{"type":"appStoreVersionLocalizations","id":"ver-loc-1"}],"meta":{"paging":{"total":1,"limit":50}}},
 					"build":{"data":null},
 					"appStoreReviewDetail":{"data":null}
@@ -222,6 +223,9 @@ func TestBuildReadinessReport_CancelsSiblingCompoundReadOnHardError(t *testing.T
 			canceledOnce.Do(func() { close(appInfoCanceled) })
 			return nil, req.Context().Err()
 		case "/v1/appStoreVersions/ver-1":
+			if req.URL.Query().Get("include") == "app" {
+				return buildsJSONResponse(http.StatusOK, `{"data":{"type":"appStoreVersions","id":"ver-1","attributes":{"platform":"IOS","versionString":"1.0"},"relationships":{"app":{"data":{"type":"apps","id":"app-1"}}}}}`)
+			}
 			<-appInfoStarted
 			return buildsJSONResponse(http.StatusBadRequest, `{"errors":[{"status":"400","code":"INVALID_REQUEST","title":"Invalid Request"}]}`)
 		default:
@@ -265,6 +269,7 @@ func TestBuildReadinessReport_SharedGateCapsNestedSubscriptionRequests(t *testin
 		case "/v1/appStoreVersions/ver-1":
 			return buildsJSONResponse(http.StatusOK, `{
 				"data":{"type":"appStoreVersions","id":"ver-1","attributes":{"platform":"IOS","versionString":"1.0"},"relationships":{
+					"app":{"data":{"type":"apps","id":"app-1"}},
 					"appStoreVersionLocalizations":{"data":[],"meta":{"paging":{"total":0,"limit":50}}},
 					"build":{"data":null},
 					"appStoreReviewDetail":{"data":null}

--- a/internal/cli/validate/readiness.go
+++ b/internal/cli/validate/readiness.go
@@ -42,6 +42,19 @@ func BuildReadinessReport(ctx context.Context, opts ReadinessOptions) (validatio
 		if err != nil {
 			return validation.Report{}, err
 		}
+	} else {
+		_, err = doReadinessRequest(ctx, func(requestCtx context.Context) (asc.Resource[asc.AppStoreVersionAttributes], error) {
+			return shared.ResolveOwnedAppStoreVersionByID(
+				requestCtx,
+				client,
+				strings.TrimSpace(opts.AppID),
+				resolvedVersionID,
+				strings.TrimSpace(opts.Platform),
+			)
+		})
+		if err != nil {
+			return validation.Report{}, fmt.Errorf("failed to verify app store version %q: %w", resolvedVersionID, err)
+		}
 	}
 
 	var versionData versionReadinessData

--- a/internal/cli/validate/readiness_compound_test.go
+++ b/internal/cli/validate/readiness_compound_test.go
@@ -15,11 +15,15 @@ func TestBuildReadinessReport_UsesCompoundReadsWithoutFallbacks(t *testing.T) {
 	var mu sync.Mutex
 	requests := make(map[string]int)
 	queries := make(map[string]string)
+	var versionQueries []string
 
 	client := newBuildsTestClient(t, buildsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		mu.Lock()
 		requests[req.URL.Path]++
 		queries[req.URL.Path] = req.URL.Query().Encode()
+		if req.URL.Path == "/v1/appStoreVersions/ver-1" {
+			versionQueries = append(versionQueries, req.URL.Query().Encode())
+		}
 		mu.Unlock()
 
 		switch req.URL.Path {
@@ -124,6 +128,9 @@ func TestBuildReadinessReport_UsesCompoundReadsWithoutFallbacks(t *testing.T) {
 	if got := queries["/v1/appStoreVersions/ver-1"]; got != "include=appStoreVersionLocalizations%2Cbuild%2CappStoreReviewDetail&limit%5BappStoreVersionLocalizations%5D=50" {
 		t.Fatalf("unexpected version compound query: %q", got)
 	}
+	if len(versionQueries) != 2 || versionQueries[0] != "include=app" || versionQueries[1] != "include=appStoreVersionLocalizations%2Cbuild%2CappStoreReviewDetail&limit%5BappStoreVersionLocalizations%5D=50" {
+		t.Fatalf("unexpected version queries: %v", versionQueries)
+	}
 	if got := queries["/v1/apps/app-1/appInfos"]; got != "include=app%2CageRatingDeclaration%2CappInfoLocalizations%2CprimaryCategory&limit%5BappInfoLocalizations%5D=50" {
 		t.Fatalf("unexpected app-info compound query: %q", got)
 	}
@@ -131,8 +138,8 @@ func TestBuildReadinessReport_UsesCompoundReadsWithoutFallbacks(t *testing.T) {
 	for _, count := range requests {
 		totalRequests += count
 	}
-	if totalRequests != 4 {
-		t.Fatalf("compound readiness request count = %d, want 4 (version, app infos, price schedule, current price)", totalRequests)
+	if totalRequests != 5 {
+		t.Fatalf("compound readiness request count = %d, want 5 (version verification, version, app infos, price schedule, current price)", totalRequests)
 	}
 	if got := queries["/v1/appPriceSchedules/schedule-1/manualPrices"]; got != "fields%5BappPricePoints%5D=customerPrice&fields%5BappPrices%5D=manual%2CstartDate%2CendDate%2CappPricePoint&include=appPricePoint&limit=200" {
 		t.Fatalf("unexpected current pricing query: %q", got)

--- a/internal/cli/validate/readiness_version_binding_test.go
+++ b/internal/cli/validate/readiness_version_binding_test.go
@@ -1,0 +1,76 @@
+package validate
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
+)
+
+func TestBuildReadinessReport_VerifiesExplicitVersionBindingBeforeReadiness(t *testing.T) {
+	tests := []struct {
+		name      string
+		version   string
+		platform  string
+		wantError string
+	}{
+		{
+			name:      "version belongs to another app",
+			version:   `{"data":{"type":"appStoreVersions","id":"ver-1","attributes":{"platform":"IOS","versionString":"1.0"},"relationships":{"app":{"data":{"type":"apps","id":"app-2"}}}}}`,
+			wantError: `version "ver-1" belongs to app "app-2", not "app-1"`,
+		},
+		{
+			name:      "version platform does not match",
+			version:   `{"data":{"type":"appStoreVersions","id":"ver-1","attributes":{"platform":"MAC_OS","versionString":"1.0"},"relationships":{"app":{"data":{"type":"apps","id":"app-1"}}}}}`,
+			platform:  "IOS",
+			wantError: `version "ver-1" is on platform "MAC_OS", not "IOS"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var mu sync.Mutex
+			var unexpectedRequests []string
+			var versionQueries []string
+			client := newBuildsTestClient(t, buildsRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				if req.URL.Path == "/v1/appStoreVersions/ver-1" {
+					query := req.URL.Query().Encode()
+					mu.Lock()
+					versionQueries = append(versionQueries, query)
+					mu.Unlock()
+					if query == "include=app" {
+						return buildsJSONResponse(http.StatusOK, test.version)
+					}
+				}
+
+				mu.Lock()
+				unexpectedRequests = append(unexpectedRequests, req.URL.RequestURI())
+				mu.Unlock()
+				return buildsJSONResponse(http.StatusInternalServerError, `{"errors":[{"status":"500","code":"UNEXPECTED_READINESS_REQUEST"}]}`)
+			}))
+			restoreClient := SetClientFactory(func() (*asc.Client, error) { return client, nil })
+			t.Cleanup(restoreClient)
+
+			_, err := BuildReadinessReport(context.Background(), ReadinessOptions{
+				AppID:     "app-1",
+				VersionID: "ver-1",
+				Platform:  test.platform,
+			})
+			if err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("BuildReadinessReport() error = %v, want %q", err, test.wantError)
+			}
+
+			mu.Lock()
+			defer mu.Unlock()
+			if len(unexpectedRequests) != 0 {
+				t.Fatalf("readiness requests started before version binding: %v", unexpectedRequests)
+			}
+			if len(versionQueries) != 1 || versionQueries[0] != "include=app" {
+				t.Fatalf("version verification queries = %v, want [include=app]", versionQueries)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- verify an explicit App Store version belongs to the requested app before readiness checks
- enforce the requested platform when `--version-id` is used
- stop before downstream readiness reads on ownership or platform mismatch

## Tests
- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- command-level local backend harness for app and platform mismatch paths
- full-branch Codex review against current `origin/main` (no actionable findings)