### PR TITLE
Harden Xcode archive inputs and tool resolution

### DIFF
--- a/cmd/profiles_local_default_test.go
+++ b/cmd/profiles_local_default_test.go
@@ -6,6 +6,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	localxcode "github.com/rudrankriyam/App-Store-Connect-CLI/internal/xcode"
 )
 
 func TestProfilesLocalDefaultFallsBackWhenXcodeDiscoveryFails(t *testing.T) {
@@ -13,13 +15,23 @@ func TestProfilesLocalDefaultFallsBackWhenXcodeDiscoveryFails(t *testing.T) {
 		t.Skip("active Xcode profile directory is macOS-specific")
 	}
 
-	binDir := t.TempDir()
+	developerDir := filepath.Join(t.TempDir(), "Xcode.app", "Contents", "Developer")
+	binDir := filepath.Join(developerDir, "usr", "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("create fake developer directory: %v", err)
+	}
 	xcodebuildPath := filepath.Join(binDir, "xcodebuild")
 	script := "#!/bin/sh\nprintf 'xcode-select: active developer directory is a command line tools instance\\n' >&2\nexit 1\n"
 	if err := os.WriteFile(xcodebuildPath, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake xcodebuild: %v", err)
 	}
-	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	fakeXcrun := filepath.Join(t.TempDir(), "xcrun")
+	xcrunScript := "#!/bin/sh\nif [ \"$1\" = \"--find\" ] && [ \"$2\" = \"xcodebuild\" ]; then\n  printf '%s\\n' \"$DEVELOPER_DIR/usr/bin/xcodebuild\"\n  exit 0\nfi\nexit 2\n"
+	if err := os.WriteFile(fakeXcrun, []byte(xcrunScript), 0o700); err != nil {
+		t.Fatalf("write fake trusted xcrun: %v", err)
+	}
+	t.Cleanup(localxcode.OverrideTrustedXcrunPathForTesting(fakeXcrun))
+	t.Setenv("DEVELOPER_DIR", developerDir)
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
 	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")

--- a/cmd/run_additional_test.go
+++ b/cmd/run_additional_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/cli/shared"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/config"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/telemetry"
+	localxcode "github.com/rudrankriyam/App-Store-Connect-CLI/internal/xcode"
 )
 
 func TestRun_VersionFlag(t *testing.T) {
@@ -3382,7 +3383,11 @@ func TestRunXcodeTestWritesStructuredJUnitReport(t *testing.T) {
 	}
 	resetReportFlags(t)
 	t.Setenv("ASC_BYPASS_KEYCHAIN", "1")
-	binDir := t.TempDir()
+	developerDir := filepath.Join(t.TempDir(), "Xcode.app", "Contents", "Developer")
+	binDir := filepath.Join(developerDir, "usr", "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() fake developer directory error: %v", err)
+	}
 	xcodebuildPath := filepath.Join(binDir, "xcodebuild")
 	xcodebuildScript := `#!/bin/sh
 if [ "$1" = "-version" ]; then
@@ -3407,18 +3412,23 @@ exit 0
 	if err := os.WriteFile(xcodebuildPath, []byte(xcodebuildScript), 0o755); err != nil {
 		t.Fatalf("WriteFile() xcodebuild error: %v", err)
 	}
-	xcrunPath := filepath.Join(binDir, "xcrun")
+	fakeXcrun := filepath.Join(t.TempDir(), "xcrun")
 	xcrunScript := `#!/bin/sh
+if [ "$1" = "--find" ] && [ "$2" = "xcodebuild" ]; then
+  printf '%s\n' "$DEVELOPER_DIR/usr/bin/xcodebuild"
+  exit 0
+fi
 if [ "$4" = "summary" ]; then
   printf '%s\n' '{"totalTestCount":1,"passedTests":1,"failedTests":0,"skippedTests":0,"testFailures":[]}'
 else
   printf '%s\n' '{"testNodes":[{"nodeType":"Test Plan","children":[{"nodeType":"Unit test bundle","children":[{"nodeType":"Test Suite","children":[{"nodeType":"Test Case","nodeIdentifier":"DemoTests/Smoke/testPass","name":"testPass","result":"Passed","duration":"0.25"}]}]}]}]}'
 fi
 `
-	if err := os.WriteFile(xcrunPath, []byte(xcrunScript), 0o755); err != nil {
-		t.Fatalf("WriteFile() xcrun error: %v", err)
+	if err := os.WriteFile(fakeXcrun, []byte(xcrunScript), 0o700); err != nil {
+		t.Fatalf("WriteFile() fake trusted xcrun error: %v", err)
 	}
-	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Cleanup(localxcode.OverrideTrustedXcrunPathForTesting(fakeXcrun))
+	t.Setenv("DEVELOPER_DIR", developerDir)
 	projectPath := filepath.Join(t.TempDir(), "Demo.xcodeproj")
 	if err := os.Mkdir(projectPath, 0o755); err != nil {
 		t.Fatalf("Mkdir() project error: %v", err)

--- a/internal/cli/cmdtest/profiles_local_test.go
+++ b/internal/cli/cmdtest/profiles_local_test.go
@@ -23,6 +23,8 @@ import (
 
 	"go.mozilla.org/pkcs7"
 	"howett.net/plist"
+
+	localxcode "github.com/rudrankriyam/App-Store-Connect-CLI/internal/xcode"
 )
 
 func TestProfilesLocalInstall_ForceActionIsInstalledWhenNoExisting(t *testing.T) {
@@ -301,12 +303,22 @@ func TestProfilesLocalDefaultFollowsActiveXcodeWithoutCombiningStores(t *testing
 		t.Skip("active Xcode profile directory is macOS-specific")
 	}
 
-	binDir := t.TempDir()
+	developerDir := filepath.Join(t.TempDir(), "Xcode.app", "Contents", "Developer")
+	binDir := filepath.Join(developerDir, "usr", "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("create fake developer directory: %v", err)
+	}
 	xcodebuildPath := filepath.Join(binDir, "xcodebuild")
 	if err := os.WriteFile(xcodebuildPath, []byte("#!/bin/sh\nprintf 'Xcode 16.0\\nBuild version 16A1\\n'\n"), 0o755); err != nil {
 		t.Fatalf("write fake xcodebuild: %v", err)
 	}
-	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	fakeXcrun := filepath.Join(t.TempDir(), "xcrun")
+	xcrunScript := "#!/bin/sh\nif [ \"$1\" = \"--find\" ] && [ \"$2\" = \"xcodebuild\" ]; then\n  printf '%s\\n' \"$DEVELOPER_DIR/usr/bin/xcodebuild\"\n  exit 0\nfi\nexit 2\n"
+	if err := os.WriteFile(fakeXcrun, []byte(xcrunScript), 0o700); err != nil {
+		t.Fatalf("write fake trusted xcrun: %v", err)
+	}
+	t.Cleanup(localxcode.OverrideTrustedXcrunPathForTesting(fakeXcrun))
+	t.Setenv("DEVELOPER_DIR", developerDir)
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
 
@@ -379,13 +391,23 @@ func TestProfilesLocalDefaultFallsBackToLegacyDirectoryWithoutFullXcode(t *testi
 		t.Skip("active Xcode profile directory is macOS-specific")
 	}
 
-	binDir := t.TempDir()
+	developerDir := filepath.Join(t.TempDir(), "Xcode.app", "Contents", "Developer")
+	binDir := filepath.Join(developerDir, "usr", "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("create fake developer directory: %v", err)
+	}
 	xcodebuildPath := filepath.Join(binDir, "xcodebuild")
 	script := "#!/bin/sh\nprintf 'xcode-select: error: tool '\\''xcodebuild'\\'' requires Xcode\\n' >&2\nexit 1\n"
 	if err := os.WriteFile(xcodebuildPath, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake xcodebuild: %v", err)
 	}
-	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	fakeXcrun := filepath.Join(t.TempDir(), "xcrun")
+	xcrunScript := "#!/bin/sh\nif [ \"$1\" = \"--find\" ] && [ \"$2\" = \"xcodebuild\" ]; then\n  printf '%s\\n' \"$DEVELOPER_DIR/usr/bin/xcodebuild\"\n  exit 0\nfi\nexit 2\n"
+	if err := os.WriteFile(fakeXcrun, []byte(xcrunScript), 0o700); err != nil {
+		t.Fatalf("write fake trusted xcrun: %v", err)
+	}
+	t.Cleanup(localxcode.OverrideTrustedXcrunPathForTesting(fakeXcrun))
+	t.Setenv("DEVELOPER_DIR", developerDir)
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
 

--- a/internal/cli/cmdtest/xcode_test.go
+++ b/internal/cli/cmdtest/xcode_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	rootcmd "github.com/rudrankriyam/App-Store-Connect-CLI/cmd"
+	localxcode "github.com/rudrankriyam/App-Store-Connect-CLI/internal/xcode"
 )
 
 func TestXcodeCommandExists(t *testing.T) {
@@ -403,7 +404,11 @@ func TestXcodeExportRequiresArchivePath(t *testing.T) {
 
 func TestXcodeExportWithoutExportOptionsPreflightsBeforeGeneration(t *testing.T) {
 	if runtime.GOOS == "darwin" {
-		binDir := t.TempDir()
+		developerDir := filepath.Join(t.TempDir(), "Xcode.app", "Contents", "Developer")
+		binDir := filepath.Join(developerDir, "usr", "bin")
+		if err := os.MkdirAll(binDir, 0o755); err != nil {
+			t.Fatalf("create fake developer directory: %v", err)
+		}
 		xcodebuildPath := filepath.Join(binDir, "xcodebuild")
 		script := "#!/bin/sh\n" +
 			"if [ \"$1\" = \"-version\" ]; then\n" +
@@ -415,7 +420,13 @@ func TestXcodeExportWithoutExportOptionsPreflightsBeforeGeneration(t *testing.T)
 		if err := os.WriteFile(xcodebuildPath, []byte(script), 0o755); err != nil {
 			t.Fatalf("write fake xcodebuild: %v", err)
 		}
-		t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+		fakeXcrun := filepath.Join(t.TempDir(), "xcrun")
+		xcrunScript := "#!/bin/sh\nif [ \"$1\" = \"--find\" ] && [ \"$2\" = \"xcodebuild\" ]; then\n  printf '%s\\n' \"$DEVELOPER_DIR/usr/bin/xcodebuild\"\n  exit 0\nfi\nexit 2\n"
+		if err := os.WriteFile(fakeXcrun, []byte(xcrunScript), 0o700); err != nil {
+			t.Fatalf("write fake trusted xcrun: %v", err)
+		}
+		t.Cleanup(localxcode.OverrideTrustedXcrunPathForTesting(fakeXcrun))
+		t.Setenv("DEVELOPER_DIR", developerDir)
 	}
 
 	root := RootCommand("1.2.3")

--- a/internal/cli/notarization/notarization_staple_test.go
+++ b/internal/cli/notarization/notarization_staple_test.go
@@ -3315,12 +3315,7 @@ func TestNotarizationStapleProductionRunnerProjectsInventoryMismatchAsPartialMut
 	if err := os.WriteFile(fakeXcrun, []byte(script), 0o700); err != nil {
 		t.Fatalf("write fake xcrun: %v", err)
 	}
-	oldPath, hadPath := os.LookupEnv("PATH")
-	pathValue := fakeBin
-	if hadPath {
-		pathValue += string(os.PathListSeparator) + oldPath
-	}
-	t.Setenv("PATH", pathValue)
+	t.Cleanup(localxcode.OverrideTrustedXcrunPathForTesting(fakeXcrun))
 
 	previous := runStaplerStaple
 	runStaplerStaple = localxcode.StapleWithVerifier
@@ -3383,12 +3378,7 @@ func TestNotarizationValidateCommandReportsContextKilledChildAsCanceled(t *testi
 	if err := os.WriteFile(fakeXcrun, []byte(script), 0o700); err != nil {
 		t.Fatalf("write fake xcrun: %v", err)
 	}
-	oldPath, hadPath := os.LookupEnv("PATH")
-	pathValue := fakeBin
-	if hadPath {
-		pathValue += string(os.PathListSeparator) + oldPath
-	}
-	t.Setenv("PATH", pathValue)
+	t.Cleanup(localxcode.OverrideTrustedXcrunPathForTesting(fakeXcrun))
 	t.Setenv("ASC_STAPLER_VALIDATE_READY_PATH", readyPath)
 
 	previous := runStaplerValidate
@@ -3471,12 +3461,7 @@ func TestNotarizationValidateCommandReportsContextKilledResolverAsCanceled(t *te
 	if err := os.WriteFile(fakeXcrun, []byte(script), 0o700); err != nil {
 		t.Fatalf("write fake xcrun: %v", err)
 	}
-	oldPath, hadPath := os.LookupEnv("PATH")
-	pathValue := fakeBin
-	if hadPath {
-		pathValue += string(os.PathListSeparator) + oldPath
-	}
-	t.Setenv("PATH", pathValue)
+	t.Cleanup(localxcode.OverrideTrustedXcrunPathForTesting(fakeXcrun))
 	t.Setenv("ASC_STAPLER_FIND_READY_PATH", readyPath)
 
 	previous := runStaplerValidate

--- a/internal/cli/xcode/xcode_version.go
+++ b/internal/cli/xcode/xcode_version.go
@@ -287,7 +287,7 @@ Examples:
 				if err := validateXcodeRemoteBuildNumberOptions(remote.options(v)); err != nil {
 					return err
 				}
-				if err := runValidateSetVersion(localxcode.SetVersionOptions{
+				if err := runValidateSetVersion(ctx, localxcode.SetVersionOptions{
 					ProjectDir:            projectInput,
 					Target:                strings.TrimSpace(*target),
 					Configuration:         strings.TrimSpace(*configuration),

--- a/internal/cli/xcode/xcode_version_test.go
+++ b/internal/cli/xcode/xcode_version_test.go
@@ -391,7 +391,7 @@ func TestXcodeVersionEditResolvesAndAppliesRemoteSafeBuildNumber(t *testing.T) {
 		runSetVersion = originalSet
 		runResolveXcodeNextBuildNumber = originalResolve
 	})
-	runValidateSetVersion = func(opts localxcode.SetVersionOptions) error { return nil }
+	runValidateSetVersion = func(context.Context, localxcode.SetVersionOptions) error { return nil }
 
 	runGetConsistentMarketingVersion = func(ctx context.Context, opts localxcode.GetVersionOptions) (string, error) {
 		if opts.BuildSettingsLookup != localxcode.BuildSettingsLookupNever || opts.BuildSettingsDiagnostic == nil {
@@ -468,7 +468,7 @@ func TestXcodeVersionEditRemoteNumberRejectsDivergentLocalVersions(t *testing.T)
 		runResolveXcodeNextBuildNumber = originalResolve
 		runSetVersion = originalSet
 	})
-	runValidateSetVersion = func(opts localxcode.SetVersionOptions) error { return nil }
+	runValidateSetVersion = func(context.Context, localxcode.SetVersionOptions) error { return nil }
 
 	runGetConsistentMarketingVersion = func(ctx context.Context, opts localxcode.GetVersionOptions) (string, error) {
 		return "", errors.New("MARKETING_VERSION has differing values")

--- a/internal/xcode/active_version.go
+++ b/internal/xcode/active_version.go
@@ -23,7 +23,10 @@ func ActiveXcodeMajorVersion(ctx context.Context) (int, error) {
 		return 0, err
 	}
 
-	cmd := commandContextFn(ctx, "xcodebuild", "-version")
+	cmd, err := trustedXcodeCommand(ctx, "xcodebuild", []string{"-version"}, nil)
+	if err != nil {
+		return 0, err
+	}
 	var stdout bytes.Buffer
 	stderr := newTailBuffer(activeXcodeVersionDiagnosticLimit)
 	cmd.Stdout = &stdout

--- a/internal/xcode/active_version_test.go
+++ b/internal/xcode/active_version_test.go
@@ -46,6 +46,11 @@ func TestParseActiveXcodeMajorVersion(t *testing.T) {
 func TestActiveXcodeMajorVersionIncludesCommandDiagnostic(t *testing.T) {
 	originalCommandContext := commandContextFn
 	t.Cleanup(func() { commandContextFn = originalCommandContext })
+	originalTrustedXcodeToolPath := trustedXcodeToolPathFn
+	trustedXcodeToolPathFn = func(context.Context, string, []string) (string, error) {
+		return "/usr/bin/xcodebuild", nil
+	}
+	t.Cleanup(func() { trustedXcodeToolPathFn = originalTrustedXcodeToolPath })
 	commandContextFn = func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
 		cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestActiveXcodeVersionHelperProcess")
 		cmd.Env = append(os.Environ(), "GO_WANT_ACTIVE_XCODE_VERSION_HELPER=error")

--- a/internal/xcode/archive_plist_limit_test.go
+++ b/internal/xcode/archive_plist_limit_test.go
@@ -1,0 +1,51 @@
+package xcode
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/infoplist"
+)
+
+func TestReadArchiveBundleInfoRejectsOversizedRootInfoPlist(t *testing.T) {
+	archivePath := filepath.Join(t.TempDir(), "Demo.xcarchive")
+	if err := os.MkdirAll(archivePath, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(archivePath, "Info.plist"), bytes.Repeat([]byte("A"), infoplist.MaxBytes+1), 0o644); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	_, err := readArchiveBundleInfo(archivePath)
+	if err == nil {
+		t.Fatal("expected oversized archive Info.plist rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "Info.plist limit") {
+		t.Fatalf("expected Info.plist limit error, got %v", err)
+	}
+}
+
+func TestReadArchiveExportOptionsTeamIDRejectsOversizedEmbeddedAppInfoPlist(t *testing.T) {
+	archivePath := filepath.Join(t.TempDir(), "Demo.xcarchive")
+	if err := writeArchiveInfoPlist(archivePath); err != nil {
+		t.Fatalf("writeArchiveInfoPlist() error: %v", err)
+	}
+	appInfoPath := filepath.Join(archivePath, "Products", "Applications", "Demo.app", "Info.plist")
+	if err := os.MkdirAll(filepath.Dir(appInfoPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error: %v", err)
+	}
+	if err := os.WriteFile(appInfoPath, bytes.Repeat([]byte("A"), infoplist.MaxBytes+1), 0o644); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	_, err := readArchiveExportOptionsTeamID(archivePath)
+	if err == nil {
+		t.Fatal("expected oversized embedded app Info.plist rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "Info.plist limit") {
+		t.Fatalf("expected Info.plist limit error, got %v", err)
+	}
+}

--- a/internal/xcode/archive_special_file_unix_test.go
+++ b/internal/xcode/archive_special_file_unix_test.go
@@ -1,0 +1,40 @@
+//go:build darwin || linux || freebsd || netbsd || openbsd || dragonfly
+
+package xcode
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestReadRegularFileFromRootRejectsFIFOWithoutBlocking(t *testing.T) {
+	directory := t.TempDir()
+	path := filepath.Join(directory, "Info.plist")
+	if err := unix.Mkfifo(path, 0o600); err != nil {
+		t.Fatalf("Mkfifo() error: %v", err)
+	}
+	root, err := os.OpenRoot(directory)
+	if err != nil {
+		t.Fatalf("OpenRoot() error: %v", err)
+	}
+	defer root.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		_, readErr := readRegularFileFromRoot(root, "Info.plist")
+		done <- readErr
+	}()
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "regular file") {
+			t.Fatalf("readRegularFileFromRoot() error = %v, want regular-file rejection", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("readRegularFileFromRoot() blocked while opening a FIFO")
+	}
+}

--- a/internal/xcode/build_test.go
+++ b/internal/xcode/build_test.go
@@ -589,8 +589,12 @@ func overrideBuildProcess(t *testing.T, mode string, productsPaths ...string) fu
 	originalGOOS := runtimeGOOS
 	originalLookPath := lookPathFn
 	originalCommandContext := commandContextFn
+	originalTrustedXcodeToolPath := trustedXcodeToolPathFn
 	runtimeGOOS = "darwin"
 	lookPathFn = func(string) (string, error) { return "/usr/bin/xcodebuild", nil }
+	trustedXcodeToolPathFn = func(_ context.Context, tool string, _ []string) (string, error) {
+		return lookPathFn(tool)
+	}
 	commandContextFn = func(ctx context.Context, _ string, args ...string) *exec.Cmd {
 		commandArgs := []string{"-test.run=TestBuildHelperProcess", "--"}
 		commandArgs = append(commandArgs, args...)
@@ -602,6 +606,7 @@ func overrideBuildProcess(t *testing.T, mode string, productsPaths ...string) fu
 		runtimeGOOS = originalGOOS
 		lookPathFn = originalLookPath
 		commandContextFn = originalCommandContext
+		trustedXcodeToolPathFn = originalTrustedXcodeToolPath
 	}
 }
 

--- a/internal/xcode/stapler.go
+++ b/internal/xcode/stapler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 )
@@ -359,14 +360,15 @@ func ensureStaplerAvailable(ctx context.Context) error {
 	if runtimeGOOS != "darwin" {
 		return fmt.Errorf("stapler is supported on macOS only; current platform is %s", runtimeGOOS)
 	}
-	if _, err := lookPathFn("xcrun"); err != nil {
-		if errors.Is(err, exec.ErrNotFound) {
+	xcrunPath, err := trustedXcrunPathFn()
+	if err != nil {
+		if isTrustedXcodeToolUnavailable(err, "xcrun") {
 			return fmt.Errorf("xcrun not available; install Xcode and ensure the active developer directory is configured")
 		}
 		return &StaplerResolutionError{Err: err}
 	}
 
-	cmd := commandContextFn(ctx, "xcrun", "--find", "stapler")
+	cmd := commandContextFn(ctx, xcrunPath, "--find", "stapler")
 	var contextCancelSucceeded atomic.Bool
 	if cancel := cmd.Cancel; cancel != nil {
 		cmd.Cancel = func() error {
@@ -428,10 +430,29 @@ func ensureStaplerAvailable(ctx context.Context) error {
 		}
 		return commandErr
 	}
-	if strings.TrimSpace(stdout.String()) == "" {
-		return fmt.Errorf("xcrun did not resolve stapler")
+	pathValue, err := parseTrustedToolPath(stdout.String(), "stapler")
+	if err != nil {
+		return &StaplerResolutionError{Err: err}
+	}
+	if _, err := validateResolvedStaplerPathForOperation(ctx, pathValue); err != nil {
+		return &StaplerResolutionError{Err: err}
 	}
 	return nil
+}
+
+func validateResolvedStaplerPathForOperation(ctx context.Context, pathValue string) (string, error) {
+	if filepath.Clean(pathValue) == trustedStaplerPath {
+		return trustedStaplerPath, nil
+	}
+	developerDir, err := trustedDeveloperDirectory(ctx, nil)
+	if err != nil {
+		return "", err
+	}
+	developerDir, _, _, err = normalizeToolchainDeveloperDir(developerDir)
+	if err != nil {
+		return "", err
+	}
+	return validateResolvedStaplerPath(pathValue, developerDir)
 }
 
 // staplerOperationAttemptedCancellationError records that a stapler child was
@@ -643,7 +664,10 @@ func runStaplerOperation(ctx context.Context, operation StaplerOperation, path s
 }
 
 func runStaplerChildCommand(ctx context.Context, operation StaplerOperation, path string, logWriter io.Writer) (bool, bool, error) {
-	cmd := commandContextFn(ctx, "xcrun", "stapler", string(operation), path)
+	cmd, err := trustedXcodeCommand(ctx, "xcrun", []string{"stapler", string(operation), path}, nil)
+	if err != nil {
+		return false, false, err
+	}
 	if beforeStaplerCommandCancelFn != nil {
 		beforeStaplerCommandCancelFn(cmd)
 	}

--- a/internal/xcode/stapler_test.go
+++ b/internal/xcode/stapler_test.go
@@ -303,7 +303,7 @@ func TestStapleWithVerifierDoesNotMarkStartFailureAsPartialMutation(t *testing.T
 	lookupCommandContext := commandContextFn
 	previousCommandContext := commandContextFn
 	commandContextFn = func(ctx context.Context, name string, args ...string) *exec.Cmd {
-		if name == "xcrun" && len(args) == 2 && args[0] == "--find" && args[1] == "stapler" {
+		if filepath.Base(name) == "xcrun" && len(args) == 2 && args[0] == "--find" && args[1] == "stapler" {
 			return lookupCommandContext(ctx, name, args...)
 		}
 		return exec.CommandContext(ctx, filepath.Join(t.TempDir(), "missing-stapler"), args...)
@@ -1235,14 +1235,9 @@ func TestStaplerReportsMissingXcrunWithoutStartingChild(t *testing.T) {
 	previousOS := runtimeGOOS
 	runtimeGOOS = "darwin"
 	t.Cleanup(func() { runtimeGOOS = previousOS })
-	previousLookPath := lookPathFn
-	lookPathFn = func(file string) (string, error) {
-		if file == "xcrun" {
-			return "", exec.ErrNotFound
-		}
-		return "/usr/bin/" + file, nil
-	}
-	t.Cleanup(func() { lookPathFn = previousLookPath })
+	previousTrustedXcrunPath := trustedXcrunPathFn
+	trustedXcrunPathFn = func() (string, error) { return "", exec.ErrNotFound }
+	t.Cleanup(func() { trustedXcrunPathFn = previousTrustedXcrunPath })
 	previousCommandContext := commandContextFn
 	commandContextFn = func(context.Context, string, ...string) *exec.Cmd {
 		t.Fatal("commandContextFn called when xcrun is missing")
@@ -1262,9 +1257,9 @@ func TestStaplerRedactsNonNotFoundXcrunLookupFailure(t *testing.T) {
 	t.Cleanup(func() { runtimeGOOS = previousOS })
 	const canary = "STAPLER_LOOKUP_PATH_CANARY_2242"
 	wantErr := errors.New("lookpath /private/tmp/" + canary + "/xcrun: permission denied")
-	previousLookPath := lookPathFn
-	lookPathFn = func(string) (string, error) { return "", wantErr }
-	t.Cleanup(func() { lookPathFn = previousLookPath })
+	previousTrustedXcrunPath := trustedXcrunPathFn
+	trustedXcrunPathFn = func() (string, error) { return "", wantErr }
+	t.Cleanup(func() { trustedXcrunPathFn = previousTrustedXcrunPath })
 
 	result, err := Staple(context.Background(), "/tmp/MyApp.dmg", nil)
 	if result != nil {
@@ -1359,9 +1354,9 @@ func TestStaplerPreservesResolutionExitStatusWhenCancellationCleanupWinsRace(t *
 	previousOS := runtimeGOOS
 	runtimeGOOS = "darwin"
 	t.Cleanup(func() { runtimeGOOS = previousOS })
-	previousLookPath := lookPathFn
-	lookPathFn = func(string) (string, error) { return "/usr/bin/xcrun", nil }
-	t.Cleanup(func() { lookPathFn = previousLookPath })
+	previousTrustedXcrunPath := trustedXcrunPathFn
+	trustedXcrunPathFn = func() (string, error) { return "/usr/bin/xcrun", nil }
+	t.Cleanup(func() { trustedXcrunPathFn = previousTrustedXcrunPath })
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -1553,12 +1548,22 @@ func configureStaplerTestEnvironment(t *testing.T, logPath string) {
 	t.Cleanup(func() { runtimeGOOS = previousOS })
 	previousLookPath := lookPathFn
 	lookPathFn = func(file string) (string, error) {
-		if file != "xcrun" {
+		if file != "xcrun" && file != "stapler" {
 			return "", fmt.Errorf("unexpected lookup %q", file)
 		}
-		return "/usr/bin/xcrun", nil
+		return "/usr/bin/" + file, nil
 	}
 	t.Cleanup(func() { lookPathFn = previousLookPath })
+	previousTrustedXcrunPath := trustedXcrunPathFn
+	trustedXcrunPathFn = func() (string, error) {
+		return lookPathFn("xcrun")
+	}
+	t.Cleanup(func() { trustedXcrunPathFn = previousTrustedXcrunPath })
+	previousTrustedXcodeToolPath := trustedXcodeToolPathFn
+	trustedXcodeToolPathFn = func(_ context.Context, tool string, _ []string) (string, error) {
+		return lookPathFn(tool)
+	}
+	t.Cleanup(func() { trustedXcodeToolPathFn = previousTrustedXcodeToolPath })
 	previousCommandContext := commandContextFn
 	commandContextFn = staplerHelperCommandContext(t, logPath)
 	t.Cleanup(func() { commandContextFn = previousCommandContext })
@@ -1568,7 +1573,7 @@ func configureStaplerTestEnvironment(t *testing.T, logPath string) {
 func staplerHelperCommandContext(t *testing.T, logPath string) func(context.Context, string, ...string) *exec.Cmd {
 	t.Helper()
 	return func(ctx context.Context, name string, args ...string) *exec.Cmd {
-		commandArgs := []string{"-test.run=TestStaplerHelperProcess", "--", name}
+		commandArgs := []string{"-test.run=TestStaplerHelperProcess", "--", filepath.Base(name)}
 		commandArgs = append(commandArgs, args...)
 		cmd := exec.CommandContext(ctx, os.Args[0], commandArgs...)
 		cmd.Env = append(os.Environ(), "GO_WANT_STAPLER_HELPER=1", "ASC_STAPLER_HELPER_LOG="+logPath)
@@ -1596,8 +1601,9 @@ func TestStaplerHelperProcess(t *testing.T) {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(2)
 	}
+	commandName := filepath.Base(args[0])
 
-	if len(args) == 3 && args[0] == "xcrun" && args[1] == "--find" && args[2] == "stapler" {
+	if len(args) == 3 && commandName == "xcrun" && args[1] == "--find" && args[2] == "stapler" {
 		if target := os.Getenv("ASC_STAPLER_SWAP_ON_FIND"); target != "" {
 			if err := os.Rename(target, target+".original"); err != nil {
 				fmt.Fprintln(os.Stderr, err)
@@ -1665,7 +1671,7 @@ func TestStaplerHelperProcess(t *testing.T) {
 		fmt.Fprintln(os.Stdout, "/usr/bin/stapler")
 		os.Exit(0)
 	}
-	if len(args) >= 4 && args[0] == "xcrun" && args[1] == "stapler" {
+	if len(args) >= 4 && commandName == "xcrun" && args[1] == "stapler" {
 		operation := strings.ToUpper(args[2][:1]) + args[2][1:]
 		if args[2] == "validate" {
 			if observationPath := os.Getenv("ASC_STAPLER_VALIDATE_OBSERVED_PATH"); observationPath != "" {
@@ -1755,7 +1761,11 @@ func appendStaplerHelperLog(path string, args []string) error {
 		return err
 	}
 	defer file.Close()
-	_, err = fmt.Fprintln(file, strings.Join(args, "|"))
+	loggedArgs := append([]string(nil), args...)
+	if len(loggedArgs) > 0 {
+		loggedArgs[0] = filepath.Base(loggedArgs[0])
+	}
+	_, err = fmt.Fprintln(file, strings.Join(loggedArgs, "|"))
 	return err
 }
 

--- a/internal/xcode/test.go
+++ b/internal/xcode/test.go
@@ -676,8 +676,8 @@ func findXctestrunPath(derivedDataPath string) string {
 }
 
 func readTestResultSummary(ctx context.Context, resultBundlePath string) (*TestSummary, error) {
-	if _, err := lookPathFn("xcrun"); err != nil {
-		if errors.Is(err, exec.ErrNotFound) {
+	if _, err := trustedXcodeToolPathFn(ctx, "xcrun", nil); err != nil {
+		if isTrustedXcodeToolUnavailable(err, "xcrun") {
 			return nil, fmt.Errorf("xcrun not available; install Xcode and ensure the active developer directory is configured")
 		}
 		return nil, fmt.Errorf("locate xcrun: %w", err)
@@ -726,14 +726,17 @@ func runXcresulttoolJSON(ctx context.Context, operation, resultBundlePath string
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	cmd := commandContextFn(ctx, "xcrun", "xcresulttool", "get", "test-results", operation, "--path", resultBundlePath, "--compact")
+	cmd, err := trustedXcodeCommand(ctx, "xcrun", []string{"xcresulttool", "get", "test-results", operation, "--path", resultBundlePath, "--compact"}, nil)
+	if err != nil {
+		return nil, err
+	}
 	var output boundedXcresulttoolOutput
 	output.limit = maxXcresulttoolOutputBytes
 	var diagnostics boundedXcresulttoolOutput
 	diagnostics.limit = maxXcresulttoolDiagnosticBytes
 	cmd.Stdout = &output
 	cmd.Stderr = &diagnostics
-	err := runXcodeCommand(cmd)
+	err = runXcodeCommand(cmd)
 	if output.exceeded {
 		if err != nil {
 			err = fmt.Errorf("xcresulttool %s output exceeds %d bytes: %w", operation, maxXcresulttoolOutputBytes, err)

--- a/internal/xcode/test_test.go
+++ b/internal/xcode/test_test.go
@@ -434,6 +434,7 @@ func TestParseTestResultSummaryPreservesFlattenedCasesWhenUnitsDiffer(t *testing
 }
 
 func TestRunXcresulttoolJSONRejectsOversizedOutput(t *testing.T) {
+	useTrustedTestCommandNames(t)
 	originalCommandContext := commandContextFn
 	t.Cleanup(func() { commandContextFn = originalCommandContext })
 	commandContextFn = func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
@@ -446,6 +447,7 @@ func TestRunXcresulttoolJSONRejectsOversizedOutput(t *testing.T) {
 }
 
 func TestRunXcresulttoolJSONPreservesBoundedDiagnostics(t *testing.T) {
+	useTrustedTestCommandNames(t)
 	originalCommandContext := commandContextFn
 	t.Cleanup(func() { commandContextFn = originalCommandContext })
 	commandContextFn = helperCommandContext(t, filepath.Join(t.TempDir(), "commands.log"))

--- a/internal/xcode/test_test.go
+++ b/internal/xcode/test_test.go
@@ -18,6 +18,15 @@ import (
 	"unicode/utf8"
 )
 
+func useLookPathAsTrustedResolver(t *testing.T) {
+	t.Helper()
+	previous := trustedXcodeToolPathFn
+	trustedXcodeToolPathFn = func(_ context.Context, tool string, _ []string) (string, error) {
+		return lookPathFn(tool)
+	}
+	t.Cleanup(func() { trustedXcodeToolPathFn = previous })
+}
+
 func TestValidateTestOptions(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -580,6 +589,7 @@ func TestParseTestResultSummaryRejectsInvalidExpectedFailureCounts(t *testing.T)
 func TestReadTestResultSummaryBoundsMergedCaseFailures(t *testing.T) {
 	originalLookPath := lookPathFn
 	originalCommandContext := commandContextFn
+	useLookPathAsTrustedResolver(t)
 	t.Cleanup(func() {
 		lookPathFn = originalLookPath
 		commandContextFn = originalCommandContext
@@ -923,6 +933,7 @@ func TestSetTestExitStatusLeavesSignalsWithoutStatus(t *testing.T) {
 func TestReadTestResultSummaryUsesCurrentXcodeOperations(t *testing.T) {
 	originalLookPath := lookPathFn
 	originalCommandContext := commandContextFn
+	useLookPathAsTrustedResolver(t)
 	t.Cleanup(func() {
 		lookPathFn = originalLookPath
 		commandContextFn = originalCommandContext
@@ -948,7 +959,7 @@ func TestReadTestResultSummaryUsesCurrentXcodeOperations(t *testing.T) {
 	if len(commands) != 2 {
 		t.Fatalf("xcresulttool command count = %d, want 2", len(commands))
 	}
-	wantPrefix := []string{"xcrun", "xcresulttool", "get", "test-results", "summary", "--path", "/tmp/Demo.xcresult", "--compact"}
+	wantPrefix := []string{"/usr/bin/xcrun", "xcresulttool", "get", "test-results", "summary", "--path", "/tmp/Demo.xcresult", "--compact"}
 	if !reflect.DeepEqual(commands[0], wantPrefix) {
 		t.Fatalf("summary command = %#v, want %#v", commands[0], wantPrefix)
 	}
@@ -960,6 +971,7 @@ func TestReadTestResultSummaryUsesCurrentXcodeOperations(t *testing.T) {
 func TestReadTestResultSummaryRetainsAggregateWhenCaseEnrichmentFails(t *testing.T) {
 	originalLookPath := lookPathFn
 	originalCommandContext := commandContextFn
+	useLookPathAsTrustedResolver(t)
 	t.Cleanup(func() {
 		lookPathFn = originalLookPath
 		commandContextFn = originalCommandContext
@@ -993,6 +1005,7 @@ func TestTestRunsActionAndParsesResult(t *testing.T) {
 	originalCommandContext := commandContextFn
 	originalRun := runXcodeTestCommand
 	originalRead := readTestResultSummaryFn
+	useLookPathAsTrustedResolver(t)
 	t.Cleanup(func() {
 		runtimeGOOS = originalRuntimeGOOS
 		lookPathFn = originalLookPath
@@ -1056,6 +1069,7 @@ func TestTestRejectsFailedPostProcessingSummary(t *testing.T) {
 	originalCommandContext := commandContextFn
 	originalRun := runXcodeTestCommand
 	originalRead := readTestResultSummaryFn
+	useLookPathAsTrustedResolver(t)
 	t.Cleanup(func() {
 		runtimeGOOS = originalRuntimeGOOS
 		lookPathFn = originalLookPath
@@ -1124,6 +1138,7 @@ func TestTestRejectsResultBundleSymlinkCreatedAfterPreflight(t *testing.T) {
 	originalCommandContext := commandContextFn
 	originalRun := runXcodeTestCommand
 	originalRead := readTestResultSummaryFn
+	useLookPathAsTrustedResolver(t)
 	t.Cleanup(func() {
 		runtimeGOOS = originalRuntimeGOOS
 		lookPathFn = originalLookPath
@@ -1172,6 +1187,7 @@ func TestTestPreservesProcessFailureAndPartialSummary(t *testing.T) {
 	originalCommandContext := commandContextFn
 	originalRun := runXcodeTestCommand
 	originalRead := readTestResultSummaryFn
+	useLookPathAsTrustedResolver(t)
 	t.Cleanup(func() {
 		runtimeGOOS = originalRuntimeGOOS
 		lookPathFn = originalLookPath
@@ -1221,6 +1237,7 @@ func TestTestRecoversPartialSummaryWithFreshPostProcessingContextAfterCancellati
 	originalCommandContext := commandContextFn
 	originalRun := runXcodeTestCommand
 	originalRead := readTestResultSummaryFn
+	useLookPathAsTrustedResolver(t)
 	t.Cleanup(func() {
 		runtimeGOOS = originalRuntimeGOOS
 		lookPathFn = originalLookPath
@@ -1292,6 +1309,7 @@ func TestTestOmitsExitStatusForContextCancellation(t *testing.T) {
 	originalLookPath := lookPathFn
 	originalCommandContext := commandContextFn
 	originalRun := runXcodeTestCommand
+	useLookPathAsTrustedResolver(t)
 	t.Cleanup(func() {
 		runtimeGOOS = originalRuntimeGOOS
 		lookPathFn = originalLookPath
@@ -1341,6 +1359,7 @@ func TestTestOmitsExitStatusForResultPostProcessingFailure(t *testing.T) {
 	originalCommandContext := commandContextFn
 	originalRun := runXcodeTestCommand
 	originalRead := readTestResultSummaryFn
+	useLookPathAsTrustedResolver(t)
 	t.Cleanup(func() {
 		runtimeGOOS = originalRuntimeGOOS
 		lookPathFn = originalLookPath
@@ -1386,6 +1405,7 @@ func TestTestRetainsAggregateWhenCaseEnrichmentFails(t *testing.T) {
 	originalCommandContext := commandContextFn
 	originalRun := runXcodeTestCommand
 	originalRead := readTestResultSummaryFn
+	useLookPathAsTrustedResolver(t)
 	t.Cleanup(func() {
 		runtimeGOOS = originalRuntimeGOOS
 		lookPathFn = originalLookPath

--- a/internal/xcode/tool_resolver.go
+++ b/internal/xcode/tool_resolver.go
@@ -55,7 +55,30 @@ func trustedXcodeCommand(ctx context.Context, tool string, args, environment []s
 	if err != nil {
 		return nil, fmt.Errorf("resolve %s: %w", tool, err)
 	}
-	return commandContextFn(ctx, pathValue, args...), nil
+	command := commandContextFn(ctx, pathValue, args...)
+	commandEnvironment, err := normalizedTrustedToolEnvironment(environment, command.Env)
+	if err != nil {
+		return nil, err
+	}
+	if commandEnvironment != nil {
+		command.Env = commandEnvironment
+	}
+	return command, nil
+}
+
+func normalizedTrustedToolEnvironment(environment, inherited []string) ([]string, error) {
+	developerDir, hasDeveloperDir := environmentValue(environment, "DEVELOPER_DIR")
+	if !hasDeveloperDir || strings.TrimSpace(developerDir) == "" {
+		if environment == nil {
+			return inherited, nil
+		}
+		return append([]string(nil), environment...), nil
+	}
+	normalizedDeveloperDir, _, _, err := normalizeToolchainDeveloperDir(developerDir)
+	if err != nil {
+		return nil, err
+	}
+	return toolchainProbeEnvironmentForCommand(environment, inherited, normalizedDeveloperDir), nil
 }
 
 func resolveTrustedXcodeToolPath(ctx context.Context, tool string, environment []string) (string, error) {

--- a/internal/xcode/tool_resolver.go
+++ b/internal/xcode/tool_resolver.go
@@ -1,0 +1,294 @@
+package xcode
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	trustedXcodeSelectPath = "/usr/bin/xcode-select"
+	trustedStaplerPath     = "/usr/bin/stapler"
+)
+
+var (
+	trustedXcrunPathFn             = resolveTrustedXcrunPath
+	trustedXcodeToolPathFn         = resolveTrustedXcodeToolPath
+	errTrustedXcodeToolUnavailable = errors.New("trusted Xcode tool is unavailable")
+)
+
+// OverrideTrustedXcrunPathForTesting replaces the trusted xcrun resolver for
+// repository integration tests that need to exercise real subprocess control.
+// The returned cleanup restores the previous resolver. Callers must not use
+// this process-global test seam from parallel tests.
+func OverrideTrustedXcrunPathForTesting(pathValue string) func() {
+	previous := trustedXcrunPathFn
+	trustedXcrunPathFn = func() (string, error) { return pathValue, nil }
+	return func() { trustedXcrunPathFn = previous }
+}
+
+// resolveTrustedXcrunPath returns the system xcrun rather than consulting
+// PATH. xcrun is the trust anchor for selecting the rest of the Xcode tools.
+func resolveTrustedXcrunPath() (string, error) {
+	info, err := statPathFn(trustedXcrunPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("%w: trusted xcrun: %w", errTrustedXcodeToolUnavailable, err)
+		}
+		return "", fmt.Errorf("trusted xcrun is unavailable: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Mode().Perm()&0o111 == 0 {
+		return "", fmt.Errorf("%w: trusted xcrun is not an executable regular file", errTrustedXcodeToolUnavailable)
+	}
+	return trustedXcrunPath, nil
+}
+
+func trustedXcodeCommand(ctx context.Context, tool string, args, environment []string) (*exec.Cmd, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	pathValue, err := trustedXcodeToolPathFn(ctx, tool, environment)
+	if err != nil {
+		return nil, fmt.Errorf("resolve %s: %w", tool, err)
+	}
+	return commandContextFn(ctx, pathValue, args...), nil
+}
+
+func resolveTrustedXcodeToolPath(ctx context.Context, tool string, environment []string) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := contextError(ctx); err != nil {
+		return "", err
+	}
+	tool = strings.TrimSpace(tool)
+	if tool == "" {
+		return "", errors.New("xcode tool name is empty")
+	}
+	if tool == "xcrun" {
+		return trustedXcrunPathFn()
+	}
+	switch tool {
+	case "xcodebuild", "agvtool", "stapler":
+	default:
+		return "", fmt.Errorf("unsupported Xcode tool %q", tool)
+	}
+
+	xcrunPath, err := trustedXcrunPathFn()
+	if err != nil {
+		return "", err
+	}
+	developerDir, err := trustedDeveloperDirectory(ctx, environment)
+	if err != nil {
+		return "", err
+	}
+	developerDir, _, _, err = normalizeToolchainDeveloperDir(developerDir)
+	if err != nil {
+		return "", err
+	}
+
+	stdout, stderr, exceeded, err := runTrustedXcrunFind(ctx, xcrunPath, tool, developerDir, environment)
+	if err != nil {
+		if detail := strings.TrimSpace(stderr); detail != "" {
+			return "", fmt.Errorf("xcrun --find %s failed: %s: %w", tool, detail, err)
+		}
+		return "", fmt.Errorf("xcrun --find %s failed: %w", tool, err)
+	}
+	if exceeded {
+		return "", fmt.Errorf("xcrun --find %s output exceeds %d bytes", tool, toolchainProbeDiagnosticLimit)
+	}
+	pathValue, err := parseTrustedToolPath(stdout, tool)
+	if err != nil {
+		return "", fmt.Errorf("xcrun --find %s: %w", tool, err)
+	}
+
+	switch tool {
+	case "xcodebuild":
+		return validateResolvedXcodebuildPath(pathValue, developerDir)
+	case "stapler":
+		return validateResolvedStaplerPath(pathValue, developerDir)
+	default:
+		return validateResolvedDeveloperToolPath(pathValue, tool, developerDir)
+	}
+}
+
+func trustedDeveloperDirectory(ctx context.Context, environment []string) (string, error) {
+	if value, ok := environmentValue(environment, "DEVELOPER_DIR"); ok {
+		if strings.TrimSpace(value) != "" {
+			return filepath.Clean(strings.TrimSpace(value)), nil
+		}
+	}
+	if environment == nil {
+		value, _, err := resolveToolchainDeveloperDir(ctx, "")
+		return value, err
+	}
+	// A caller-supplied environment is exact, so do not accidentally select a
+	// DEVELOPER_DIR inherited by the current process when it is absent there.
+	return activeDeveloperDirFromTrustedSelect(ctx, environment)
+}
+
+func activeDeveloperDirFromTrustedSelect(ctx context.Context, environment []string) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cmd := commandContextFn(ctx, trustedXcodeSelectPath, "-p")
+	if environment != nil {
+		// The caller supplied an exact environment. Preserve that boundary for
+		// xcode-select as well, so an ambient DEVELOPER_DIR cannot override it.
+		cmd.Env = append([]string(nil), environment...)
+	}
+	output, err := outputXcodeCommand(cmd)
+	if err != nil {
+		return "", err
+	}
+	value := strings.TrimSpace(string(output))
+	if value == "" {
+		return "", errors.New("xcode-select returned an empty developer directory")
+	}
+	return filepath.Clean(value), nil
+}
+
+func environmentValue(environment []string, name string) (string, bool) {
+	if environment == nil {
+		value, ok := os.LookupEnv(name)
+		return value, ok
+	}
+	prefix := name + "="
+	for _, entry := range environment {
+		if strings.HasPrefix(entry, prefix) {
+			return strings.TrimPrefix(entry, prefix), true
+		}
+	}
+	return "", false
+}
+
+func runTrustedXcrunFind(ctx context.Context, xcrunPath, tool, developerDir string, environment []string) (stdout, stderr string, exceeded bool, err error) {
+	cmd := commandContextFn(ctx, xcrunPath, "--find", tool)
+	cmd.Env = toolchainProbeEnvironmentForCommand(environment, cmd.Env, developerDir)
+	stdoutBuffer := newBoundedToolOutput(toolchainProbeDiagnosticLimit)
+	stderrBuffer := newBoundedToolOutput(toolchainProbeDiagnosticLimit)
+	cmd.Stdout = stdoutBuffer
+	cmd.Stderr = stderrBuffer
+	err = runXcodeCommand(cmd)
+	if ctxErr := ctx.Err(); err != nil && ctxErr != nil {
+		err = ctxErr
+	}
+	return stdoutBuffer.String(), stderrBuffer.String(), stdoutBuffer.exceeded || stderrBuffer.exceeded, err
+}
+
+func toolchainProbeEnvironmentForCommand(environment, inherited []string, developerDir string) []string {
+	base := environment
+	if base == nil {
+		base = inherited
+	}
+	if base == nil {
+		base = os.Environ()
+	}
+	result := make([]string, 0, len(base)+1)
+	for _, entry := range base {
+		if strings.HasPrefix(entry, "DEVELOPER_DIR=") {
+			continue
+		}
+		result = append(result, entry)
+	}
+	return append(result, "DEVELOPER_DIR="+developerDir)
+}
+
+func parseTrustedToolPath(output, tool string) (string, error) {
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" {
+		return "", errors.New("resolver returned an empty path")
+	}
+	if strings.ContainsAny(trimmed, "\x00\r\n") {
+		return "", errors.New("resolver returned multiple or invalid paths")
+	}
+	if !filepath.IsAbs(trimmed) {
+		return "", fmt.Errorf("resolver returned a non-absolute %s path %q", tool, trimmed)
+	}
+	return filepath.Clean(trimmed), nil
+}
+
+func validateResolvedDeveloperToolPath(pathValue, tool, developerDir string) (string, error) {
+	if !strings.EqualFold(filepath.Base(pathValue), tool) {
+		return "", fmt.Errorf("xcrun returned an unexpected executable path %q", pathValue)
+	}
+	canonicalDeveloperDir, err := filepath.EvalSymlinks(developerDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve selected developer directory symlinks: %w", err)
+	}
+	canonicalPath, err := filepath.EvalSymlinks(pathValue)
+	if err != nil {
+		if !pathWithinDirectoryFold(canonicalDeveloperDir, pathValue) {
+			return "", fmt.Errorf("xcrun resolved %s outside selected developer directory %q", tool, canonicalDeveloperDir)
+		}
+		return "", fmt.Errorf("resolved %s path %q is unavailable: %w", tool, pathValue, err)
+	}
+	contained, err := pathIdentityWithinDirectory(filepath.Clean(canonicalDeveloperDir), filepath.Clean(canonicalPath))
+	if err != nil {
+		return "", fmt.Errorf("compare %s path with developer directory: %w", tool, err)
+	}
+	if !contained {
+		return "", fmt.Errorf("xcrun resolved %s outside selected developer directory %q", tool, canonicalDeveloperDir)
+	}
+	info, err := statPathFn(filepath.Clean(canonicalPath))
+	if err != nil {
+		return "", fmt.Errorf("resolved %s path %q is unavailable: %w", tool, canonicalPath, err)
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("resolved %s path %q is not a regular file", tool, canonicalPath)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		return "", fmt.Errorf("resolved %s path %q is not executable", tool, canonicalPath)
+	}
+	return pathValue, nil
+}
+
+func validateResolvedStaplerPath(pathValue, developerDir string) (string, error) {
+	if filepath.Clean(pathValue) == trustedStaplerPath {
+		return trustedStaplerPath, nil
+	}
+	return validateResolvedDeveloperToolPath(pathValue, "stapler", developerDir)
+}
+
+func isTrustedXcodeToolUnavailable(err error, _ string) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, exec.ErrNotFound) || errors.Is(err, errTrustedXcodeToolUnavailable)
+}
+
+type boundedToolOutput struct {
+	data     []byte
+	limit    int
+	exceeded bool
+}
+
+func newBoundedToolOutput(limit int) *boundedToolOutput {
+	return &boundedToolOutput{limit: limit}
+}
+
+func (b *boundedToolOutput) Write(data []byte) (int, error) {
+	if len(data) == 0 {
+		return 0, nil
+	}
+	remaining := b.limit - len(b.data)
+	if remaining <= 0 {
+		b.exceeded = true
+		return len(data), nil
+	}
+	if len(data) > remaining {
+		b.data = append(b.data, data[:remaining]...)
+		b.exceeded = true
+		return len(data), nil
+	}
+	b.data = append(b.data, data...)
+	return len(data), nil
+}
+
+func (b *boundedToolOutput) String() string {
+	return string(b.data)
+}

--- a/internal/xcode/tool_resolver_test.go
+++ b/internal/xcode/tool_resolver_test.go
@@ -181,6 +181,38 @@ func TestTrustedXcodeCommandUsesResolvedAbsolutePath(t *testing.T) {
 	}
 }
 
+func TestTrustedXcodeCommandNormalizesRelativeDeveloperDirectoryBeforeChildChangesDirectory(t *testing.T) {
+	developerDir := filepath.Join(t.TempDir(), "Developer")
+	if err := os.MkdirAll(developerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	workingDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	relativeDeveloperDir, err := filepath.Rel(workingDir, developerDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEVELOPER_DIR", relativeDeveloperDir)
+
+	previousResolver := trustedXcodeToolPathFn
+	trustedXcodeToolPathFn = func(context.Context, string, []string) (string, error) {
+		return "/usr/bin/xcodebuild", nil
+	}
+	t.Cleanup(func() { trustedXcodeToolPathFn = previousResolver })
+
+	cmd, err := trustedXcodeCommand(t.Context(), "xcodebuild", []string{"-version"}, nil)
+	if err != nil {
+		t.Fatalf("trustedXcodeCommand() error: %v", err)
+	}
+	cmd.Dir = t.TempDir()
+	got, ok := environmentValue(cmd.Env, "DEVELOPER_DIR")
+	if !ok || got != developerDir {
+		t.Fatalf("child DEVELOPER_DIR = %q, %t; want %q", got, ok, developerDir)
+	}
+}
+
 func TestRunXcodebuildUsesTrustedResolvedPath(t *testing.T) {
 	const wantPath = "/selected/Xcode.app/Contents/Developer/usr/bin/xcodebuild"
 	previousResolver := trustedXcodeToolPathFn

--- a/internal/xcode/tool_resolver_test.go
+++ b/internal/xcode/tool_resolver_test.go
@@ -1,0 +1,333 @@
+package xcode
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestResolveTrustedXcodeToolUsesTrustedXcrunAndSelectedDeveloperDir(t *testing.T) {
+	developerDir := filepath.Join(t.TempDir(), "Xcode.app", "Contents", "Developer")
+	for _, tool := range []string{"xcodebuild", "agvtool"} {
+		pathValue := filepath.Join(developerDir, "usr", "bin", tool)
+		if err := os.MkdirAll(filepath.Dir(pathValue), 0o755); err != nil {
+			t.Fatalf("MkdirAll() error: %v", err)
+		}
+		if err := os.WriteFile(pathValue, []byte("tool"), 0o755); err != nil {
+			t.Fatalf("WriteFile() error: %v", err)
+		}
+	}
+
+	trustedPath := filepath.Join(t.TempDir(), "trusted-xcrun")
+	var calls []struct {
+		name string
+		args []string
+		cmd  *exec.Cmd
+	}
+	previousXcrunPath := trustedXcrunPathFn
+	previousCommandContext := commandContextFn
+	trustedXcrunPathFn = func() (string, error) { return trustedPath, nil }
+	commandContextFn = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		calls = append(calls, struct {
+			name string
+			args []string
+			cmd  *exec.Cmd
+		}{name: name, args: append([]string(nil), args...)})
+		cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestTrustedToolResolverHelperProcess", "--")
+		cmd.Env = append(os.Environ(), "GO_WANT_TRUSTED_TOOL_RESOLVER_HELPER=1", "TRUSTED_TOOL_RESOLVER_OUTPUT="+filepath.Join(developerDir, "usr", "bin", args[len(args)-1]))
+		calls[len(calls)-1].cmd = cmd
+		return cmd
+	}
+	t.Cleanup(func() {
+		trustedXcrunPathFn = previousXcrunPath
+		commandContextFn = previousCommandContext
+	})
+
+	pathValue, err := resolveTrustedXcodeToolPath(context.Background(), "xcodebuild", []string{
+		"PATH=/tmp/path-shadow",
+		"DEVELOPER_DIR=" + developerDir,
+		"GO_WANT_TRUSTED_TOOL_RESOLVER_HELPER=1",
+		"TRUSTED_TOOL_RESOLVER_OUTPUT=" + filepath.Join(developerDir, "usr", "bin", "xcodebuild"),
+	})
+	if err != nil {
+		t.Fatalf("resolveTrustedXcodeToolPath() error: %v", err)
+	}
+	wantPath := filepath.Join(developerDir, "usr", "bin", "xcodebuild")
+	if pathValue != wantPath {
+		t.Fatalf("resolved path = %q, want %q", pathValue, wantPath)
+	}
+	if len(calls) != 1 || calls[0].name != trustedPath {
+		t.Fatalf("resolver calls = %#v, want one call through %q", calls, trustedPath)
+	}
+	if len(calls[0].args) != 2 || calls[0].args[0] != "--find" || calls[0].args[1] != "xcodebuild" {
+		t.Fatalf("resolver args = %#v, want --find xcodebuild", calls[0].args)
+	}
+	if !containsDeveloperDirectoryValue(calls[0].cmd.Env, developerDir) {
+		t.Fatalf("resolver environment = %#v, want selected developer directory", calls[0].cmd.Env)
+	}
+	agvtoolPath, err := resolveTrustedXcodeToolPath(context.Background(), "agvtool", []string{
+		"PATH=/tmp/path-shadow",
+		"DEVELOPER_DIR=" + developerDir,
+		"GO_WANT_TRUSTED_TOOL_RESOLVER_HELPER=1",
+		"TRUSTED_TOOL_RESOLVER_OUTPUT=" + filepath.Join(developerDir, "usr", "bin", "agvtool"),
+	})
+	if err != nil {
+		t.Fatalf("resolveTrustedXcodeToolPath(agvtool) error: %v", err)
+	}
+	if want := filepath.Join(developerDir, "usr", "bin", "agvtool"); agvtoolPath != want {
+		t.Fatalf("resolved agvtool path = %q, want %q", agvtoolPath, want)
+	}
+}
+
+func TestTrustedToolUnavailableClassificationPreservesToolchainConfigurationErrors(t *testing.T) {
+	configurationErr := errors.New(`selected developer directory "/missing/Xcode.app" is unavailable`)
+	if isTrustedXcodeToolUnavailable(configurationErr, "xcodebuild") {
+		t.Fatal("selected developer directory error was classified as a missing xcodebuild")
+	}
+	if !isTrustedXcodeToolUnavailable(fmt.Errorf("resolve xcodebuild: %w", errTrustedXcodeToolUnavailable), "xcodebuild") {
+		t.Fatal("typed trusted-tool error was not classified as unavailable")
+	}
+	if !isTrustedXcodeToolUnavailable(exec.ErrNotFound, "xcodebuild") {
+		t.Fatal("exec.ErrNotFound was not classified as unavailable")
+	}
+}
+
+func TestResolveTrustedXcodeToolRejectsPathOutsideSelectedDeveloperDir(t *testing.T) {
+	developerDir := filepath.Join(t.TempDir(), "Selected.app", "Contents", "Developer")
+	if err := os.MkdirAll(developerDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error: %v", err)
+	}
+	outsidePath := filepath.Join(t.TempDir(), "Other.app", "Contents", "Developer", "usr", "bin", "xcodebuild")
+	if err := os.MkdirAll(filepath.Dir(outsidePath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error: %v", err)
+	}
+	if err := os.WriteFile(outsidePath, []byte("shadow"), 0o755); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	previousXcrunPath := trustedXcrunPathFn
+	previousCommandContext := commandContextFn
+	trustedXcrunPathFn = func() (string, error) { return "/trusted/xcrun", nil }
+	commandContextFn = func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+		cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestTrustedToolResolverHelperProcess", "--")
+		cmd.Env = append(os.Environ(), "GO_WANT_TRUSTED_TOOL_RESOLVER_HELPER=1", "TRUSTED_TOOL_RESOLVER_OUTPUT="+outsidePath)
+		return cmd
+	}
+	t.Cleanup(func() {
+		trustedXcrunPathFn = previousXcrunPath
+		commandContextFn = previousCommandContext
+	})
+
+	_, err := resolveTrustedXcodeToolPath(context.Background(), "xcodebuild", []string{
+		"DEVELOPER_DIR=" + developerDir,
+		"GO_WANT_TRUSTED_TOOL_RESOLVER_HELPER=1",
+		"TRUSTED_TOOL_RESOLVER_OUTPUT=" + outsidePath,
+	})
+	if err == nil || !strings.Contains(err.Error(), "outside selected developer directory") {
+		t.Fatalf("resolveTrustedXcodeToolPath() error = %v, want containment rejection", err)
+	}
+}
+
+func TestParseTrustedToolPathRejectsMalformedResolverOutput(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		output string
+	}{
+		{name: "empty", output: ""},
+		{name: "relative", output: "usr/bin/xcodebuild"},
+		{name: "multiple paths", output: "/Xcode/usr/bin/xcodebuild\n/tmp/shadow/xcodebuild"},
+		{name: "nul", output: "/Xcode/usr/bin/xcodebuild\x00"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := parseTrustedToolPath(test.output, "xcodebuild"); err == nil {
+				t.Fatalf("parseTrustedToolPath(%q) succeeded, want rejection", test.output)
+			}
+		})
+	}
+}
+
+func TestTrustedXcodeCommandUsesResolvedAbsolutePath(t *testing.T) {
+	const wantPath = "/selected/Xcode.app/Contents/Developer/usr/bin/xcodebuild"
+	previousResolver := trustedXcodeToolPathFn
+	previousCommandContext := commandContextFn
+	trustedXcodeToolPathFn = func(_ context.Context, tool string, _ []string) (string, error) {
+		if tool != "xcodebuild" {
+			return "", fmt.Errorf("unexpected tool %q", tool)
+		}
+		return wantPath, nil
+	}
+	var gotPath string
+	commandContextFn = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		gotPath = name
+		return exec.CommandContext(ctx, os.Args[0], "-test.run=TestTrustedToolResolverHelperProcess", "--")
+	}
+	t.Cleanup(func() {
+		trustedXcodeToolPathFn = previousResolver
+		commandContextFn = previousCommandContext
+	})
+
+	cmd, err := trustedXcodeCommand(context.Background(), "xcodebuild", []string{"-version"}, nil)
+	if err != nil {
+		t.Fatalf("trustedXcodeCommand() error: %v", err)
+	}
+	if gotPath != wantPath || cmd == nil {
+		t.Fatalf("trustedXcodeCommand() path = %q, want %q", gotPath, wantPath)
+	}
+}
+
+func TestRunXcodebuildUsesTrustedResolvedPath(t *testing.T) {
+	const wantPath = "/selected/Xcode.app/Contents/Developer/usr/bin/xcodebuild"
+	previousResolver := trustedXcodeToolPathFn
+	previousCommandContext := commandContextFn
+	trustedXcodeToolPathFn = func(_ context.Context, tool string, _ []string) (string, error) {
+		if tool != "xcodebuild" {
+			return "", fmt.Errorf("unexpected tool %q", tool)
+		}
+		return wantPath, nil
+	}
+	var gotPath string
+	commandContextFn = func(ctx context.Context, name string, _ ...string) *exec.Cmd {
+		gotPath = name
+		return exec.CommandContext(ctx, "true")
+	}
+	t.Cleanup(func() {
+		trustedXcodeToolPathFn = previousResolver
+		commandContextFn = previousCommandContext
+	})
+
+	if err := runXcodebuild(context.Background(), []string{"-version"}, nil); err != nil {
+		t.Fatalf("runXcodebuild() error: %v", err)
+	}
+	if gotPath != wantPath {
+		t.Fatalf("runXcodebuild() path = %q, want %q", gotPath, wantPath)
+	}
+}
+
+func TestResolveTrustedXcrunPathDoesNotConsultPATH(t *testing.T) {
+	previousStatPath := statPathFn
+	previousLookPath := lookPathFn
+	statPathFn = func(path string) (os.FileInfo, error) {
+		if path != trustedXcrunPath {
+			return nil, errors.New("unexpected stat path")
+		}
+		return fakeExecutableInfo{}, nil
+	}
+	lookPathFn = func(string) (string, error) {
+		t.Fatal("lookPathFn must not be consulted for trusted xcrun")
+		return "", nil
+	}
+	t.Cleanup(func() {
+		statPathFn = previousStatPath
+		lookPathFn = previousLookPath
+	})
+
+	pathValue, err := resolveToolchainXcrunPath()
+	if err != nil {
+		t.Fatalf("resolveToolchainXcrunPath() error: %v", err)
+	}
+	if pathValue != trustedXcrunPath {
+		t.Fatalf("resolveToolchainXcrunPath() = %q, want %q", pathValue, trustedXcrunPath)
+	}
+}
+
+func TestActiveDeveloperDirFromTrustedSelectUsesExactEnvironment(t *testing.T) {
+	t.Setenv("DEVELOPER_DIR", "/ambient/Xcode.app/Contents/Developer")
+	const want = "/selected/Xcode.app/Contents/Developer"
+	exactEnvironment := []string{
+		"GO_WANT_TRUSTED_TOOL_RESOLVER_HELPER=1",
+		"TRUSTED_TOOL_RESOLVER_OUTPUT=" + want,
+	}
+	previousCommandContext := commandContextFn
+	var command *exec.Cmd
+	commandContextFn = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		if name != trustedXcodeSelectPath || len(args) != 1 || args[0] != "-p" {
+			t.Fatalf("xcode-select command = %q %#v", name, args)
+		}
+		command = exec.CommandContext(ctx, os.Args[0], "-test.run=TestTrustedToolResolverHelperProcess", "--")
+		return command
+	}
+	t.Cleanup(func() { commandContextFn = previousCommandContext })
+
+	got, err := activeDeveloperDirFromTrustedSelect(context.Background(), exactEnvironment)
+	if err != nil {
+		t.Fatalf("activeDeveloperDirFromTrustedSelect() error: %v", err)
+	}
+	if got != want {
+		t.Fatalf("active developer directory = %q, want %q", got, want)
+	}
+	if command == nil || containsDeveloperDirectoryValue(command.Env, "/ambient/Xcode.app/Contents/Developer") {
+		t.Fatalf("xcode-select inherited ambient DEVELOPER_DIR: %#v", command)
+	}
+	if len(command.Env) != len(exactEnvironment) {
+		t.Fatalf("xcode-select environment = %#v, want exact %#v", command.Env, exactEnvironment)
+	}
+}
+
+func TestTrustedDeveloperDirectoryTreatsEmptyOverrideAsUnset(t *testing.T) {
+	t.Setenv("DEVELOPER_DIR", "/ambient/Xcode.app/Contents/Developer")
+	const want = "/selected/Xcode.app/Contents/Developer"
+	exactEnvironment := []string{
+		"DEVELOPER_DIR=",
+		"GO_WANT_TRUSTED_TOOL_RESOLVER_HELPER=1",
+		"TRUSTED_TOOL_RESOLVER_OUTPUT=" + want,
+	}
+	previousCommandContext := commandContextFn
+	var command *exec.Cmd
+	commandContextFn = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		if name != trustedXcodeSelectPath || len(args) != 1 || args[0] != "-p" {
+			t.Fatalf("xcode-select command = %q %#v", name, args)
+		}
+		command = exec.CommandContext(ctx, os.Args[0], "-test.run=TestTrustedToolResolverHelperProcess", "--")
+		return command
+	}
+	t.Cleanup(func() { commandContextFn = previousCommandContext })
+
+	got, err := trustedDeveloperDirectory(context.Background(), exactEnvironment)
+	if err != nil {
+		t.Fatalf("trustedDeveloperDirectory() error: %v", err)
+	}
+	if got != want {
+		t.Fatalf("trusted developer directory = %q, want %q", got, want)
+	}
+	if command == nil || !containsDeveloperDirectoryValue(command.Env, "") {
+		t.Fatalf("xcode-select environment = %#v, want explicit empty DEVELOPER_DIR", command)
+	}
+	if containsDeveloperDirectoryValue(command.Env, "/ambient/Xcode.app/Contents/Developer") {
+		t.Fatalf("xcode-select inherited ambient DEVELOPER_DIR: %#v", command.Env)
+	}
+}
+
+type fakeExecutableInfo struct{}
+
+func (fakeExecutableInfo) Name() string       { return "xcrun" }
+func (fakeExecutableInfo) Size() int64        { return 1 }
+func (fakeExecutableInfo) Mode() os.FileMode  { return 0o755 }
+func (fakeExecutableInfo) ModTime() time.Time { return time.Time{} }
+func (fakeExecutableInfo) IsDir() bool        { return false }
+func (fakeExecutableInfo) Sys() any           { return nil }
+
+func containsDeveloperDirectoryValue(environment []string, want string) bool {
+	const prefix = "DEVELOPER_DIR="
+	for _, entry := range environment {
+		if strings.HasPrefix(entry, prefix) && strings.TrimPrefix(entry, prefix) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestTrustedToolResolverHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_TRUSTED_TOOL_RESOLVER_HELPER") != "1" {
+		return
+	}
+	if output := os.Getenv("TRUSTED_TOOL_RESOLVER_OUTPUT"); output != "" {
+		fmt.Fprintln(os.Stdout, output)
+	}
+	os.Exit(0)
+}

--- a/internal/xcode/toolchain.go
+++ b/internal/xcode/toolchain.go
@@ -188,7 +188,7 @@ func InspectToolchain(ctx context.Context, opts ToolchainOptions) (*ToolchainRep
 	var xcrunCheck ToolchainCheck
 	var xcrunCheckErr error
 	if xcrunLookupErr != nil {
-		message := "xcrun is not available in PATH"
+		message := "trusted xcrun is not available"
 		if !errors.Is(xcrunLookupErr, exec.ErrNotFound) {
 			message = sanitizeToolchainError(fmt.Errorf("locate xcrun: %w", xcrunLookupErr))
 		}
@@ -395,26 +395,7 @@ func classifyBetaXcodePath(developerDir, xcodePath string) (*bool, error) {
 }
 
 func resolveToolchainXcrunPath() (string, error) {
-	if info, err := statPathFn(trustedXcrunPath); err == nil && info.Mode().IsRegular() && info.Mode().Perm()&0o111 != 0 {
-		return trustedXcrunPath, nil
-	}
-
-	pathValue, err := lookPathFn("xcrun")
-	if err != nil {
-		return "", err
-	}
-	pathValue = strings.TrimSpace(pathValue)
-	if pathValue == "" {
-		return "", errors.New("xcrun path is empty")
-	}
-	if !filepath.IsAbs(pathValue) {
-		return "", fmt.Errorf("xcrun path %q is not absolute", pathValue)
-	}
-	pathValue = filepath.Clean(pathValue)
-	if filepath.Base(pathValue) != "xcrun" {
-		return "", fmt.Errorf("xcrun path %q has unexpected executable name", pathValue)
-	}
-	return pathValue, nil
+	return trustedXcrunPathFn()
 }
 
 func validateResolvedXcodebuildPath(pathValue, developerDir string) (string, error) {
@@ -458,8 +439,8 @@ func validateResolvedXcodebuildPath(pathValue, developerDir string) (string, err
 	if err != nil {
 		return "", fmt.Errorf("resolved xcodebuild path %q is unavailable: %w", canonicalPath, err)
 	}
-	if info.IsDir() {
-		return "", fmt.Errorf("resolved xcodebuild path %q is a directory", canonicalPath)
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("resolved xcodebuild path %q is not a regular file", canonicalPath)
 	}
 	if info.Mode().Perm()&0o111 == 0 {
 		return "", fmt.Errorf("resolved xcodebuild path %q is not executable", canonicalPath)

--- a/internal/xcode/version.go
+++ b/internal/xcode/version.go
@@ -229,7 +229,7 @@ func getVersionLegacy(
 	if err := requireMacOS(); err != nil {
 		return nil, err
 	}
-	if err := requireAgvtool(); err != nil {
+	if err := requireAgvtool(ctx); err != nil {
 		return nil, err
 	}
 
@@ -328,11 +328,11 @@ func ValidateSetVersion(opts SetVersionOptions) error {
 	if strings.TrimSpace(opts.Target) != "" || strings.TrimSpace(opts.Configuration) != "" {
 		return fmt.Errorf("scoped edits require structured Xcode build settings: %w", structuredErr)
 	}
-	return validateSetVersionLegacy()
+	return validateSetVersionLegacy(context.Background())
 }
 
 func setVersionLegacy(ctx context.Context, opts SetVersionOptions) (*SetVersionResult, error) {
-	if err := validateSetVersionLegacy(); err != nil {
+	if err := validateSetVersionLegacy(ctx); err != nil {
 		return nil, err
 	}
 	if strings.TrimSpace(opts.Target) != "" {
@@ -358,11 +358,11 @@ func setVersionLegacy(ctx context.Context, opts SetVersionOptions) (*SetVersionR
 	return result, nil
 }
 
-func validateSetVersionLegacy() error {
+func validateSetVersionLegacy(ctx context.Context) error {
 	if err := requireMacOS(); err != nil {
 		return err
 	}
-	return requireAgvtool()
+	return requireAgvtool(ctx)
 }
 
 func attachBuildSettingsLookupSession(opts *BumpVersionOptions) error {
@@ -444,7 +444,7 @@ func ValidateBumpVersion(ctx context.Context, opts BumpVersionOptions) error {
 	if strings.TrimSpace(opts.Target) != "" || strings.TrimSpace(opts.Configuration) != "" {
 		return fmt.Errorf("scoped bumps require structured Xcode build settings: %w", structuredErr)
 	}
-	if err := validateSetVersionLegacy(); err != nil {
+	if err := validateSetVersionLegacy(ctx); err != nil {
 		return err
 	}
 	current, err := getVersionLegacy(ctx, opts.ProjectDir, "", opts.BuildSettingsSession)
@@ -542,7 +542,7 @@ func bumpVersionLegacy(ctx context.Context, opts BumpVersionOptions) (*BumpVersi
 	if err := requireMacOS(); err != nil {
 		return nil, err
 	}
-	if err := requireAgvtool(); err != nil {
+	if err := requireAgvtool(ctx); err != nil {
 		return nil, err
 	}
 	trimmedTarget := strings.TrimSpace(opts.Target)
@@ -600,16 +600,25 @@ func requireMacOS() error {
 	return nil
 }
 
-func requireAgvtool() error {
-	_, err := lookPathFn("agvtool")
+func requireAgvtool(ctx context.Context) error {
+	_, err := trustedXcodeToolPathFn(ctx, "agvtool", nil)
 	if err != nil {
+		if contextErr := contextError(ctx); contextErr != nil {
+			return contextErr
+		}
+		if !isTrustedXcodeToolUnavailable(err, "agvtool") {
+			return fmt.Errorf("resolve agvtool: %w", err)
+		}
 		return fmt.Errorf("agvtool not found: install Xcode command-line tools")
 	}
 	return nil
 }
 
 func runAgvtool(ctx context.Context, projectDir string, args ...string) (string, error) {
-	cmd := commandContextFn(ctx, "agvtool", args...)
+	cmd, err := trustedXcodeCommand(ctx, "agvtool", args, nil)
+	if err != nil {
+		return "", err
+	}
 	cmd.Dir = resolvedProjectDir(projectDir)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -663,7 +672,10 @@ func readBuildSettings(
 		}
 		lookupSession.warned = true
 	}
-	cmd := commandContextFn(ctx, "xcodebuild", args...)
+	cmd, err := trustedXcodeCommand(ctx, "xcodebuild", args, nil)
+	if err != nil {
+		return nil, err
+	}
 	cmd.Dir = resolvedProjectDir(projectDir)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/internal/xcode/version.go
+++ b/internal/xcode/version.go
@@ -305,7 +305,7 @@ func SetVersion(ctx context.Context, opts SetVersionOptions) (*SetVersionResult,
 
 // ValidateSetVersion verifies that a version mutation is locally valid and
 // editable without changing any files. Callers can use it before remote work.
-func ValidateSetVersion(opts SetVersionOptions) error {
+func ValidateSetVersion(ctx context.Context, opts SetVersionOptions) error {
 	if err := validateVersionMutationValue("--version", opts.Version); err != nil {
 		return err
 	}
@@ -328,7 +328,7 @@ func ValidateSetVersion(opts SetVersionOptions) error {
 	if strings.TrimSpace(opts.Target) != "" || strings.TrimSpace(opts.Configuration) != "" {
 		return fmt.Errorf("scoped edits require structured Xcode build settings: %w", structuredErr)
 	}
-	return validateSetVersionLegacy(context.Background())
+	return validateSetVersionLegacy(ctx)
 }
 
 func setVersionLegacy(ctx context.Context, opts SetVersionOptions) (*SetVersionResult, error) {

--- a/internal/xcode/version_structured_test.go
+++ b/internal/xcode/version_structured_test.go
@@ -1038,7 +1038,7 @@ func TestValidateSetVersionDoesNotMutateProjectOrXCConfig(t *testing.T) {
 	pbxprojBefore := mustReadVersionTestFile(t, pbxprojPath)
 	xcconfigBefore := mustReadVersionTestFile(t, xcconfigPath)
 
-	err := ValidateSetVersion(SetVersionOptions{
+	err := ValidateSetVersion(t.Context(), SetVersionOptions{
 		ProjectDir:    project,
 		Target:        "App",
 		Configuration: "Release",
@@ -1361,7 +1361,7 @@ func TestStructuredVersion_ScopedConditionalSharedSettingDoesNotReportFalseSucce
 		ProjectDir: project, Target: "App", Configuration: "Release", Version: "2.0.0",
 	}
 
-	if err := ValidateSetVersion(setOptions); err == nil || !strings.Contains(err.Error(), "conditional") {
+	if err := ValidateSetVersion(t.Context(), setOptions); err == nil || !strings.Contains(err.Error(), "conditional") {
 		t.Fatalf("expected conditional-only scoped preflight error, got %v", err)
 	}
 	if got := mustReadVersionTestFile(t, sharedPath); got != conditional {

--- a/internal/xcode/version_test.go
+++ b/internal/xcode/version_test.go
@@ -36,6 +36,34 @@ func TestGetVersionLegacyHonorsCanceledContextDuringAgvtoolResolution(t *testing
 	}
 }
 
+func TestValidateSetVersionLegacyHonorsCanceledContextDuringAgvtoolResolution(t *testing.T) {
+	projectDir := writeLegacyVersionProject(t)
+	restore := overrideTestEnvironment(t)
+	runtimeGOOS = "darwin"
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	resolverCalled := false
+	trustedXcodeToolPathFn = func(got context.Context, tool string, _ []string) (string, error) {
+		resolverCalled = true
+		if tool != "agvtool" {
+			t.Fatalf("tool = %q, want agvtool", tool)
+		}
+		return "", got.Err()
+	}
+	t.Cleanup(restore)
+
+	err := ValidateSetVersion(ctx, SetVersionOptions{
+		ProjectDir:  projectDir,
+		BuildNumber: "1",
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("ValidateSetVersion() error = %v, want context.Canceled", err)
+	}
+	if !resolverCalled {
+		t.Fatal("agvtool resolver was not called")
+	}
+}
+
 func TestGetVersion_NotMacOS(t *testing.T) {
 	projectDir := writeLegacyVersionProject(t)
 	prev := runtimeGOOS

--- a/internal/xcode/version_test.go
+++ b/internal/xcode/version_test.go
@@ -3,12 +3,38 @@ package xcode
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestGetVersionLegacyHonorsCanceledContextDuringAgvtoolResolution(t *testing.T) {
+	projectDir := writeLegacyVersionProject(t)
+	restore := overrideTestEnvironment(t)
+	runtimeGOOS = "darwin"
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	resolverCalled := false
+	trustedXcodeToolPathFn = func(got context.Context, tool string, _ []string) (string, error) {
+		resolverCalled = true
+		if tool != "agvtool" {
+			t.Fatalf("tool = %q, want agvtool", tool)
+		}
+		return "", got.Err()
+	}
+	t.Cleanup(restore)
+
+	_, err := getVersionLegacy(ctx, projectDir, "", nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("getVersionLegacy() error = %v, want context.Canceled", err)
+	}
+	if !resolverCalled {
+		t.Fatal("agvtool resolver was not called")
+	}
+}
 
 func TestGetVersion_NotMacOS(t *testing.T) {
 	projectDir := writeLegacyVersionProject(t)
@@ -48,11 +74,11 @@ func TestBumpVersion_NotMacOS(t *testing.T) {
 
 func TestGetVersion_MissingAgvtool(t *testing.T) {
 	projectDir := writeLegacyVersionProject(t)
-	prev := lookPathFn
-	lookPathFn = func(file string) (string, error) {
+	prev := trustedXcodeToolPathFn
+	trustedXcodeToolPathFn = func(context.Context, string, []string) (string, error) {
 		return "", exec.ErrNotFound
 	}
-	defer func() { lookPathFn = prev }()
+	defer func() { trustedXcodeToolPathFn = prev }()
 
 	prevOS := runtimeGOOS
 	runtimeGOOS = "darwin"
@@ -501,7 +527,7 @@ func TestGetVersionScopedAutoWarnsBeforeXcodebuildSettingsFallback(t *testing.T)
 	lookPathFn = func(file string) (string, error) { return "/usr/bin/" + file, nil }
 	helpers := helperCommandContext(t, logPath)
 	commandContextFn = func(ctx context.Context, name string, args ...string) *exec.Cmd {
-		if name == "xcodebuild" && len(args) > 0 && args[0] == "-showBuildSettings" {
+		if filepath.Base(name) == "xcodebuild" && len(args) > 0 && args[0] == "-showBuildSettings" {
 			warning := diagnostic.String()
 			for _, want := range []string{marketingVersionSetting, currentProjectSetting, "--xcodebuild-settings-lookup never"} {
 				if !strings.Contains(warning, want) {

--- a/internal/xcode/version_xcconfig_containment_test.go
+++ b/internal/xcode/version_xcconfig_containment_test.go
@@ -69,7 +69,7 @@ func TestValidateSetVersionRefusesExternalXCConfigByDefault(t *testing.T) {
 	externalPath := filepath.Join(externalDir, "Shared.xcconfig")
 	before := mustReadVersionTestFile(t, externalPath)
 
-	err := ValidateSetVersion(SetVersionOptions{
+	err := ValidateSetVersion(t.Context(), SetVersionOptions{
 		ProjectDir:  projectPath,
 		BuildNumber: "1",
 	})

--- a/internal/xcode/xcode.go
+++ b/internal/xcode/xcode.go
@@ -1520,9 +1520,6 @@ func runCommandWithBoundedOutputEnvironmentMode(ctx context.Context, name string
 	if err != nil {
 		return err
 	}
-	if environment != nil {
-		cmd.Env = cloneEnvironment(environment)
-	}
 	outputWindow := newXcodeDiagnosticBuffer(xcodebuildErrorTailLimit, logWriter)
 	cmd.Stdout = outputWindow
 	cmd.Stderr = outputWindow

--- a/internal/xcode/xcode.go
+++ b/internal/xcode/xcode.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/infoplist"
 	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/secureopen"
 )
 
 var (
@@ -417,8 +418,8 @@ func Validate(ctx context.Context, opts ValidateOptions) (*ValidateResult, error
 	if err := ensureXcodeAvailable(ctx); err != nil {
 		return nil, err
 	}
-	if _, err := lookPathFn("xcrun"); err != nil {
-		if errors.Is(err, exec.ErrNotFound) {
+	if _, err := trustedXcodeToolPathFn(ctx, "xcrun", nil); err != nil {
+		if isTrustedXcodeToolUnavailable(err, "xcrun") {
 			return nil, fmt.Errorf("xcrun not available; install Xcode and ensure the active developer directory is configured")
 		}
 		return nil, fmt.Errorf("locate xcrun: %w", err)
@@ -459,8 +460,8 @@ func BuildStatus(ctx context.Context, opts BuildStatusOptions) (*BuildStatusResu
 	if err := ensureXcodeAvailable(ctx); err != nil {
 		return nil, err
 	}
-	if _, err := lookPathFn("xcrun"); err != nil {
-		if errors.Is(err, exec.ErrNotFound) {
+	if _, err := trustedXcodeToolPathFn(ctx, "xcrun", nil); err != nil {
+		if isTrustedXcodeToolUnavailable(err, "xcrun") {
 			return nil, fmt.Errorf("xcrun not available; install Xcode and ensure the active developer directory is configured")
 		}
 		return nil, fmt.Errorf("locate xcrun: %w", err)
@@ -740,13 +741,10 @@ func ensureXcodeAvailableWithEnvironment(ctx context.Context, environment []stri
 	if runtimeGOOS != "darwin" {
 		return fmt.Errorf("supported on macOS only; current platform is %s", runtimeGOOS)
 	}
-	if _, err := lookPathFn("xcodebuild"); err != nil {
-		if errors.Is(err, exec.ErrNotFound) {
+	if err := runXcodebuildWithEnvironment(ctx, []string{"-version"}, environment, io.Discard, terminateProcessGroup); err != nil {
+		if isTrustedXcodeToolUnavailable(err, "xcodebuild") {
 			return fmt.Errorf("xcodebuild not available; install Xcode and ensure the active developer directory is configured")
 		}
-		return fmt.Errorf("locate xcodebuild: %w", err)
-	}
-	if err := runXcodebuildWithEnvironment(ctx, []string{"-version"}, environment, io.Discard, terminateProcessGroup); err != nil {
 		return fmt.Errorf("xcodebuild not usable: %w", err)
 	}
 	return nil
@@ -791,15 +789,7 @@ func activeDeveloperDir(ctx context.Context) (string, error) {
 	if developerDir := strings.TrimSpace(os.Getenv("DEVELOPER_DIR")); developerDir != "" {
 		return filepath.Clean(developerDir), nil
 	}
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	cmd := exec.CommandContext(ctx, "xcode-select", "-p")
-	output, err := outputXcodeCommand(cmd)
-	if err != nil {
-		return "", err
-	}
-	return filepath.Clean(strings.TrimSpace(string(output))), nil
+	return activeDeveloperDirFromTrustedSelect(ctx, nil)
 }
 
 func isBetaXcodePath(pathValue string) bool {
@@ -957,7 +947,10 @@ func runAltoolValidate(ctx context.Context, args []string, logWriter io.Writer) 
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	cmd := commandContextFn(ctx, "xcrun", args...)
+	cmd, err := trustedXcodeCommand(ctx, "xcrun", args, nil)
+	if err != nil {
+		return err
+	}
 	outputTail := newTailBuffer(xcodebuildErrorTailLimit)
 	combinedOutput := io.Writer(outputTail)
 	if logWriter != nil {
@@ -1190,7 +1183,10 @@ func runAltoolAndCapture(ctx context.Context, args []string, logWriter io.Writer
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	cmd := commandContextFn(ctx, "xcrun", args...)
+	cmd, err := trustedXcodeCommand(ctx, "xcrun", args, nil)
+	if err != nil {
+		return "", err
+	}
 	var stdout strings.Builder
 	var stderr strings.Builder
 	outputTail := newTailBuffer(xcodebuildErrorTailLimit)
@@ -1233,7 +1229,10 @@ func readAltoolHelpOutput(ctx context.Context) (string, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	cmd := commandContextFn(ctx, "xcrun", "altool", "--help")
+	cmd, err := trustedXcodeCommand(ctx, "xcrun", []string{"altool", "--help"}, nil)
+	if err != nil {
+		return "", err
+	}
 	var stdout strings.Builder
 	var stderr strings.Builder
 	cmd.Stdout = &stdout
@@ -1504,7 +1503,10 @@ func runCommandWithBoundedOutputEnvironmentMode(ctx context.Context, name string
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	cmd := commandContextFn(ctx, name, args...)
+	cmd, err := trustedXcodeCommand(ctx, name, args, environment)
+	if err != nil {
+		return err
+	}
 	if environment != nil {
 		cmd.Env = cloneEnvironment(environment)
 	}
@@ -2117,7 +2119,12 @@ func moveExportedArtifact(sourcePath, destinationPath, artifactName string, over
 }
 
 func readArchiveBundleInfo(archivePath string) (bundleInfo, error) {
-	data, err := os.ReadFile(filepath.Join(archivePath, "Info.plist"))
+	archiveRoot, err := os.OpenRoot(archivePath)
+	if err != nil {
+		return bundleInfo{}, fmt.Errorf("open archive: %w", err)
+	}
+	defer func() { _ = archiveRoot.Close() }()
+	data, err := readRegularFileFromRoot(archiveRoot, "Info.plist")
 	if err != nil {
 		return bundleInfo{}, fmt.Errorf("read archive Info.plist: %w", err)
 	}
@@ -2269,7 +2276,7 @@ func readArchivedAppInfoPlistFromRoot(archiveRoot *os.Root, appProps map[string]
 }
 
 func readRegularFileFromRoot(root *os.Root, name string) ([]byte, error) {
-	file, err := root.Open(name)
+	file, err := secureopen.OpenExistingNoFollowInRoot(root, name)
 	if err != nil {
 		return nil, err
 	}
@@ -2281,7 +2288,13 @@ func readRegularFileFromRoot(root *os.Root, name string) ([]byte, error) {
 	if !info.Mode().IsRegular() {
 		return nil, fmt.Errorf("metadata path must be a regular file: %s", name)
 	}
-	return io.ReadAll(file)
+	if info.Size() < 0 {
+		return nil, fmt.Errorf("metadata path has an invalid size: %s", name)
+	}
+	if err := infoplist.CheckDeclaredSize(uint64(info.Size())); err != nil {
+		return nil, err
+	}
+	return infoplist.ReadBounded(file)
 }
 
 func inferAppStorePlatformFromPlist(payload map[string]any) string {

--- a/internal/xcode/xcode_test.go
+++ b/internal/xcode/xcode_test.go
@@ -1757,8 +1757,9 @@ func TestRunXcodebuildFailurePreservesRecognizedErrorsAndFinalOutputWithinBound(
 	logPath := filepath.Join(tempDir, "commands.log")
 
 	restore := overrideTestEnvironment(t)
-	commandContextFn = helperCommandContext(t, logPath)
 	t.Cleanup(restore)
+	useTrustedTestCommandNames(t)
+	commandContextFn = helperCommandContext(t, logPath)
 
 	tests := []struct {
 		name                 string
@@ -1809,8 +1810,9 @@ func TestRunXcodebuildFailureStillStreamsCompleteOutputOnce(t *testing.T) {
 	logPath := filepath.Join(tempDir, "commands.log")
 
 	restore := overrideTestEnvironment(t)
-	commandContextFn = helperCommandContext(t, logPath)
 	t.Cleanup(restore)
+	useTrustedTestCommandNames(t)
+	commandContextFn = helperCommandContext(t, logPath)
 
 	var streamed bytes.Buffer
 	err := runXcodebuild(context.Background(), []string{"fail-large-output"}, &streamed)
@@ -1843,8 +1845,9 @@ func TestRunXcodebuildFailureStillStreamsCompleteOutputOnce(t *testing.T) {
 func TestRunXcodebuildInterruptionPreservesRecognizedErrorsAndFinalOutputWithinBound(t *testing.T) {
 	tempDir := t.TempDir()
 	restore := overrideTestEnvironment(t)
-	commandContextFn = helperCommandContext(t, filepath.Join(tempDir, "commands.log"))
 	t.Cleanup(restore)
+	useTrustedTestCommandNames(t)
+	commandContextFn = helperCommandContext(t, filepath.Join(tempDir, "commands.log"))
 
 	tests := []struct {
 		name            string
@@ -2221,8 +2224,9 @@ func TestXcodeDiagnosticBufferSerializesConcurrentWrites(t *testing.T) {
 
 func TestRunXcodebuildPreservesCombinedChildStreamOrder(t *testing.T) {
 	restore := overrideTestEnvironment(t)
-	commandContextFn = helperCommandContext(t, filepath.Join(t.TempDir(), "commands.log"))
 	t.Cleanup(restore)
+	useTrustedTestCommandNames(t)
+	commandContextFn = helperCommandContext(t, filepath.Join(t.TempDir(), "commands.log"))
 
 	const want = "FIRST-STDOUT\nSECOND-STDERR\nTHIRD-STDOUT\nFINAL-STDERR\n"
 	var streamed bytes.Buffer
@@ -2267,6 +2271,8 @@ func TestRunXcodebuildDoesNotWaitForDescendantHoldingOutputPipes(t *testing.T) {
 	pidPath := filepath.Join(tempDir, "descendant.pid")
 
 	restore := overrideTestEnvironment(t)
+	t.Cleanup(restore)
+	useTrustedTestCommandNames(t)
 	// Race-instrumented helper binaries otherwise spend the race runtime's
 	// default one-second atexit delay in the direct child before it exits. That
 	// delay is unrelated to the descendant retaining the output descriptors and
@@ -2274,7 +2280,6 @@ func TestRunXcodebuildDoesNotWaitForDescendantHoldingOutputPipes(t *testing.T) {
 	t.Setenv("GORACE", strings.TrimSpace(os.Getenv("GORACE")+" atexit_sleep_ms=0"))
 	commandContextFn = helperCommandContext(t, filepath.Join(tempDir, "commands.log"))
 	t.Setenv("ASC_XCODE_HELPER_DESCENDANT_PID", pidPath)
-	t.Cleanup(restore)
 	t.Cleanup(func() {
 		data, err := os.ReadFile(pidPath)
 		if err != nil {
@@ -2303,8 +2308,9 @@ func TestRunXcodebuildDoesNotWaitForDescendantHoldingOutputPipes(t *testing.T) {
 func TestRunXcodebuildPreservesContextCancellation(t *testing.T) {
 	tempDir := t.TempDir()
 	restore := overrideTestEnvironment(t)
-	commandContextFn = helperCommandContext(t, filepath.Join(tempDir, "commands.log"))
 	t.Cleanup(restore)
+	useTrustedTestCommandNames(t)
+	commandContextFn = helperCommandContext(t, filepath.Join(tempDir, "commands.log"))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
@@ -2340,6 +2346,18 @@ func overrideTestEnvironment(t *testing.T) func() {
 		trustedXcrunPathFn = originalTrustedXcrunPath
 		trustedXcodeToolPathFn = originalTrustedXcodeToolPath
 	}
+}
+
+// useTrustedTestCommandNames keeps subprocess-focused tests independent of
+// host Xcode installation while production continues to resolve absolute
+// paths from the selected trusted toolchain.
+func useTrustedTestCommandNames(t *testing.T) {
+	t.Helper()
+	previous := trustedXcodeToolPathFn
+	trustedXcodeToolPathFn = func(_ context.Context, tool string, _ []string) (string, error) {
+		return filepath.Join("/usr/bin", tool), nil
+	}
+	t.Cleanup(func() { trustedXcodeToolPathFn = previous })
 }
 
 func helperCommandContext(t *testing.T, logPath string) func(context.Context, string, ...string) *exec.Cmd {

--- a/internal/xcode/xcode_test.go
+++ b/internal/xcode/xcode_test.go
@@ -2121,12 +2121,22 @@ func overrideTestEnvironment(t *testing.T) func() {
 	originalStatPath := statPathFn
 	originalCommandContext := commandContextFn
 	originalActiveDeveloperDir := activeDeveloperDirFn
+	originalTrustedXcrunPath := trustedXcrunPathFn
+	originalTrustedXcodeToolPath := trustedXcodeToolPathFn
+	trustedXcrunPathFn = func() (string, error) {
+		return lookPathFn("xcrun")
+	}
+	trustedXcodeToolPathFn = func(_ context.Context, tool string, _ []string) (string, error) {
+		return lookPathFn(tool)
+	}
 	return func() {
 		runtimeGOOS = originalGOOS
 		lookPathFn = originalLookPath
 		statPathFn = originalStatPath
 		commandContextFn = originalCommandContext
 		activeDeveloperDirFn = originalActiveDeveloperDir
+		trustedXcrunPathFn = originalTrustedXcrunPath
+		trustedXcodeToolPathFn = originalTrustedXcodeToolPath
 	}
 }
 
@@ -2134,7 +2144,7 @@ func helperCommandContext(t *testing.T, logPath string) func(context.Context, st
 	t.Helper()
 
 	return func(ctx context.Context, name string, args ...string) *exec.Cmd {
-		commandArgs := []string{"-test.run=TestXcodeHelperProcess", "--", name}
+		commandArgs := []string{"-test.run=TestXcodeHelperProcess", "--", filepath.Base(name)}
 		commandArgs = append(commandArgs, args...)
 		cmd := exec.CommandContext(ctx, os.Args[0], commandArgs...)
 		cmd.Env = append(
@@ -2168,8 +2178,9 @@ func TestXcodeHelperProcess(t *testing.T) {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(2)
 	}
+	commandName := filepath.Base(commandArgs[0])
 	if environmentLog := os.Getenv("ASC_XCODE_HELPER_ENV_LOG"); environmentLog != "" {
-		entry := fmt.Sprintf("%s ASC_ONLY=%s ASC_SHOULD_NOT_LEAK=%s\n", commandArgs[0], os.Getenv("ASC_ONLY"), os.Getenv("ASC_SHOULD_NOT_LEAK"))
+		entry := fmt.Sprintf("%s ASC_ONLY=%s ASC_SHOULD_NOT_LEAK=%s\n", commandName, os.Getenv("ASC_ONLY"), os.Getenv("ASC_SHOULD_NOT_LEAK"))
 		file, err := os.OpenFile(environmentLog, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
@@ -2186,12 +2197,12 @@ func TestXcodeHelperProcess(t *testing.T) {
 		}
 	}
 
-	if len(commandArgs) >= 2 && commandArgs[0] == "xcodebuild" && commandArgs[1] == "-version" {
+	if len(commandArgs) >= 2 && commandName == "xcodebuild" && commandArgs[1] == "-version" {
 		fmt.Fprintln(os.Stdout, "Xcode 16.2")
 		os.Exit(0)
 	}
 
-	if len(commandArgs) >= 2 && commandArgs[0] == "xcodebuild" && commandArgs[1] == "write-canary-after-delay" {
+	if len(commandArgs) >= 2 && commandName == "xcodebuild" && commandArgs[1] == "write-canary-after-delay" {
 		if err := os.WriteFile(os.Getenv("ASC_XCODE_HELPER_DESCENDANT_READY"), []byte("ready"), 0o600); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(2)
@@ -2213,7 +2224,24 @@ func TestXcodeHelperProcess(t *testing.T) {
 		os.Exit(0)
 	}
 
-	if len(commandArgs) >= 2 && commandArgs[0] == "xcrun" && commandArgs[1] == "altool" {
+	if len(commandArgs) >= 3 && commandName == "xcrun" && commandArgs[1] == "--find" && commandArgs[2] == "xcodebuild" {
+		developerDir := os.Getenv("DEVELOPER_DIR")
+		fmt.Fprintln(os.Stdout, filepath.Join(developerDir, "usr", "bin", "xcodebuild"))
+		os.Exit(0)
+	}
+
+	if len(commandArgs) >= 3 && commandName == "xcrun" && commandArgs[1] == "--find" && commandArgs[2] == "agvtool" {
+		developerDir := os.Getenv("DEVELOPER_DIR")
+		fmt.Fprintln(os.Stdout, filepath.Join(developerDir, "usr", "bin", "agvtool"))
+		os.Exit(0)
+	}
+
+	if len(commandArgs) >= 3 && commandName == "xcrun" && commandArgs[1] == "--find" && commandArgs[2] == "stapler" {
+		fmt.Fprintln(os.Stdout, trustedStaplerPath)
+		os.Exit(0)
+	}
+
+	if len(commandArgs) >= 2 && commandName == "xcrun" && commandArgs[1] == "altool" {
 		if helperContainsArg(commandArgs[2:], "--build-status") {
 			if _, err := valueAfter(commandArgs[2:], "--apple-id"); err != nil {
 				fmt.Fprintln(os.Stderr, err)
@@ -2257,7 +2285,7 @@ func TestXcodeHelperProcess(t *testing.T) {
 		os.Exit(0)
 	}
 
-	if len(commandArgs) >= 2 && commandArgs[0] == "xcrun" && commandArgs[1] == "xcresulttool" {
+	if len(commandArgs) >= 2 && commandName == "xcrun" && commandArgs[1] == "xcresulttool" {
 		if output := os.Getenv("ASC_XCODE_HELPER_XCRESULT_STDERR"); output != "" {
 			fmt.Fprint(os.Stderr, output)
 		}
@@ -2272,7 +2300,7 @@ func TestXcodeHelperProcess(t *testing.T) {
 		os.Exit(0)
 	}
 
-	if len(commandArgs) >= 2 && commandArgs[0] == "agvtool" {
+	if len(commandArgs) >= 2 && commandName == "agvtool" {
 		switch commandArgs[1] {
 		case "what-marketing-version":
 			if os.Getenv("ASC_XCODE_HELPER_VARIABLE_VERSION") == "1" {
@@ -2301,12 +2329,12 @@ func TestXcodeHelperProcess(t *testing.T) {
 		}
 	}
 
-	if len(commandArgs) >= 2 && commandArgs[0] == "xcodebuild" && commandArgs[1] == "-showBuildSettings" {
+	if len(commandArgs) >= 2 && commandName == "xcodebuild" && commandArgs[1] == "-showBuildSettings" {
 		fmt.Fprint(os.Stdout, "Build settings for action build and target App:\n    MARKETING_VERSION = 4.5.6\n    CURRENT_PROJECT_VERSION = 99\n")
 		os.Exit(0)
 	}
 
-	if len(commandArgs) >= 1 && commandArgs[0] == "xcodebuild" && helperContainsArg(commandArgs[1:], "archive") {
+	if len(commandArgs) >= 1 && commandName == "xcodebuild" && helperContainsArg(commandArgs[1:], "archive") {
 		archivePath, err := valueAfter(commandArgs[1:], "-archivePath")
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
@@ -2319,7 +2347,7 @@ func TestXcodeHelperProcess(t *testing.T) {
 		os.Exit(0)
 	}
 
-	if len(commandArgs) >= 1 && commandArgs[0] == "xcodebuild" && helperContainsArg(commandArgs[1:], "-exportArchive") {
+	if len(commandArgs) >= 1 && commandName == "xcodebuild" && helperContainsArg(commandArgs[1:], "-exportArchive") {
 		if os.Getenv("ASC_XCODE_HELPER_EXPORT_FAIL") == "1" {
 			fmt.Fprintln(os.Stderr, "requested export failure")
 			os.Exit(1)
@@ -2450,7 +2478,7 @@ func TestXcodeHelperProcess(t *testing.T) {
 		os.Exit(0)
 	}
 
-	if len(commandArgs) >= 2 && commandArgs[0] == "xcodebuild" && commandArgs[1] == "retain-output-after-exit" {
+	if len(commandArgs) >= 2 && commandName == "xcodebuild" && commandArgs[1] == "retain-output-after-exit" {
 		descendantArgs := []string{"-test.run=TestXcodeHelperProcess", "--", "xcodebuild", "hold-output-descriptors"}
 		descendant := exec.Command(os.Args[0], descendantArgs...)
 		descendant.Env = os.Environ()
@@ -2467,24 +2495,24 @@ func TestXcodeHelperProcess(t *testing.T) {
 		os.Exit(0)
 	}
 
-	if len(commandArgs) >= 2 && commandArgs[0] == "xcodebuild" && commandArgs[1] == "hold-output-descriptors" {
+	if len(commandArgs) >= 2 && commandName == "xcodebuild" && commandArgs[1] == "hold-output-descriptors" {
 		time.Sleep(2 * time.Second)
 		os.Exit(0)
 	}
 
-	if len(commandArgs) >= 2 && commandArgs[0] == "xcodebuild" && commandArgs[1] == "wait-for-context-cancel" {
+	if len(commandArgs) >= 2 && commandName == "xcodebuild" && commandArgs[1] == "wait-for-context-cancel" {
 		time.Sleep(2 * time.Second)
 		os.Exit(0)
 	}
 
-	if len(commandArgs) >= 2 && commandArgs[0] == "xcodebuild" && commandArgs[1] == "fail-large-output" {
+	if len(commandArgs) >= 2 && commandName == "xcodebuild" && commandArgs[1] == "fail-large-output" {
 		fmt.Fprint(os.Stderr, "file.m:4:3: error: root cause\n")
 		fmt.Fprint(os.Stderr, strings.Repeat("x", xcodebuildErrorTailLimit+128))
 		fmt.Fprint(os.Stderr, "\nFINAL-DIAGNOSTIC\n")
 		os.Exit(1)
 	}
 
-	if len(commandArgs) >= 2 && commandArgs[0] == "xcodebuild" && commandArgs[1] == "alternating-stream-output" {
+	if len(commandArgs) >= 2 && commandName == "xcodebuild" && commandArgs[1] == "alternating-stream-output" {
 		stdoutInfo, stdoutErr := os.Stdout.Stat()
 		stderrInfo, stderrErr := os.Stderr.Stat()
 		fmt.Fprint(os.Stdout, "FIRST-STDOUT\n")
@@ -2498,7 +2526,7 @@ func TestXcodeHelperProcess(t *testing.T) {
 		os.Exit(0)
 	}
 
-	if len(commandArgs) >= 2 && commandArgs[0] == "xcodebuild" && commandArgs[1] == "large-output-then-wait" {
+	if len(commandArgs) >= 2 && commandName == "xcodebuild" && commandArgs[1] == "large-output-then-wait" {
 		if len(commandArgs) < 3 {
 			fmt.Fprintln(os.Stderr, "missing helper readiness path")
 			os.Exit(2)
@@ -2524,7 +2552,11 @@ func appendHelperLog(path string, args []string) error {
 		return err
 	}
 	defer f.Close()
-	_, err = fmt.Fprintln(f, strings.Join(args, "|"))
+	loggedArgs := append([]string(nil), args...)
+	if len(loggedArgs) > 0 {
+		loggedArgs[0] = filepath.Base(loggedArgs[0])
+	}
+	_, err = fmt.Fprintln(f, strings.Join(loggedArgs, "|"))
 	return err
 }
 

--- a/internal/xcode/xcode_test.go
+++ b/internal/xcode/xcode_test.go
@@ -1530,7 +1530,11 @@ func TestExportWarnsForBetaXcodeAppStoreExport(t *testing.T) {
 		return "/usr/bin/xcodebuild", nil
 	}
 	commandContextFn = helperCommandContext(t, logPath)
-	t.Setenv("DEVELOPER_DIR", "/Applications/Xcode-beta.app/Contents/Developer")
+	developerDir := filepath.Join(tempDir, "Xcode-beta.app", "Contents", "Developer")
+	if err := os.MkdirAll(developerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEVELOPER_DIR", developerDir)
 	t.Cleanup(restore)
 
 	var stderr bytes.Buffer
@@ -1543,7 +1547,7 @@ func TestExportWarnsForBetaXcodeAppStoreExport(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Export() error: %v", err)
 	}
-	if !strings.Contains(stderr.String(), `Warning: active Xcode developer directory "/Applications/Xcode-beta.app/Contents/Developer" appears to be a beta build`) {
+	if !strings.Contains(stderr.String(), fmt.Sprintf("Warning: active Xcode developer directory %q appears to be a beta build", developerDir)) {
 		t.Fatalf("expected beta Xcode warning, got %q", stderr.String())
 	}
 	if !strings.Contains(stderr.String(), "App Store review can later reject builds for unsupported SDK/Xcode") {
@@ -1571,7 +1575,11 @@ func TestExportDoesNotWarnForStableXcodeAppStoreExport(t *testing.T) {
 		return "/usr/bin/xcodebuild", nil
 	}
 	commandContextFn = helperCommandContext(t, logPath)
-	t.Setenv("DEVELOPER_DIR", "/Applications/Xcode-26.3.0.app/Contents/Developer")
+	developerDir := filepath.Join(tempDir, "Xcode-26.3.0.app", "Contents", "Developer")
+	if err := os.MkdirAll(developerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEVELOPER_DIR", developerDir)
 	t.Cleanup(restore)
 
 	var stderr bytes.Buffer
@@ -1608,7 +1616,11 @@ func TestExportDoesNotWarnForBetaXcodeDevelopmentExport(t *testing.T) {
 		return "/usr/bin/xcodebuild", nil
 	}
 	commandContextFn = helperCommandContext(t, logPath)
-	t.Setenv("DEVELOPER_DIR", "/Applications/Xcode-beta.app/Contents/Developer")
+	developerDir := filepath.Join(tempDir, "Xcode-beta.app", "Contents", "Developer")
+	if err := os.MkdirAll(developerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEVELOPER_DIR", developerDir)
 	t.Cleanup(restore)
 
 	var stderr bytes.Buffer

--- a/internal/xcode/xcode_test.go
+++ b/internal/xcode/xcode_test.go
@@ -572,7 +572,7 @@ func TestValidatePinsArtifactAcrossPathReplacement(t *testing.T) {
 	replaced := false
 	commandContextFn = func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		cmd := baseCommandContext(ctx, name, args...)
-		if name == "xcrun" && len(args) > 0 && args[0] == "altool" {
+		if filepath.Base(name) == "xcrun" && len(args) > 0 && args[0] == "altool" {
 			preservedPath := filepath.Join(tempDir, "original.ipa")
 			if err := os.Rename(ipaPath, preservedPath); err != nil {
 				t.Fatalf("preserve original IPA: %v", err)


### PR DESCRIPTION
Summary
- bound and no-follow archive metadata reads before plist decoding
- resolve xcodebuild, xcrun, agvtool, stapler, and xcode-select through trusted system and selected-toolchain paths
- preserve cancellation and actionable tool-resolution diagnostics across Xcode workflows
- adapt repository integration tests to the trusted resolver boundary

Validation
- make build
- make format
- make check-docs
- make lint
- ASC_BYPASS_KEYCHAIN=1 make test
- full-branch Codex review against current origin/main: no actionable findings
- Xcode 27 production smoke: doctor, explicit toolchain selection, PATH-shadow rejection, real CLI Release archive, and export-options generation on a production-shaped macOS archive

The production smoke used disposable files under /private/tmp and did not mutate Apple APIs, uploads, signing state, or keychain state.