### PR TITLE
fix(notarization): validate Notary API inputs

### DIFF
--- a/internal/asc/notary.go
+++ b/internal/asc/notary.go
@@ -231,9 +231,13 @@ func (c *Client) SubmitNotarization(ctx context.Context, sha256Hash, submissionN
 	if submissionName == "" {
 		return nil, fmt.Errorf("submission name is required")
 	}
+	normalizedHash, err := validateNotarySHA256(sha256Hash)
+	if err != nil {
+		return nil, err
+	}
 
 	payload := NotarySubmissionRequest{
-		Sha256:         sha256Hash,
+		Sha256:         normalizedHash,
 		SubmissionName: submissionName,
 	}
 
@@ -257,9 +261,10 @@ func (c *Client) SubmitNotarization(ctx context.Context, sha256Hash, submissionN
 
 // GetNotarizationStatus retrieves the status of a notarization submission.
 func (c *Client) GetNotarizationStatus(ctx context.Context, submissionID string) (*NotarySubmissionStatusResponse, error) {
-	submissionID = strings.TrimSpace(submissionID)
-	if submissionID == "" {
-		return nil, fmt.Errorf("submission ID is required")
+	var err error
+	submissionID, err = validateNotarySubmissionID(submissionID)
+	if err != nil {
+		return nil, err
 	}
 
 	path := fmt.Sprintf("%s/%s", notarySubmissionsPath, submissionID)
@@ -278,9 +283,10 @@ func (c *Client) GetNotarizationStatus(ctx context.Context, submissionID string)
 
 // GetNotarizationLogs retrieves the developer log URL for a notarization submission.
 func (c *Client) GetNotarizationLogs(ctx context.Context, submissionID string) (*NotarySubmissionLogsResponse, error) {
-	submissionID = strings.TrimSpace(submissionID)
-	if submissionID == "" {
-		return nil, fmt.Errorf("submission ID is required")
+	var err error
+	submissionID, err = validateNotarySubmissionID(submissionID)
+	if err != nil {
+		return nil, err
 	}
 
 	path := fmt.Sprintf("%s/%s/logs", notarySubmissionsPath, submissionID)
@@ -314,10 +320,39 @@ func (c *Client) ListNotarizations(ctx context.Context) (*NotarySubmissionsListR
 
 // ComputeFileSHA256 computes the SHA-256 hex digest of an opened file and
 // rewinds it so the same descriptor can be uploaded.
-func ComputeFileSHA256(file io.ReadSeeker) (string, error) {
+func ComputeFileSHA256(ctx context.Context, file io.ReadSeeker) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
 	h := sha256.New()
-	if _, err := io.Copy(h, file); err != nil {
-		return "", fmt.Errorf("read file: %w", err)
+	buffer := make([]byte, 64*1024)
+	for {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+
+		n, err := file.Read(buffer)
+		if n > 0 {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return "", ctxErr
+			}
+			if _, writeErr := h.Write(buffer[:n]); writeErr != nil {
+				return "", fmt.Errorf("hash file: %w", writeErr)
+			}
+		}
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return "", fmt.Errorf("read file: %w", err)
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
 	}
 	if _, err := file.Seek(0, io.SeekStart); err != nil {
 		return "", fmt.Errorf("rewind file: %w", err)
@@ -329,13 +364,18 @@ func ComputeFileSHA256(file io.ReadSeeker) (string, error) {
 // UploadToS3 uploads file data to the S3 bucket using AWS Signature V4 authentication.
 // This is a minimal implementation for the single PutObject operation needed by the Notary API.
 func UploadToS3(ctx context.Context, creds S3Credentials, data io.Reader, payloadHash string, contentLength int64, contentType string) error {
-	if creds.Bucket == "" || creds.Object == "" {
-		return fmt.Errorf("S3 bucket and object are required")
+	if err := validateNotaryS3Credentials(creds); err != nil {
+		return err
 	}
 	payloadHash = strings.TrimSpace(payloadHash)
 	if payloadHash == "" {
 		return fmt.Errorf("payload hash is required")
 	}
+	normalizedHash, err := validateNotarySHA256(payloadHash)
+	if err != nil {
+		return err
+	}
+	payloadHash = normalizedHash
 	if contentLength <= 0 {
 		return fmt.Errorf("content length must be positive")
 	}
@@ -348,6 +388,62 @@ func UploadToS3(ctx context.Context, creds S3Credentials, data io.Reader, payloa
 	}
 
 	return uploadSinglePartToS3(ctx, creds, data, payloadHash, contentLength, contentType)
+}
+
+func validateNotarySHA256(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if len(value) != sha256.Size*2 {
+		return "", fmt.Errorf("SHA-256 hash must be exactly 64 hexadecimal characters")
+	}
+	if _, err := hex.DecodeString(value); err != nil {
+		return "", fmt.Errorf("SHA-256 hash must contain only hexadecimal characters")
+	}
+	return strings.ToLower(value), nil
+}
+
+func validateNotarySubmissionID(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("submission ID is required")
+	}
+	if len(value) != 36 {
+		return "", fmt.Errorf("submission ID must be a valid UUID")
+	}
+	for index := 0; index < len(value); index++ {
+		if index == 8 || index == 13 || index == 18 || index == 23 {
+			if value[index] != '-' {
+				return "", fmt.Errorf("submission ID must be a valid UUID")
+			}
+			continue
+		}
+		if !isHexDigit(value[index]) {
+			return "", fmt.Errorf("submission ID must be a valid UUID")
+		}
+	}
+	return value, nil
+}
+
+func isHexDigit(value byte) bool {
+	return value >= '0' && value <= '9' || value >= 'a' && value <= 'f' || value >= 'A' && value <= 'F'
+}
+
+func validateNotaryS3Credentials(creds S3Credentials) error {
+	if strings.TrimSpace(creds.AccessKeyID) == "" {
+		return fmt.Errorf("S3 access key ID is required")
+	}
+	if strings.TrimSpace(creds.SecretAccessKey) == "" {
+		return fmt.Errorf("S3 secret access key is required")
+	}
+	if strings.TrimSpace(creds.SessionToken) == "" {
+		return fmt.Errorf("S3 session token is required")
+	}
+	if strings.TrimSpace(creds.Bucket) == "" {
+		return fmt.Errorf("S3 bucket is required")
+	}
+	if strings.TrimSpace(creds.Object) == "" {
+		return fmt.Errorf("S3 object is required")
+	}
+	return nil
 }
 
 func uploadSinglePartToS3(ctx context.Context, creds S3Credentials, data io.Reader, payloadHash string, contentLength int64, contentType string) error {

--- a/internal/asc/notary_test.go
+++ b/internal/asc/notary_test.go
@@ -37,6 +37,28 @@ func newTestNotaryClient(t *testing.T, serverURL string) *Client {
 	return c
 }
 
+const (
+	testNotarySHA256 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	testSubmissionID = "550e8400-e29b-41d4-a716-446655440000"
+)
+
+type cancelAfterReadSeeker struct {
+	reader *bytes.Reader
+	cancel context.CancelFunc
+}
+
+func (r *cancelAfterReadSeeker) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	if n > 0 {
+		r.cancel()
+	}
+	return n, err
+}
+
+func (r *cancelAfterReadSeeker) Seek(offset int64, whence int) (int64, error) {
+	return r.reader.Seek(offset, whence)
+}
+
 func TestGenerateNotaryJWT(t *testing.T) {
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
@@ -136,8 +158,8 @@ func TestSubmitNotarization_SendsRequest(t *testing.T) {
 		if err := json.Unmarshal(body, &req); err != nil {
 			t.Errorf("parse request: %v", err)
 		}
-		if req.Sha256 != "abc123def456" {
-			t.Errorf("expected sha256 abc123def456, got %s", req.Sha256)
+		if req.Sha256 != testNotarySHA256 {
+			t.Errorf("expected sha256 %s, got %s", testNotarySHA256, req.Sha256)
 		}
 		if req.SubmissionName != "MyApp.zip" {
 			t.Errorf("expected name MyApp.zip, got %s", req.SubmissionName)
@@ -164,7 +186,7 @@ func TestSubmitNotarization_SendsRequest(t *testing.T) {
 	client := newTestNotaryClient(t, server.URL)
 	ctx := context.Background()
 
-	resp, err := client.SubmitNotarization(ctx, "abc123def456", "MyApp.zip")
+	resp, err := client.SubmitNotarization(ctx, "  "+strings.ToUpper(testNotarySHA256)+"  ", "MyApp.zip")
 	if err != nil {
 		t.Fatalf("SubmitNotarization() error: %v", err)
 	}
@@ -196,9 +218,61 @@ func TestSubmitNotarization_ErrorResponse(t *testing.T) {
 	defer server.Close()
 
 	client := newTestNotaryClient(t, server.URL)
-	_, err := client.SubmitNotarization(context.Background(), "abc123", "test.zip")
+	_, err := client.SubmitNotarization(context.Background(), testNotarySHA256, "test.zip")
 	if err == nil {
 		t.Fatal("expected error for 403 response")
+	}
+}
+
+func TestSubmitNotarization_RejectsInvalidSHA256BeforeRequest(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+	}))
+	defer server.Close()
+
+	client := newTestNotaryClient(t, server.URL)
+	_, err := client.SubmitNotarization(context.Background(), "not-a-sha256", "test.zip")
+	if err == nil || !strings.Contains(err.Error(), "64 hexadecimal") {
+		t.Fatalf("SubmitNotarization() error = %v, want strict SHA-256 validation error", err)
+	}
+	if requests != 0 {
+		t.Fatalf("got %d requests for invalid hash, want 0", requests)
+	}
+}
+
+func TestValidateNotarySHA256(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		want      string
+		wantError bool
+	}{
+		{name: "empty", value: "", wantError: true},
+		{name: "short", value: "abc123", wantError: true},
+		{name: "long", value: testNotarySHA256 + "0", wantError: true},
+		{name: "non hexadecimal", value: strings.Repeat("g", 64), wantError: true},
+		{name: "uppercase and whitespace", value: "  " + strings.ToUpper(testNotarySHA256) + "  ", want: testNotarySHA256},
+		{name: "valid", value: testNotarySHA256, want: testNotarySHA256},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validateNotarySHA256(tt.value)
+			if tt.wantError {
+				if err == nil {
+					t.Fatal("validateNotarySHA256() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("validateNotarySHA256() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("validateNotarySHA256() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -219,13 +293,13 @@ func TestGetNotarizationStatus_SendsRequest(t *testing.T) {
 				if r.Method != "GET" {
 					t.Errorf("expected GET, got %s", r.Method)
 				}
-				if !strings.HasSuffix(r.URL.Path, "/notary/v2/submissions/sub-456") {
+				if !strings.HasSuffix(r.URL.Path, "/notary/v2/submissions/"+testSubmissionID) {
 					t.Errorf("unexpected path: %s", r.URL.Path)
 				}
 
 				resp := NotarySubmissionStatusResponse{
 					Data: NotarySubmissionStatusData{
-						ID:   "sub-456",
+						ID:   testSubmissionID,
 						Type: "submissions",
 						Attributes: NotarySubmissionStatusAttributes{
 							Status:      tt.status,
@@ -240,7 +314,7 @@ func TestGetNotarizationStatus_SendsRequest(t *testing.T) {
 			defer server.Close()
 
 			client := newTestNotaryClient(t, server.URL)
-			resp, err := client.GetNotarizationStatus(context.Background(), "sub-456")
+			resp, err := client.GetNotarizationStatus(context.Background(), "  "+testSubmissionID+"  ")
 			if err != nil {
 				t.Fatalf("GetNotarizationStatus() error: %v", err)
 			}
@@ -248,8 +322,8 @@ func TestGetNotarizationStatus_SendsRequest(t *testing.T) {
 			if resp.Data.Attributes.Status != tt.status {
 				t.Errorf("expected status %s, got %s", tt.status, resp.Data.Attributes.Status)
 			}
-			if resp.Data.ID != "sub-456" {
-				t.Errorf("expected ID sub-456, got %s", resp.Data.ID)
+			if resp.Data.ID != testSubmissionID {
+				t.Errorf("expected ID %s, got %s", testSubmissionID, resp.Data.ID)
 			}
 			if resp.Data.Attributes.Name != "test.zip" {
 				t.Errorf("expected name test.zip, got %s", resp.Data.Attributes.Name)
@@ -266,7 +340,7 @@ func TestGetNotarizationStatus_ErrorResponse(t *testing.T) {
 	defer server.Close()
 
 	client := newTestNotaryClient(t, server.URL)
-	_, err := client.GetNotarizationStatus(context.Background(), "nonexistent")
+	_, err := client.GetNotarizationStatus(context.Background(), testSubmissionID)
 	if err == nil {
 		t.Fatal("expected error for 404 response")
 	}
@@ -277,16 +351,16 @@ func TestGetNotarizationLogs_SendsRequest(t *testing.T) {
 		if r.Method != "GET" {
 			t.Errorf("expected GET, got %s", r.Method)
 		}
-		if !strings.HasSuffix(r.URL.Path, "/notary/v2/submissions/sub-789/logs") {
+		if !strings.HasSuffix(r.URL.Path, "/notary/v2/submissions/"+testSubmissionID+"/logs") {
 			t.Errorf("unexpected path: %s", r.URL.Path)
 		}
 
 		resp := NotarySubmissionLogsResponse{
 			Data: NotarySubmissionLogsData{
-				ID:   "sub-789",
+				ID:   testSubmissionID,
 				Type: "submissionsLog",
 				Attributes: NotarySubmissionLogsAttributes{
-					DeveloperLogURL: "https://example.com/logs/sub-789.json",
+					DeveloperLogURL: "https://example.com/logs/" + testSubmissionID + ".json",
 				},
 			},
 		}
@@ -296,15 +370,15 @@ func TestGetNotarizationLogs_SendsRequest(t *testing.T) {
 	defer server.Close()
 
 	client := newTestNotaryClient(t, server.URL)
-	resp, err := client.GetNotarizationLogs(context.Background(), "sub-789")
+	resp, err := client.GetNotarizationLogs(context.Background(), "  "+testSubmissionID+"  ")
 	if err != nil {
 		t.Fatalf("GetNotarizationLogs() error: %v", err)
 	}
 
-	if resp.Data.Attributes.DeveloperLogURL != "https://example.com/logs/sub-789.json" {
+	if resp.Data.Attributes.DeveloperLogURL != "https://example.com/logs/"+testSubmissionID+".json" {
 		t.Errorf("unexpected log URL: %s", resp.Data.Attributes.DeveloperLogURL)
 	}
-	if resp.Data.ID != "sub-789" {
+	if resp.Data.ID != testSubmissionID {
 		t.Errorf("unexpected ID: %s", resp.Data.ID)
 	}
 }
@@ -317,9 +391,56 @@ func TestGetNotarizationLogs_ErrorResponse(t *testing.T) {
 	defer server.Close()
 
 	client := newTestNotaryClient(t, server.URL)
-	_, err := client.GetNotarizationLogs(context.Background(), "nonexistent")
+	_, err := client.GetNotarizationLogs(context.Background(), testSubmissionID)
 	if err == nil {
 		t.Fatal("expected error for 404 response")
+	}
+}
+
+func TestNotarizationRequestIDsRejectInvalidValuesBeforeRequest(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL.RequestURI())
+	}))
+	defer server.Close()
+
+	invalidIDs := []string{
+		"",
+		"sub-456",
+		"550e8400e29b41d4a716446655440000",
+		"urn:uuid:" + testSubmissionID,
+		"{" + testSubmissionID + "}",
+		"550e8400-e29b-41d4-a716-44665544000g",
+		"550e8400-e29b-41d4-a716-446655440000?admin=true",
+		"550e8400-e29b-41d4-a716-446655440000/logs",
+	}
+
+	for _, id := range invalidIDs {
+		client := newTestNotaryClient(t, server.URL)
+		if _, err := client.GetNotarizationStatus(context.Background(), id); err == nil {
+			t.Errorf("GetNotarizationStatus(%q) error = nil, want validation error", id)
+		}
+		if _, err := client.GetNotarizationLogs(context.Background(), id); err == nil {
+			t.Errorf("GetNotarizationLogs(%q) error = nil, want validation error", id)
+		}
+	}
+	if requests != 0 {
+		t.Fatalf("got %d requests for invalid IDs, want 0", requests)
+	}
+}
+
+func TestValidateNotarySubmissionID(t *testing.T) {
+	got, err := validateNotarySubmissionID("  " + testSubmissionID + "  ")
+	if err != nil {
+		t.Fatalf("validateNotarySubmissionID() error = %v", err)
+	}
+	if got != testSubmissionID {
+		t.Fatalf("validateNotarySubmissionID() = %q, want %q", got, testSubmissionID)
+	}
+
+	if _, err := validateNotarySubmissionID(strings.ToUpper(testSubmissionID)); err != nil {
+		t.Fatalf("uppercase canonical UUID rejected: %v", err)
 	}
 }
 
@@ -420,7 +541,7 @@ func TestListNotarizations_ErrorResponse(t *testing.T) {
 func TestComputeFileSHA256(t *testing.T) {
 	content := []byte("hello world")
 	file := bytes.NewReader(content)
-	got, err := ComputeFileSHA256(file)
+	got, err := ComputeFileSHA256(context.Background(), file)
 	if err != nil {
 		t.Fatalf("ComputeFileSHA256() error: %v", err)
 	}
@@ -442,7 +563,7 @@ func TestComputeFileSHA256(t *testing.T) {
 }
 
 func TestComputeFileSHA256_EmptyFile(t *testing.T) {
-	got, err := ComputeFileSHA256(bytes.NewReader(nil))
+	got, err := ComputeFileSHA256(context.Background(), bytes.NewReader(nil))
 	if err != nil {
 		t.Fatalf("ComputeFileSHA256() error: %v", err)
 	}
@@ -453,6 +574,35 @@ func TestComputeFileSHA256_EmptyFile(t *testing.T) {
 
 	if got != want {
 		t.Errorf("got %s, want %s", got, want)
+	}
+}
+
+func TestComputeFileSHA256_ContextCancellationBeforeRead(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	got, err := ComputeFileSHA256(ctx, bytes.NewReader([]byte("data")))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("ComputeFileSHA256() error = %v, want context.Canceled", err)
+	}
+	if got != "" {
+		t.Fatalf("ComputeFileSHA256() hash = %q, want empty hash on cancellation", got)
+	}
+}
+
+func TestComputeFileSHA256_ContextCancellationDuringRead(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	file := &cancelAfterReadSeeker{
+		reader: bytes.NewReader(bytes.Repeat([]byte("x"), 128*1024)),
+		cancel: cancel,
+	}
+
+	got, err := ComputeFileSHA256(ctx, file)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("ComputeFileSHA256() error = %v, want context.Canceled", err)
+	}
+	if got != "" {
+		t.Fatalf("ComputeFileSHA256() hash = %q, want empty hash on cancellation", got)
 	}
 }
 
@@ -518,52 +668,62 @@ func mustWriteBody(t *testing.T, w http.ResponseWriter, body string) {
 }
 
 func TestUploadToS3_Validation(t *testing.T) {
-	// Empty credentials
-	err := UploadToS3(context.Background(), S3Credentials{}, strings.NewReader("data"), "hash", 4, "application/octet-stream")
-	if err == nil {
-		t.Fatal("expected error for empty credentials")
-	}
-
-	// Empty bucket
-	err = UploadToS3(context.Background(), S3Credentials{
+	validCredentials := S3Credentials{
 		AccessKeyID:     "key",
 		SecretAccessKey: "secret",
-		Object:          "obj",
-	}, strings.NewReader("data"), "hash", 4, "application/octet-stream")
-	if err == nil {
-		t.Fatal("expected error for empty bucket")
-	}
-
-	// Empty object
-	err = UploadToS3(context.Background(), S3Credentials{
-		AccessKeyID:     "key",
-		SecretAccessKey: "secret",
-		Bucket:          "bucket",
-	}, strings.NewReader("data"), "hash", 4, "application/octet-stream")
-	if err == nil {
-		t.Fatal("expected error for empty object")
-	}
-
-	// Empty payload hash
-	err = UploadToS3(context.Background(), S3Credentials{
-		AccessKeyID:     "key",
-		SecretAccessKey: "secret",
+		SessionToken:    "token",
 		Bucket:          "bucket",
 		Object:          "object",
-	}, strings.NewReader("data"), "", 4, "application/octet-stream")
-	if err == nil {
-		t.Fatal("expected error for empty payload hash")
 	}
 
-	// Invalid content length
-	err = UploadToS3(context.Background(), S3Credentials{
+	tests := []struct {
+		name   string
+		mutate func(*S3Credentials)
+		want   string
+	}{
+		{name: "access key ID", mutate: func(creds *S3Credentials) { creds.AccessKeyID = "" }, want: "S3 access key ID is required"},
+		{name: "secret access key", mutate: func(creds *S3Credentials) { creds.SecretAccessKey = "" }, want: "S3 secret access key is required"},
+		{name: "session token", mutate: func(creds *S3Credentials) { creds.SessionToken = "" }, want: "S3 session token is required"},
+		{name: "bucket", mutate: func(creds *S3Credentials) { creds.Bucket = "" }, want: "S3 bucket is required"},
+		{name: "object", mutate: func(creds *S3Credentials) { creds.Object = "" }, want: "S3 object is required"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			creds := validCredentials
+			tt.mutate(&creds)
+			err := UploadToS3(context.Background(), creds, strings.NewReader("data"), testNotarySHA256, 4, "application/octet-stream")
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("UploadToS3() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+
+	err := UploadToS3(context.Background(), validCredentials, strings.NewReader("data"), "", 4, "application/octet-stream")
+	if err == nil || !strings.Contains(err.Error(), "payload hash") {
+		t.Fatalf("UploadToS3() error = %v, want payload hash error", err)
+	}
+
+	err = UploadToS3(context.Background(), validCredentials, strings.NewReader("data"), testNotarySHA256, 0, "application/octet-stream")
+	if err == nil || !strings.Contains(err.Error(), "content length") {
+		t.Fatalf("UploadToS3() error = %v, want content length error", err)
+	}
+}
+
+func TestUploadToS3_RejectsInvalidPayloadHashBeforeRequest(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	creds := S3Credentials{
 		AccessKeyID:     "key",
 		SecretAccessKey: "secret",
+		SessionToken:    "token",
 		Bucket:          "bucket",
 		Object:          "object",
-	}, strings.NewReader("data"), "hash", 0, "application/octet-stream")
-	if err == nil {
-		t.Fatal("expected error for invalid content length")
+	}
+	err := UploadToS3(ctx, creds, strings.NewReader("data"), "not-a-sha256", 4, "application/octet-stream")
+	if err == nil || !strings.Contains(err.Error(), "64 hexadecimal") {
+		t.Fatalf("UploadToS3() error = %v, want strict SHA-256 validation error", err)
 	}
 }
 
@@ -761,7 +921,7 @@ func TestSubmitNotarization_EmptyInputs(t *testing.T) {
 		t.Fatal("expected error for empty sha256")
 	}
 
-	_, err = client.SubmitNotarization(ctx, "abc123", "")
+	_, err = client.SubmitNotarization(ctx, testNotarySHA256, "")
 	if err == nil {
 		t.Fatal("expected error for empty name")
 	}
@@ -802,7 +962,7 @@ func TestNotarySubmissionStatusConstants(t *testing.T) {
 
 func TestNotarySubmissionRequestJSON(t *testing.T) {
 	req := NotarySubmissionRequest{
-		Sha256:         "deadbeef",
+		Sha256:         testNotarySHA256,
 		SubmissionName: "app.zip",
 	}
 
@@ -816,8 +976,8 @@ func TestNotarySubmissionRequestJSON(t *testing.T) {
 		t.Fatalf("unmarshal: %v", err)
 	}
 
-	if parsed["sha256"] != "deadbeef" {
-		t.Errorf("expected sha256 deadbeef, got %s", parsed["sha256"])
+	if parsed["sha256"] != testNotarySHA256 {
+		t.Errorf("expected sha256 %s, got %s", testNotarySHA256, parsed["sha256"])
 	}
 	if parsed["submissionName"] != "app.zip" {
 		t.Errorf("expected submissionName app.zip, got %s", parsed["submissionName"])

--- a/internal/cli/notarization/notarization.go
+++ b/internal/cli/notarization/notarization.go
@@ -1529,7 +1529,7 @@ Examples:
 			if shared.ProgressEnabled() {
 				fmt.Fprintf(os.Stderr, "Computing SHA-256 hash of %s...\n", pathValue)
 			}
-			sha256Hash, err := asc.ComputeFileSHA256(fileHandle)
+			sha256Hash, err := asc.ComputeFileSHA256(ctx, fileHandle)
 			if err != nil {
 				return fmt.Errorf("notarization submit: failed to compute SHA-256: %w", err)
 			}

--- a/internal/cli/notarization/notarization_wait_test.go
+++ b/internal/cli/notarization/notarization_wait_test.go
@@ -16,13 +16,15 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/asc"
 )
 
+const testNotarizationSubmissionID = "550e8400-e29b-41d4-a716-446655440000"
+
 func TestWaitForNotarizationRetriesTransientStatusFailures(t *testing.T) {
 	var mu sync.Mutex
 	attempts := 0
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if req.URL.Path != "/notary/v2/submissions/submission-1" {
-			t.Errorf("status request path = %q, want /notary/v2/submissions/submission-1", req.URL.Path)
+		if req.URL.Path != "/notary/v2/submissions/"+testNotarizationSubmissionID {
+			t.Errorf("status request path = %q, want /notary/v2/submissions/%s", req.URL.Path, testNotarizationSubmissionID)
 		}
 
 		mu.Lock()
@@ -52,7 +54,7 @@ func TestWaitForNotarizationRetriesTransientStatusFailures(t *testing.T) {
 	var resp *asc.NotarySubmissionStatusResponse
 	var waitErr error
 	stderr := captureNotarizationStderr(t, func() {
-		resp, waitErr = waitForNotarization(context.Background(), client, "submission-1", 5*time.Millisecond)
+		resp, waitErr = waitForNotarization(context.Background(), client, testNotarizationSubmissionID, 5*time.Millisecond)
 	})
 
 	if waitErr != nil {
@@ -92,7 +94,7 @@ func TestWaitForNotarizationFailsFastOnTerminalStatusError(t *testing.T) {
 
 	var waitErr error
 	captureNotarizationStderr(t, func() {
-		_, waitErr = waitForNotarization(context.Background(), client, "submission-1", 5*time.Millisecond)
+		_, waitErr = waitForNotarization(context.Background(), client, testNotarizationSubmissionID, 5*time.Millisecond)
 	})
 
 	if waitErr == nil {
@@ -131,7 +133,7 @@ func TestWaitForNotarizationReportsWaitDeadlineDuringInFlightStatusRequest(t *te
 
 	var waitErr error
 	captureNotarizationStderr(t, func() {
-		_, waitErr = waitForNotarization(ctx, client, "submission-1", 5*time.Millisecond)
+		_, waitErr = waitForNotarization(ctx, client, testNotarizationSubmissionID, 5*time.Millisecond)
 	})
 
 	if waitErr == nil {
@@ -160,7 +162,7 @@ func TestWaitForNotarizationReportsLastTransientFailureAtDeadline(t *testing.T) 
 
 	var waitErr error
 	captureNotarizationStderr(t, func() {
-		_, waitErr = waitForNotarization(ctx, client, "submission-1", 5*time.Millisecond)
+		_, waitErr = waitForNotarization(ctx, client, testNotarizationSubmissionID, 5*time.Millisecond)
 	})
 
 	if waitErr == nil {
@@ -191,7 +193,7 @@ func TestWaitForNotarizationReportsCancellationSeparatelyFromTimeout(t *testing.
 
 	var waitErr error
 	captureNotarizationStderr(t, func() {
-		_, waitErr = waitForNotarization(ctx, client, "submission-1", 5*time.Millisecond)
+		_, waitErr = waitForNotarization(ctx, client, testNotarizationSubmissionID, 5*time.Millisecond)
 	})
 
 	if waitErr == nil {
@@ -211,7 +213,7 @@ func writeNotaryStatus(t *testing.T, w http.ResponseWriter, status asc.NotarySub
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(asc.NotarySubmissionStatusResponse{
 		Data: asc.NotarySubmissionStatusData{
-			ID:   "submission-1",
+			ID:   testNotarizationSubmissionID,
 			Type: "submissions",
 			Attributes: asc.NotarySubmissionStatusAttributes{
 				Status: status,


### PR DESCRIPTION
## Summary

- make Notary API file hashing cancellable while rewinding the same opened descriptor for upload
- require canonical 64-digit SHA-256 inputs and UUID-shaped submission IDs before requests
- reject incomplete S3 credential responses before upload setup
- cover invalid inputs, cancellation, request suppression, and updated status/log paths

## Validation

- `make build`
- `make format`
- `make check-docs`
- `make lint`
- `ASC_BYPASS_KEYCHAIN=1 make test`
- final full-branch review against current `origin/main`: no findings
- independent focused audit of hashing, UUID/SHA validation, and S3 credentials: no findings

No live notarization submission or Apple upload was performed; those are mutating operations and require an explicit artifact/account target.
