### PR TITLE
feat(xcode): support manual macOS export options

### DIFF
--- a/docs/design/xcode-export-options-generation.md
+++ b/docs/design/xcode-export-options-generation.md
@@ -40,10 +40,13 @@ The archive is required so ASC can validate that the artifact is an Xcode
 archive and infer its team and bundle metadata. `--team-id` overrides archive
 inference. Automatic signing omits provisioning-profile mappings and lets
 Xcode resolve every embedded app, extension, widget, watch component, or App
-Clip. Manual signing delegates local certificate/profile selection to Bitrise's
-export-options generator for its supported iOS/tvOS archive shapes and fails
-clearly for unsupported or ambiguous archives; users can always retain an
-explicit custom plist.
+Clip. Manual signing delegates local certificate/profile selection for
+iOS/tvOS archive shapes to the pinned archive library. App Store macOS exports
+also resolve same-team application and installer identities, plus replacement
+profiles for executable bundles whose entitlements require one. Bundles that
+carry an embedded profile always receive a replacement mapping; bundles with
+only unrestricted macOS entitlements remain valid without a synthetic mapping.
+Other macOS export methods require an explicit custom plist.
 
 Existing invocations remain valid. `asc xcode export` accepts the same
 `--method` value for implicit generation and makes
@@ -70,8 +73,8 @@ The generator result contains:
 - `path` and `archive_path`;
 - `method`, `destination`, and `signing_style`;
 - inferred or explicit `team_id` when available;
-- `signing_certificate` and a stable bundle-ID-to-profile map for manual
-  signing and both supported methods;
+- `signing_certificate`, `installer_signing_certificate` when a macOS package
+  needs one, and a stable bundle-ID-to-profile map for manual signing;
 - `overwritten`.
 
 JSON uses those field names. Table and Markdown render the same values with one
@@ -100,8 +103,12 @@ failed validation or write leaves the previous file unchanged.
 
 Automatic generation uses archive metadata only and does not touch the
 Keychain or App Store Connect. Manual generation is macOS-only and may inspect
-locally installed signing identities and provisioning profiles through Bitrise.
-It does not create or mutate signing assets.
+locally installed signing identities and provisioning profiles through the
+pinned signing libraries. For macOS, ASC recursively inventories nested app,
+extension, XPC service, and system extension bundles so required profile
+mappings are not limited to the main app and top-level extensions. Non-bundle
+helper executables and frameworks remain Xcode-managed and are not assigned
+provisioning-profile mappings. ASC does not create or mutate signing assets.
 
 ## Compatibility and lifecycle
 

--- a/internal/cli/xcode/export_options.go
+++ b/internal/cli/xcode/export_options.go
@@ -35,6 +35,10 @@ an existing .xcarchive. Automatic signing lets Xcode resolve signing for the
 app and any embedded targets; provide --signing-style manual to resolve local
 profiles.
 
+Manual App Store macOS generation also resolves an installed package-installer
+identity. Profile mappings are emitted for executable bundles that carry an
+embedded provisioning profile or whose entitlements require one.
+
 Examples:
   asc xcode export-options generate --archive-path .asc/artifacts/App.xcarchive
   asc xcode export-options generate --archive-path .asc/artifacts/App.xcarchive --method release-testing
@@ -172,6 +176,9 @@ func exportOptionsResultRows(result *localxcode.ExportOptionsGenerateResult) [][
 	}
 	if signingCertificate := strings.TrimSpace(result.SigningCertificate); signingCertificate != "" {
 		rows = append(rows, []string{"signing_certificate", signingCertificate})
+	}
+	if installerSigningCertificate := strings.TrimSpace(result.InstallerSigningCertificate); installerSigningCertificate != "" {
+		rows = append(rows, []string{"installer_signing_certificate", installerSigningCertificate})
 	}
 	bundleIDs := make([]string, 0, len(result.ProvisioningProfiles))
 	for bundleID := range result.ProvisioningProfiles {

--- a/internal/cli/xcode/xcode.go
+++ b/internal/cli/xcode/xcode.go
@@ -221,8 +221,8 @@ uses app-store-connect and automatic signing by default. Use
 --team-id optionally overrides archive metadata.
 For local exports, provide exactly one destination: --ipa-path for iOS, tvOS,
 or visionOS, or --pkg-path for macOS. asc moves the exported artifact to that
-exact path. Generated manual signing options support iOS and tvOS archives;
-provide an explicit --export-options plist for a manually signed macOS export.
+exact path. Generated manual signing options support iOS, tvOS, and App Store
+macOS archives; provide an explicit --export-options plist for other macOS methods.
 When ExportOptions.plist uses destination=upload, xcodebuild uploads directly
 to App Store Connect and asc returns archive metadata without writing a local
 artifact or requiring a destination path. Use --wait to generate direct-upload
@@ -306,9 +306,6 @@ Examples:
 			}
 			if exportOptionsPath == "" && trimmedPKGPath != "" && methodValue == "release-testing" {
 				return shared.UsageError("--pkg-path cannot be combined with --method release-testing")
-			}
-			if exportOptionsPath == "" && trimmedPKGPath != "" && signingStyleValue == "manual" {
-				return shared.UsageError("--pkg-path with manual signing requires an explicit --export-options plist")
 			}
 			directUpload := *wait
 			if exportOptionsPath != "" {

--- a/internal/cli/xcode/xcode_test.go
+++ b/internal/cli/xcode/xcode_test.go
@@ -136,39 +136,47 @@ func TestXcodeExportRejectsMultipleArtifactPaths(t *testing.T) {
 	}
 }
 
-func TestXcodeExportRejectsGeneratedManualPKGOptions(t *testing.T) {
+func TestXcodeExportGeneratesManualPKGOptions(t *testing.T) {
 	restore := overrideXcodeCommandTestHooks(t)
 	defer restore()
 
-	runGenerateExportOptions = func(context.Context, localxcode.ExportOptionsGenerateOptions) (*localxcode.ExportOptionsGenerateResult, error) {
-		t.Fatal("generator must not run for unsupported macOS manual signing")
-		return nil, nil
+	var generatedOptions localxcode.ExportOptionsGenerateOptions
+	runGenerateExportOptions = func(_ context.Context, opts localxcode.ExportOptionsGenerateOptions) (*localxcode.ExportOptionsGenerateResult, error) {
+		generatedOptions = opts
+		return &localxcode.ExportOptionsGenerateResult{Path: filepath.Join(t.TempDir(), "ExportOptions.plist")}, nil
 	}
-	runExport = func(context.Context, localxcode.ExportOptions) (*localxcode.ExportResult, error) {
-		t.Fatal("export must not run for unsupported macOS manual signing")
-		return nil, nil
+	var exportedOptions localxcode.ExportOptions
+	runExport = func(_ context.Context, opts localxcode.ExportOptions) (*localxcode.ExportResult, error) {
+		exportedOptions = opts
+		return &localxcode.ExportResult{ArchivePath: opts.ArchivePath, PKGPath: opts.PKGPath}, nil
 	}
 
 	cmd := XcodeExportCommand()
 	cmd.FlagSet.SetOutput(io.Discard)
+	pkgPath := filepath.Join(t.TempDir(), "Demo.pkg")
 	if err := cmd.FlagSet.Parse([]string{
 		"--archive-path", "Demo.xcarchive",
-		"--pkg-path", "Demo.pkg",
+		"--pkg-path", pkgPath,
 		"--signing-style", "manual",
+		"--output", "json",
 	}); err != nil {
 		t.Fatalf("failed to parse flags: %v", err)
 	}
 
-	var runErr error
-	_, stderr := captureCommandOutput(t, func() error {
-		runErr = cmd.Exec(context.Background(), nil)
-		return runErr
+	stdout, stderr := captureCommandOutput(t, func() error {
+		return cmd.Exec(context.Background(), nil)
 	})
-	if !errors.Is(runErr, flag.ErrHelp) {
-		t.Fatalf("Exec() error = %v, want usage error", runErr)
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
 	}
-	if !strings.Contains(stderr, "Error: --pkg-path with manual signing requires an explicit --export-options plist") {
-		t.Fatalf("stderr = %q, want manual-signing guidance", stderr)
+	if generatedOptions.Method != "app-store-connect" || generatedOptions.SigningStyle != "manual" || generatedOptions.Destination != "export" {
+		t.Fatalf("generated options = %+v, want App Store manual export", generatedOptions)
+	}
+	if exportedOptions.PKGPath != pkgPath || exportedOptions.IPAPath != "" {
+		t.Fatalf("export options = %+v, want only PKG path", exportedOptions)
+	}
+	if !strings.Contains(stdout, `"pkg_path"`) {
+		t.Fatalf("stdout = %q, want JSON export result", stdout)
 	}
 }
 

--- a/internal/xcode/export_options.go
+++ b/internal/xcode/export_options.go
@@ -36,25 +36,28 @@ type ExportOptionsGenerateOptions struct {
 
 // ExportOptionsGenerateResult describes the generated ExportOptions.plist.
 type ExportOptionsGenerateResult struct {
-	Path                 string            `json:"path"`
-	ArchivePath          string            `json:"archive_path"`
-	Method               string            `json:"method"`
-	Destination          string            `json:"destination"`
-	SigningStyle         string            `json:"signing_style"`
-	TeamID               string            `json:"team_id,omitempty"`
-	SigningCertificate   string            `json:"signing_certificate,omitempty"`
-	ProvisioningProfiles map[string]string `json:"provisioning_profiles,omitempty"`
-	Overwritten          bool              `json:"overwritten"`
+	Path                        string            `json:"path"`
+	ArchivePath                 string            `json:"archive_path"`
+	Method                      string            `json:"method"`
+	Destination                 string            `json:"destination"`
+	SigningStyle                string            `json:"signing_style"`
+	TeamID                      string            `json:"team_id,omitempty"`
+	SigningCertificate          string            `json:"signing_certificate,omitempty"`
+	InstallerSigningCertificate string            `json:"installer_signing_certificate,omitempty"`
+	ProvisioningProfiles        map[string]string `json:"provisioning_profiles,omitempty"`
+	Overwritten                 bool              `json:"overwritten"`
 }
 
 // manualExportOptions contains the signing material ASC owns after Bitrise has
 // resolved installed certificates and profiles. It deliberately does not leak
 // Bitrise's v1 ExportOptions interface into ASC's public API.
 type manualExportOptions struct {
-	TeamID                     string
-	SigningCertificate         string
-	ProvisioningProfiles       map[string]string
-	ICloudContainerEnvironment string
+	TeamID                       string
+	SigningCertificate           string
+	InstallerSigningCertificate  string
+	ProvisioningProfiles         map[string]string
+	ICloudContainerEnvironment   string
+	ProvisioningProfilesOptional bool
 }
 
 var (
@@ -143,7 +146,7 @@ func GenerateExportOptions(ctx context.Context, opts ExportOptionsGenerateOption
 	}
 
 	payload := buildExportOptionsPayload(opts, teamID, manual)
-	if err := validateExportOptionsPayload(payload, opts.Method, opts.SigningStyle); err != nil {
+	if err := validateExportOptionsPayload(payload, opts.Method, opts.SigningStyle, manual.ProvisioningProfilesOptional); err != nil {
 		return nil, err
 	}
 	data, err := plist.MarshalIndent(payload, plist.XMLFormat, "\t")
@@ -154,7 +157,7 @@ func GenerateExportOptions(ctx context.Context, opts ExportOptionsGenerateOption
 	if _, err := plist.Unmarshal(data, &decoded); err != nil {
 		return nil, fmt.Errorf("decode generated export options plist: %w", err)
 	}
-	if err := validateExportOptionsPayload(decoded, opts.Method, opts.SigningStyle); err != nil {
+	if err := validateExportOptionsPayload(decoded, opts.Method, opts.SigningStyle, manual.ProvisioningProfilesOptional); err != nil {
 		return nil, fmt.Errorf("validate generated export options plist: %w", err)
 	}
 
@@ -184,6 +187,7 @@ func GenerateExportOptions(ctx context.Context, opts ExportOptionsGenerateOption
 	}
 	if opts.SigningStyle == exportOptionsSigningStyleManual {
 		result.SigningCertificate = manual.SigningCertificate
+		result.InstallerSigningCertificate = manual.InstallerSigningCertificate
 		result.ProvisioningProfiles = cloneProvisioningProfiles(manual.ProvisioningProfiles)
 	}
 	return result, nil
@@ -311,7 +315,7 @@ func buildExportOptionsPayload(opts ExportOptionsGenerateOptions, teamID string,
 	return buildPlatformExportOptionsPayload(opts, teamID, manual)
 }
 
-func validateExportOptionsPayload(payload map[string]any, method, signingStyle string) error {
+func validateExportOptionsPayload(payload map[string]any, method, signingStyle string, provisioningProfilesOptional bool) error {
 	if got := exportOptionsString(payload["method"]); got != method {
 		return fmt.Errorf("export options method must be %q", method)
 	}
@@ -333,13 +337,20 @@ func validateExportOptionsPayload(payload map[string]any, method, signingStyle s
 	if certificate == "" {
 		return fmt.Errorf("manual export options require a signing certificate")
 	}
-	profiles, err := provisioningProfilesFromPayload(payload["provisioningProfiles"])
-	if err != nil {
-		return err
+	installerCertificate := exportOptionsString(payload["installerSigningCertificate"])
+	profiles := map[string]string(nil)
+	if profilesValue, found := payload["provisioningProfiles"]; found {
+		var err error
+		profiles, err = provisioningProfilesFromPayload(profilesValue)
+		if err != nil {
+			return err
+		}
 	}
 	return validateManualExportOptions(manualExportOptions{
-		SigningCertificate:   certificate,
-		ProvisioningProfiles: profiles,
+		SigningCertificate:           certificate,
+		InstallerSigningCertificate:  installerCertificate,
+		ProvisioningProfiles:         profiles,
+		ProvisioningProfilesOptional: provisioningProfilesOptional,
 	})
 }
 
@@ -351,7 +362,10 @@ func validateManualExportOptions(options manualExportOptions) error {
 	if strings.TrimSpace(options.SigningCertificate) == "" {
 		return fmt.Errorf("manual export options require a signing certificate")
 	}
-	if len(options.ProvisioningProfiles) == 0 {
+	if options.ProvisioningProfilesOptional && strings.TrimSpace(options.InstallerSigningCertificate) == "" {
+		return fmt.Errorf("manual macOS export options require an installer signing certificate")
+	}
+	if len(options.ProvisioningProfiles) == 0 && !options.ProvisioningProfilesOptional {
 		return fmt.Errorf("manual export options require provisioning profile mappings")
 	}
 	for bundleID, profile := range options.ProvisioningProfiles {

--- a/internal/xcode/export_options_darwin.go
+++ b/internal/xcode/export_options_darwin.go
@@ -45,6 +45,7 @@ func buildPlatformExportOptionsPayload(opts ExportOptionsGenerateOptions, teamID
 	model.SigningStyle = exportoptions.SigningStyle(opts.SigningStyle)
 	if opts.SigningStyle == exportOptionsSigningStyleManual {
 		model.SigningCertificate = manual.SigningCertificate
+		model.InstallerSigningCertificate = manual.InstallerSigningCertificate
 		model.BundleIDProvisioningProfileMapping = cloneProvisioningProfiles(manual.ProvisioningProfiles)
 		model.ICloudContainerEnvironment = exportoptions.ICloudContainerEnvironment(manual.ICloudContainerEnvironment)
 	}
@@ -59,8 +60,14 @@ func generateManualExportOptions(ctx context.Context, archivePath, teamID, metho
 	if err != nil {
 		return manualExportOptions{}, fmt.Errorf("infer archive platform: %w", err)
 	}
+	if platform == "MAC_OS" {
+		if method != exportOptionsMethodAppStoreConnect {
+			return manualExportOptions{}, fmt.Errorf("manual signing export options generation for macOS archives only supports method %q; got %q", exportOptionsMethodAppStoreConnect, method)
+		}
+		return generateMacManualExportOptions(ctx, archivePath, teamID)
+	}
 	if platform != "IOS" && platform != "TV_OS" {
-		return manualExportOptions{}, fmt.Errorf("manual signing export options generation only supports iOS and tvOS archives; archive platform is %s", platform)
+		return manualExportOptions{}, fmt.Errorf("manual signing export options generation only supports iOS, tvOS, and App Store macOS archives; archive platform is %s", platform)
 	}
 	var generated legacyexportoptions.ExportOptions
 	if _, err := captureBitriseStdout(func() error {
@@ -90,6 +97,14 @@ func generateManualExportOptions(ctx context.Context, archivePath, teamID, metho
 }
 
 func readArchiveExportInfo(archivePath string) (exportoptionsgenerator.ArchiveInfo, error) {
+	platform, err := InferArchivePlatform(archivePath)
+	if err == nil && platform == "MAC_OS" {
+		macArchive, macErr := readMacArchiveExportInfo(context.Background(), archivePath)
+		if macErr != nil {
+			return exportoptionsgenerator.ArchiveInfo{}, macErr
+		}
+		return macArchive.ArchiveInfo, nil
+	}
 	archive, err := xcarchive.NewIosArchive(archivePath)
 	if err != nil {
 		return exportoptionsgenerator.ArchiveInfo{}, fmt.Errorf("read iOS archive: %w", err)
@@ -178,9 +193,10 @@ func manualExportOptionsFromHash(payload map[string]interface{}) (manualExportOp
 		cloudEnvironment = strings.TrimSpace(fmt.Sprint(value))
 	}
 	return manualExportOptions{
-		TeamID:                     strings.TrimSpace(coercePlistValueToString(payload["teamID"])),
-		SigningCertificate:         strings.TrimSpace(coercePlistValueToString(payload["signingCertificate"])),
-		ProvisioningProfiles:       profiles,
-		ICloudContainerEnvironment: cloudEnvironment,
+		TeamID:                      strings.TrimSpace(coercePlistValueToString(payload["teamID"])),
+		SigningCertificate:          strings.TrimSpace(coercePlistValueToString(payload["signingCertificate"])),
+		InstallerSigningCertificate: strings.TrimSpace(coercePlistValueToString(payload["installerSigningCertificate"])),
+		ProvisioningProfiles:        profiles,
+		ICloudContainerEnvironment:  cloudEnvironment,
 	}, nil
 }

--- a/internal/xcode/export_options_darwin_test.go
+++ b/internal/xcode/export_options_darwin_test.go
@@ -705,6 +705,66 @@ func TestSelectMacProvisioningProfileAllowsAppStoreEntitlementTransitions(t *tes
 	}
 }
 
+func TestSelectMacProvisioningProfileAllowsCloudKitProfileValueShapes(t *testing.T) {
+	now := time.Now()
+	profile := profileutil.ProvisioningProfileInfoModel{
+		UUID: "cloudkit", Name: "cloudkit", BundleID: "com.example.demo", TeamID: "TEAM123",
+		Type: profileutil.ProfileTypeMacOs, ExportType: legacyexportoptions.MethodAppStoreConnect,
+		ExpirationDate: now.Add(time.Hour), DeveloperCertificates: []certificateutil.CertificateInfoModel{{Serial: "CERT"}},
+		Entitlements: plistutil.PlistData{
+			"com.apple.developer.icloud-container-environment": []any{"Production", "Development"},
+			"com.apple.developer.icloud-services":              "*",
+		},
+	}
+	targetEntitlements := plistutil.PlistData{
+		"com.apple.developer.icloud-container-environment": "Development",
+		"com.apple.developer.icloud-services":              []any{"CloudKit", "CloudDocuments"},
+	}
+
+	selected, ok := selectMacProvisioningProfile("com.example.demo", nil, []profileutil.ProvisioningProfileInfoModel{profile}, "CERT", "TEAM123", targetEntitlements)
+	if !ok || selected.UUID != "cloudkit" {
+		t.Fatalf("selected profile = %#v, %t; want CloudKit profile", selected, ok)
+	}
+}
+
+func TestSelectMacProvisioningProfileRejectsUnsafeCloudKitProfileValueShapes(t *testing.T) {
+	now := time.Now()
+	profile := func(entitlements plistutil.PlistData) profileutil.ProvisioningProfileInfoModel {
+		return profileutil.ProvisioningProfileInfoModel{
+			UUID: "unsafe", Name: "unsafe", BundleID: "com.example.demo", TeamID: "TEAM123",
+			Type: profileutil.ProfileTypeMacOs, ExportType: legacyexportoptions.MethodAppStoreConnect,
+			ExpirationDate: now.Add(time.Hour), DeveloperCertificates: []certificateutil.CertificateInfoModel{{Serial: "CERT"}},
+			Entitlements: entitlements,
+		}
+	}
+
+	tests := []struct {
+		name    string
+		profile any
+		target  any
+		key     string
+	}{
+		{name: "reverse environment transition", key: "com.apple.developer.icloud-container-environment", profile: []any{"Development"}, target: "Production"},
+		{name: "unknown profile environment", key: "com.apple.developer.icloud-container-environment", profile: []any{"Production", "Staging"}, target: "Development"},
+		{name: "unknown iCloud service", key: "com.apple.developer.icloud-services", profile: "*", target: []any{"CloudKit", "Unknown"}},
+		{name: "App Clip-only iCloud service", key: "com.apple.developer.icloud-services", profile: "*", target: []any{"CloudKit-Anonymous"}},
+		{name: "target iCloud service wildcard", key: "com.apple.developer.icloud-services", profile: "*", target: []any{"*"}},
+		{name: "scalar target iCloud service", key: "com.apple.developer.icloud-services", profile: "*", target: "CloudKit"},
+		{name: "non-string environment", key: "com.apple.developer.icloud-container-environment", profile: []any{"Production", 42}, target: "Production"},
+		{name: "empty environment set", key: "com.apple.developer.icloud-container-environment", profile: []any{}, target: "Development"},
+		{name: "non-string iCloud service", key: "com.apple.developer.icloud-services", profile: "*", target: []any{"CloudKit", 42}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			candidate := profile(plistutil.PlistData{tt.key: tt.profile})
+			if selected, ok := selectMacProvisioningProfile("com.example.demo", nil, []profileutil.ProvisioningProfileInfoModel{candidate}, "CERT", "TEAM123", plistutil.PlistData{tt.key: tt.target}); ok {
+				t.Fatalf("selected unsafe profile %#v", selected)
+			}
+		})
+	}
+}
+
 func TestMacProfileEntitlementTransitionsRejectWrongDirectionAndUnknownValues(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -746,6 +806,12 @@ func TestMacProfileEntitlementTransitionsRejectWrongDirectionAndUnknownValues(t 
 			name:    "unknown App Attest value",
 			key:     "com.apple.developer.devicecheck.appattest-environment",
 			profile: "production",
+			target:  "staging",
+		},
+		{
+			name:    "matching unknown App Attest value",
+			key:     "com.apple.developer.devicecheck.appattest-environment",
+			profile: "staging",
 			target:  "staging",
 		},
 		{

--- a/internal/xcode/export_options_darwin_test.go
+++ b/internal/xcode/export_options_darwin_test.go
@@ -670,6 +670,102 @@ func TestSelectMacProvisioningProfileMatchesEntitlementValues(t *testing.T) {
 	}
 }
 
+func TestSelectMacProvisioningProfileAllowsAppStoreEntitlementTransitions(t *testing.T) {
+	now := time.Now()
+	profile := profileutil.ProvisioningProfileInfoModel{
+		UUID: "app-store", Name: "app-store", BundleID: "com.example.demo", TeamID: "TEAM123",
+		Type: profileutil.ProfileTypeMacOs, ExportType: legacyexportoptions.MethodAppStoreConnect,
+		ExpirationDate: now.Add(time.Hour), DeveloperCertificates: []certificateutil.CertificateInfoModel{{Serial: "CERT"}},
+		Entitlements: plistutil.PlistData{
+			"com.apple.developer.icloud-container-environment":      "Production",
+			"com.apple.developer.aps-environment":                   "production",
+			"com.apple.developer.devicecheck.appattest-environment": "production",
+		},
+	}
+	targetEntitlements := plistutil.PlistData{
+		"com.apple.developer.icloud-container-environment":      "Development",
+		"com.apple.developer.aps-environment":                   "development",
+		"com.apple.developer.devicecheck.appattest-environment": "development",
+	}
+
+	selected, ok := selectMacProvisioningProfile("com.example.demo", nil, []profileutil.ProvisioningProfileInfoModel{profile}, "CERT", "TEAM123", targetEntitlements)
+	if !ok || selected.UUID != "app-store" {
+		t.Fatalf("selected profile = %#v, %t; want App Store profile", selected, ok)
+	}
+}
+
+func TestMacProfileEntitlementTransitionsRejectWrongDirectionAndUnknownValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     string
+		profile any
+		target  any
+	}{
+		{
+			name:    "CloudKit production archive to development profile",
+			key:     "com.apple.developer.icloud-container-environment",
+			profile: "Development",
+			target:  "Production",
+		},
+		{
+			name:    "push production archive to development profile",
+			key:     "com.apple.developer.aps-environment",
+			profile: "development",
+			target:  "production",
+		},
+		{
+			name:    "unknown CloudKit value",
+			key:     "com.apple.developer.icloud-container-environment",
+			profile: "Production",
+			target:  "Staging",
+		},
+		{
+			name:    "unknown push value",
+			key:     "com.apple.developer.aps-environment",
+			profile: "production",
+			target:  "staging",
+		},
+		{
+			name:    "App Attest production archive to development profile",
+			key:     "com.apple.developer.devicecheck.appattest-environment",
+			profile: "development",
+			target:  "production",
+		},
+		{
+			name:    "unknown App Attest value",
+			key:     "com.apple.developer.devicecheck.appattest-environment",
+			profile: "production",
+			target:  "staging",
+		},
+		{
+			name:    "noncanonical CloudKit case",
+			key:     "com.apple.developer.icloud-container-environment",
+			profile: "production",
+			target:  "development",
+		},
+		{
+			name:    "noncanonical push case",
+			key:     "com.apple.developer.aps-environment",
+			profile: "production",
+			target:  "DEVELOPMENT",
+		},
+		{
+			name:    "noncanonical App Attest whitespace",
+			key:     "com.apple.developer.devicecheck.appattest-environment",
+			profile: "production",
+			target:  " development ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if macProfileEntitlementValuePermitsForExport(tt.key, tt.profile, tt.target) {
+				t.Fatalf("profile value %#v permitted target %#v for %q", tt.profile, tt.target, tt.key)
+			}
+		})
+	}
+}
+
 func TestSelectMacProvisioningProfileAllowsWildcardEntitlementValues(t *testing.T) {
 	now := time.Now()
 	profiles := []profileutil.ProvisioningProfileInfoModel{{

--- a/internal/xcode/export_options_darwin_test.go
+++ b/internal/xcode/export_options_darwin_test.go
@@ -1068,7 +1068,7 @@ func TestResolveMacManualExportOptionsPairsInstallerWithInferredApplicationTeam(
 		EntitlementsByBundleID: map[string]plistutil.PlistData{
 			"com.example.demo": {"com.apple.security.app-sandbox": true},
 		},
-	}}
+	}, SigningIdentity: "Apple Distribution: B"}
 	certificates := []certificateutil.CertificateInfoModel{
 		{CommonName: "Apple Distribution: A", TeamID: "TEAMA", Serial: "APP-A"},
 		{CommonName: "Apple Distribution: B", TeamID: "TEAMB", Serial: "APP-B"},
@@ -1082,8 +1082,104 @@ func TestResolveMacManualExportOptionsPairsInstallerWithInferredApplicationTeam(
 	if err != nil {
 		t.Fatalf("resolveMacManualExportOptions() error: %v", err)
 	}
-	if manual.TeamID != "TEAMA" || manual.SigningCertificate != "Apple Distribution: A" || manual.InstallerSigningCertificate != "3rd Party Mac Developer Installer: Z" {
+	if manual.TeamID != "TEAMB" || manual.SigningCertificate != "Apple Distribution: B" || manual.InstallerSigningCertificate != "3rd Party Mac Developer Installer: A" {
 		t.Fatalf("manual identities were not paired by inferred team: %#v", manual)
+	}
+}
+
+func TestResolveMacManualExportOptionsRejectsAmbiguousInstalledTeams(t *testing.T) {
+	archiveInfo := macArchiveExportInfo{ArchiveInfo: exportoptionsgenerator.ArchiveInfo{
+		AppBundleID: "com.example.demo",
+		EntitlementsByBundleID: map[string]plistutil.PlistData{
+			"com.example.demo": {"com.apple.security.app-sandbox": true},
+		},
+	}}
+	certificates := []certificateutil.CertificateInfoModel{
+		{CommonName: "Apple Distribution: A", TeamID: "TEAMA", Serial: "APP-A"},
+		{CommonName: "Apple Distribution: B", TeamID: "TEAMB", Serial: "APP-B"},
+	}
+	installers := []certificateutil.CertificateInfoModel{
+		{CommonName: "3rd Party Mac Developer Installer: A", TeamID: "TEAMA", Serial: "INSTALLER-A"},
+		{CommonName: "3rd Party Mac Developer Installer: B", TeamID: "TEAMB", Serial: "INSTALLER-B"},
+	}
+
+	_, err := resolveMacManualExportOptions(archiveInfo, nil, certificates, installers, "")
+	if err == nil || !strings.Contains(err.Error(), "multiple installed teams") || !strings.Contains(err.Error(), "--team-id") {
+		t.Fatalf("resolveMacManualExportOptions() error = %v, want ambiguous-team guidance", err)
+	}
+}
+
+func TestResolveMacManualExportOptionsInfersTeamFromEntitlements(t *testing.T) {
+	archiveInfo := macArchiveExportInfo{ArchiveInfo: exportoptionsgenerator.ArchiveInfo{
+		AppBundleID: "com.example.demo",
+		EntitlementsByBundleID: map[string]plistutil.PlistData{
+			"com.example.demo": {
+				"com.apple.developer.team-identifier": "TEAMB",
+				"com.apple.security.app-sandbox":      true,
+			},
+		},
+	}}
+	certificates := []certificateutil.CertificateInfoModel{
+		{CommonName: "Apple Distribution: A", TeamID: "TEAMA", Serial: "APP-A"},
+		{CommonName: "Apple Distribution: B", TeamID: "TEAMB", Serial: "APP-B"},
+	}
+	installers := []certificateutil.CertificateInfoModel{
+		{CommonName: "3rd Party Mac Developer Installer: A", TeamID: "TEAMA", Serial: "INSTALLER-A"},
+		{CommonName: "3rd Party Mac Developer Installer: B", TeamID: "TEAMB", Serial: "INSTALLER-B"},
+	}
+
+	manual, err := resolveMacManualExportOptions(archiveInfo, nil, certificates, installers, "")
+	if err != nil {
+		t.Fatalf("resolveMacManualExportOptions() error: %v", err)
+	}
+	if manual.TeamID != "TEAMB" || manual.SigningCertificate != "Apple Distribution: B" || manual.InstallerSigningCertificate != "3rd Party Mac Developer Installer: B" {
+		t.Fatalf("manual identities were not selected using the archived entitlement team: %#v", manual)
+	}
+}
+
+func TestResolveMacManualExportOptionsInfersTeamFromArchivedIdentityName(t *testing.T) {
+	archiveInfo := macArchiveExportInfo{
+		ArchiveInfo: exportoptionsgenerator.ArchiveInfo{
+			AppBundleID: "com.example.demo",
+			EntitlementsByBundleID: map[string]plistutil.PlistData{
+				"com.example.demo": {"com.apple.security.app-sandbox": true},
+			},
+		},
+		SigningIdentity: "Apple Development: Example (TEAM123456)",
+	}
+	certificates := []certificateutil.CertificateInfoModel{
+		{CommonName: "Apple Distribution: Other", TeamID: "OTHER12345", Serial: "APP-A"},
+		{CommonName: "Apple Distribution: Example", TeamID: "TEAM123456", Serial: "APP-B"},
+	}
+	installers := []certificateutil.CertificateInfoModel{
+		{CommonName: "Mac Installer Distribution: Example", TeamID: "TEAM123456", Serial: "INSTALLER-B"},
+	}
+
+	manual, err := resolveMacManualExportOptions(archiveInfo, nil, certificates, installers, "")
+	if err != nil {
+		t.Fatalf("resolveMacManualExportOptions() error: %v", err)
+	}
+	if manual.TeamID != "TEAM123456" || manual.SigningCertificate != "Apple Distribution: Example" {
+		t.Fatalf("manual identity was not selected using the archived identity team: %#v", manual)
+	}
+}
+
+func TestResolveMacManualExportOptionsRejectsConflictingArchiveTeams(t *testing.T) {
+	archiveInfo := macArchiveExportInfo{
+		ArchiveInfo: exportoptionsgenerator.ArchiveInfo{
+			AppBundleID: "com.example.demo",
+			EntitlementsByBundleID: map[string]plistutil.PlistData{
+				"com.example.demo": {"com.apple.developer.team-identifier": "TEAMB"},
+			},
+		},
+		EmbeddedProfiles: map[string]profileutil.ProvisioningProfileInfoModel{
+			"com.example.demo": {TeamID: "TEAMA"},
+		},
+	}
+
+	_, err := resolveMacManualExportOptions(archiveInfo, nil, nil, nil, "")
+	if err == nil || !strings.Contains(err.Error(), "conflicting team identifiers") || !strings.Contains(err.Error(), "TEAMA, TEAMB") {
+		t.Fatalf("resolveMacManualExportOptions() error = %v, want conflicting archive teams", err)
 	}
 }
 

--- a/internal/xcode/export_options_darwin_test.go
+++ b/internal/xcode/export_options_darwin_test.go
@@ -604,6 +604,17 @@ func TestMacBundleRequiresProvisioningProfileForApplicationGroups(t *testing.T) 
 	}
 }
 
+func TestMacBundleDoesNotRequireProvisioningProfileForScriptingTargets(t *testing.T) {
+	if macBundleRequiresProvisioningProfile(plistutil.PlistData{
+		"com.apple.security.app-sandbox": true,
+		"com.apple.security.scripting-targets": map[string]any{
+			"com.apple.mail": []string{"com.apple.mail.compose"},
+		},
+	}, false) {
+		t.Fatal("App Sandbox scripting targets must not require a macOS provisioning profile")
+	}
+}
+
 func TestSelectMacProvisioningProfileMatchesEntitlementValues(t *testing.T) {
 	now := time.Now()
 	profile := func(uuid string, entitlements plistutil.PlistData) profileutil.ProvisioningProfileInfoModel {

--- a/internal/xcode/export_options_darwin_test.go
+++ b/internal/xcode/export_options_darwin_test.go
@@ -3,16 +3,31 @@
 package xcode
 
 import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"errors"
 	"fmt"
+	"math/big"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/bitrise-io/go-xcode/certificateutil"
 	legacyexportoptions "github.com/bitrise-io/go-xcode/exportoptions"
 	"github.com/bitrise-io/go-xcode/v2/exportoptionsgenerator"
+	"github.com/bitrise-io/go-xcode/v2/plistutil"
+	"github.com/bitrise-io/go-xcode/v2/profileutil"
+	"github.com/fullsailor/pkcs7"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/infoplist"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
 	"howett.net/plist"
 )
 
@@ -73,32 +88,859 @@ func TestGenerateManualExportOptionsCapturesArchiveReaderStdout(t *testing.T) {
 	}
 }
 
-func TestGenerateManualExportOptionsRejectsMacOSArchiveClearly(t *testing.T) {
-	archivePath := writeExportOptionsTestArchive(t, "TEAM123")
-	appInfoPath := filepath.Join(archivePath, "Products", "Applications", "Demo.app", "Info.plist")
-	data, err := plist.Marshal(map[string]any{
-		"CFBundleIdentifier": "com.example.demo",
-		"DTPlatformName":     "macosx",
-	}, plist.XMLFormat)
+func TestGenerateManualExportOptionsSupportsMacOSAppStore(t *testing.T) {
+	archivePath := writeMacExportOptionsTestArchive(t)
+	originalReader := readMacArchiveExportInfoFn
+	originalProfiles := installedMacProvisioningProfileInfosFn
+	originalCertificates := installedCodesignIdentityInfosFn
+	originalInstallerCertificates := installedInstallerIdentityInfosFn
+	readMacArchiveExportInfoFn = func(context.Context, string) (macArchiveExportInfo, error) {
+		return macArchiveExportInfo{
+			ArchiveInfo: exportoptionsgenerator.ArchiveInfo{
+				AppBundleID: "com.example.demo",
+				EntitlementsByBundleID: map[string]plistutil.PlistData{
+					"com.example.demo":       {"com.apple.developer.team-identifier": "TEAM123"},
+					"com.example.demo.share": {"com.apple.developer.team-identifier": "TEAM123"},
+				},
+			},
+			EmbeddedProfiles: map[string]profileutil.ProvisioningProfileInfoModel{
+				"com.example.demo":       {UUID: "MAIN-UUID", BundleID: "com.example.demo", TeamID: "TEAM123"},
+				"com.example.demo.share": {UUID: "EMBEDDED-SHARE-UUID", BundleID: "com.example.demo.share", TeamID: "TEAM123"},
+			},
+		}, nil
+	}
+	installedMacProvisioningProfileInfosFn = func(context.Context) ([]profileutil.ProvisioningProfileInfoModel, error) {
+		return []profileutil.ProvisioningProfileInfoModel{
+			{
+				UUID: "MAIN-UUID", Name: "Main Mac Profile", BundleID: "com.example.demo", TeamID: "TEAM123",
+				Type: profileutil.ProfileTypeMacOs, ExportType: legacyexportoptions.MethodAppStoreConnect,
+				ExpirationDate: time.Now().Add(time.Hour), DeveloperCertificates: []certificateutil.CertificateInfoModel{{Serial: "CERT-SERIAL"}},
+				Entitlements: plistutil.PlistData{"com.apple.developer.team-identifier": "TEAM123"},
+			},
+			{
+				UUID: "SHARE-UUID", Name: "Share Mac Profile", BundleID: "com.example.demo.*", TeamID: "TEAM123",
+				Type: profileutil.ProfileTypeMacOs, ExportType: legacyexportoptions.MethodAppStoreConnect,
+				ExpirationDate: time.Now().Add(time.Hour), DeveloperCertificates: []certificateutil.CertificateInfoModel{{Serial: "CERT-SERIAL"}},
+				Entitlements: plistutil.PlistData{"com.apple.developer.team-identifier": "TEAM123"},
+			},
+		}, nil
+	}
+	installedCodesignIdentityInfosFn = func(context.Context) ([]certificateutil.CertificateInfoModel, error) {
+		return []certificateutil.CertificateInfoModel{{CommonName: "Mac App Distribution: Example (TEAM123)", TeamID: "TEAM123", Serial: "CERT-SERIAL"}}, nil
+	}
+	installedInstallerIdentityInfosFn = func(context.Context) ([]certificateutil.CertificateInfoModel, error) {
+		return []certificateutil.CertificateInfoModel{{CommonName: "Mac Installer Distribution: Example (TEAM123)", TeamID: "TEAM123", Serial: "INSTALLER-SERIAL"}}, nil
+	}
+	t.Cleanup(func() {
+		readMacArchiveExportInfoFn = originalReader
+		installedMacProvisioningProfileInfosFn = originalProfiles
+		installedCodesignIdentityInfosFn = originalCertificates
+		installedInstallerIdentityInfosFn = originalInstallerCertificates
+	})
+
+	manual, err := generateManualExportOptions(t.Context(), archivePath, "TEAM123", exportOptionsMethodAppStoreConnect)
+	if err != nil {
+		t.Fatalf("generateManualExportOptions() error: %v", err)
+	}
+	if manual.SigningCertificate != "Mac App Distribution: Example (TEAM123)" {
+		t.Fatalf("signing certificate = %q", manual.SigningCertificate)
+	}
+	if manual.InstallerSigningCertificate != "Mac Installer Distribution: Example (TEAM123)" {
+		t.Fatalf("installer signing certificate = %q", manual.InstallerSigningCertificate)
+	}
+	if got := manual.ProvisioningProfiles["com.example.demo"]; got != "MAIN-UUID" {
+		t.Fatalf("main profile = %q", got)
+	}
+	if got := manual.ProvisioningProfiles["com.example.demo.share"]; got != "SHARE-UUID" {
+		t.Fatalf("extension profile = %q", got)
+	}
+}
+
+func TestGenerateManualExportOptionsRejectsMacOSReleaseTesting(t *testing.T) {
+	archivePath := writeMacExportOptionsTestArchive(t)
+	_, err := generateManualExportOptions(t.Context(), archivePath, "TEAM123", exportOptionsMethodReleaseTesting)
+	if err == nil || !strings.Contains(err.Error(), "macOS archives only supports method") || !strings.Contains(err.Error(), exportOptionsMethodAppStoreConnect) {
+		t.Fatalf("expected macOS method rejection, got %v", err)
+	}
+}
+
+func TestReadArchiveExportInfoSupportsMacOSArchive(t *testing.T) {
+	archivePath := writeMacExportOptionsTestArchive(t)
+	binDir := t.TempDir()
+	codesignPath := filepath.Join(binDir, "codesign")
+	pathCanary := filepath.Join(t.TempDir(), "ambient-codesign-ran")
+	codesignScript := []byte("#!/bin/sh\nprintf invoked > \"$ASC_PATH_CANARY\"\n")
+	if err := os.WriteFile(codesignPath, codesignScript, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("ASC_PATH_CANARY", pathCanary)
+	originalCodesignCommand := macCodesignCommandContextFn
+	codesignCalls := 0
+	macCodesignCommandContextFn = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		if name != "/usr/bin/codesign" {
+			t.Fatalf("codesign path = %q, want /usr/bin/codesign", name)
+		}
+		codesignCalls++
+		return exec.CommandContext(ctx, "/usr/bin/true")
+	}
+	t.Cleanup(func() { macCodesignCommandContextFn = originalCodesignCommand })
+
+	info, err := readArchiveExportInfo(archivePath)
+	if err != nil {
+		t.Fatalf("readArchiveExportInfo() error: %v", err)
+	}
+	if info.AppBundleID != "com.example.demo" {
+		t.Fatalf("app bundle ID = %q", info.AppBundleID)
+	}
+	if len(info.EntitlementsByBundleID) != 10 {
+		t.Fatalf("entitlements = %#v, want every executable bundle in the archive", info.EntitlementsByBundleID)
+	}
+	for _, bundleID := range []string{
+		"com.example.demo.helper",
+		"com.example.demo.login",
+		"com.example.demo.network-extension",
+		"com.example.demo.driver-extension",
+		"com.example.demo.bundle",
+		"com.example.demo.plugin",
+		"com.example.demo.quicklook",
+		"com.example.demo.metadata-importer",
+	} {
+		if _, ok := info.EntitlementsByBundleID[bundleID]; !ok {
+			t.Fatalf("nested bundle %q is absent from entitlements: %#v", bundleID, info.EntitlementsByBundleID)
+		}
+	}
+	if _, err := os.Stat(pathCanary); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("ambient PATH codesign was invoked: %v", err)
+	}
+	if codesignCalls != 10 {
+		t.Fatalf("system codesign invocations = %d, want 10", codesignCalls)
+	}
+}
+
+func TestReadMacExecutableEntitlementsUsesImmutableSnapshotAndSystemCodesign(t *testing.T) {
+	directory := t.TempDir()
+	executablePath := filepath.Join(directory, "Demo")
+	if err := os.WriteFile(executablePath, []byte("original executable"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	executable, err := os.Open(executablePath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(appInfoPath, data, 0o644); err != nil {
+	defer executable.Close()
+
+	originalCodesignCommand := macCodesignCommandContextFn
+	var snapshotDirectory string
+	macCodesignCommandContextFn = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		if name != "/usr/bin/codesign" {
+			t.Fatalf("codesign path = %q, want /usr/bin/codesign", name)
+		}
+		if len(args) != 4 || args[0] != "-d" || args[1] != "--entitlements" || args[2] != ":-" {
+			t.Fatalf("codesign args = %#v", args)
+		}
+		snapshotPath := args[3]
+		snapshotDirectory = filepath.Dir(snapshotPath)
+		if snapshotPath == executablePath || strings.HasPrefix(snapshotPath, directory+string(filepath.Separator)) {
+			t.Fatalf("codesign input = %q, want private snapshot", snapshotPath)
+		}
+		if err := os.Rename(executablePath, executablePath+".original"); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(executablePath, []byte("replacement executable"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		snapshot, err := os.ReadFile(snapshotPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(snapshot) != "original executable" {
+			t.Fatalf("snapshot = %q, want original executable", snapshot)
+		}
+		return exec.CommandContext(ctx, "/bin/sh", "-c", `printf '%s' '<?xml version="1.0" encoding="UTF-8"?><plist version="1.0"><dict><key>com.apple.developer.team-identifier</key><string>TEAM123</string></dict></plist>'`)
+	}
+	t.Cleanup(func() { macCodesignCommandContextFn = originalCodesignCommand })
+
+	entitlements, err := readMacExecutableEntitlements(t.Context(), executable)
+	if err != nil {
+		t.Fatalf("readMacExecutableEntitlements() error: %v", err)
+	}
+	if entitlements["com.apple.developer.team-identifier"] != "TEAM123" {
+		t.Fatalf("entitlements = %#v", entitlements)
+	}
+	if _, err := os.Stat(snapshotDirectory); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("snapshot directory remains after codesign: %v", err)
+	}
+}
+
+func TestReadMacExecutableEntitlementsPreservesCancellation(t *testing.T) {
+	executablePath := filepath.Join(t.TempDir(), "Demo")
+	if err := os.WriteFile(executablePath, []byte("executable"), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	executable, err := os.Open(executablePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer executable.Close()
 
-	_, err = generateManualExportOptions(t.Context(), archivePath, "TEAM123", exportOptionsMethodAppStoreConnect)
-	if err == nil || !strings.Contains(err.Error(), "only supports iOS and tvOS archives") || !strings.Contains(err.Error(), "MAC_OS") {
-		t.Fatalf("expected clear macOS archive rejection, got %v", err)
+	originalCodesignCommand := macCodesignCommandContextFn
+	macCodesignCommandContextFn = func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, "/bin/sh", "-c", "sleep 10")
+	}
+	t.Cleanup(func() { macCodesignCommandContextFn = originalCodesignCommand })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	_, err = readMacExecutableEntitlements(ctx, executable)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("readMacExecutableEntitlements() error = %v, want context deadline exceeded", err)
+	}
+}
+
+func TestReadMacArchiveExportInfoRejectsSymlinkedNestedBundle(t *testing.T) {
+	archivePath := writeMacExportOptionsTestArchive(t)
+	appPath := filepath.Join(archivePath, "Products", "Applications", "Demo.app")
+	outside := filepath.Join(t.TempDir(), "Outside.xpc")
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(appPath, "Contents", "XPCServices", "Linked.xpc")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatal(err)
+	}
+	originalCodesignCommand := macCodesignCommandContextFn
+	macCodesignCommandContextFn = func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, "/usr/bin/true")
+	}
+	t.Cleanup(func() { macCodesignCommandContextFn = originalCodesignCommand })
+
+	_, err := readMacArchiveExportInfo(t.Context(), archivePath)
+	if err == nil || !strings.Contains(err.Error(), "symlinked macOS executable bundle") {
+		t.Fatalf("readMacArchiveExportInfo() error = %v, want symlink rejection", err)
+	}
+}
+
+func TestReadMacArchiveExportInfoRejectsOversizedMetadataAndProfile(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		path func(string) string
+		size int
+	}{
+		{
+			name: "archive Info.plist",
+			path: func(archivePath string) string { return filepath.Join(archivePath, "Info.plist") },
+			size: infoplist.MaxBytes + 1,
+		},
+		{
+			name: "application Info.plist",
+			path: func(archivePath string) string {
+				return filepath.Join(archivePath, "Products", "Applications", "Demo.app", "Contents", "Info.plist")
+			},
+			size: infoplist.MaxBytes + 1,
+		},
+		{
+			name: "embedded profile",
+			path: func(archivePath string) string {
+				return filepath.Join(archivePath, "Products", "Applications", "Demo.app", "Contents", "embedded.provisionprofile")
+			},
+			size: int(macEmbeddedProfileMaxBytes) + 1,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			archivePath := writeMacExportOptionsTestArchive(t)
+			if err := os.WriteFile(test.path(archivePath), make([]byte, test.size), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			originalCodesignCommand := macCodesignCommandContextFn
+			macCodesignCommandContextFn = func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+				return exec.CommandContext(ctx, "/usr/bin/true")
+			}
+			t.Cleanup(func() { macCodesignCommandContextFn = originalCodesignCommand })
+
+			_, err := readMacArchiveExportInfo(t.Context(), archivePath)
+			if err == nil || !strings.Contains(err.Error(), "size limit") {
+				t.Fatalf("readMacArchiveExportInfo() error = %v, want size limit", err)
+			}
+		})
+	}
+}
+
+func TestReadMacArchiveExportInfoHonorsCanceledContext(t *testing.T) {
+	archivePath := writeMacExportOptionsTestArchive(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	originalCodesignCommand := macCodesignCommandContextFn
+	macCodesignCommandContextFn = func(context.Context, string, ...string) *exec.Cmd {
+		t.Fatal("codesign command was created after cancellation")
+		return nil
+	}
+	t.Cleanup(func() { macCodesignCommandContextFn = originalCodesignCommand })
+
+	if _, err := readMacArchiveExportInfo(ctx, archivePath); !errors.Is(err, context.Canceled) {
+		t.Fatalf("readMacArchiveExportInfo() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestDiscoverNestedMacBundlePathsHonorsCanceledContext(t *testing.T) {
+	archivePath := writeMacExportOptionsTestArchive(t)
+	archiveRoot, err := rootfs.New(archivePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer archiveRoot.Close()
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err = discoverNestedMacBundlePaths(ctx, archiveRoot, "Products/Applications/Demo.app")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("discoverNestedMacBundlePaths() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestReadMacArchiveExportInfoRejectsArchiveRootSwap(t *testing.T) {
+	archivePath := writeMacExportOptionsTestArchive(t)
+	outsideArchive := writeMacExportOptionsTestArchive(t)
+	originalHook := afterMacArchiveInitialLstatFn
+	afterMacArchiveInitialLstatFn = func() {
+		if err := os.Rename(archivePath, archivePath+".original"); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(outsideArchive, archivePath); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Cleanup(func() { afterMacArchiveInitialLstatFn = originalHook })
+	originalCodesignCommand := macCodesignCommandContextFn
+	macCodesignCommandContextFn = func(context.Context, string, ...string) *exec.Cmd {
+		t.Fatal("codesign command was created after archive root replacement")
+		return nil
+	}
+	t.Cleanup(func() { macCodesignCommandContextFn = originalCodesignCommand })
+
+	_, err := readMacArchiveExportInfo(t.Context(), archivePath)
+	if err == nil || !strings.Contains(err.Error(), "same non-symlinked directory") {
+		t.Fatalf("readMacArchiveExportInfo() error = %v, want archive root identity rejection", err)
+	}
+}
+
+func TestInstalledMacProvisioningProfileInfosUsesBoundedNoFollowInventory(t *testing.T) {
+	t.Run("reads both native profile directories", func(t *testing.T) {
+		home := t.TempDir()
+		modern := filepath.Join(home, "Library", "Developer", "Xcode", "UserData", "Provisioning Profiles")
+		legacy := filepath.Join(home, "Library", "MobileDevice", "Provisioning Profiles")
+		for _, directory := range []string{modern, legacy} {
+			if err := os.MkdirAll(directory, 0o755); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := os.WriteFile(filepath.Join(modern, "modern.provisionprofile"), signedMacProvisioningProfile(t, "MODERN-UUID"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(legacy, "legacy.mobileprovision"), signedMacProvisioningProfile(t, "LEGACY-UUID"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(modern, "ignored.txt"), []byte("not a profile"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		originalHome := macUserHomeDirFn
+		macUserHomeDirFn = func() (string, error) { return home, nil }
+		t.Cleanup(func() { macUserHomeDirFn = originalHome })
+
+		profiles, err := installedMacProvisioningProfileInfos(t.Context())
+		if err != nil {
+			t.Fatalf("installedMacProvisioningProfileInfos() error: %v", err)
+		}
+		if len(profiles) != 2 || profiles[0].UUID != "LEGACY-UUID" || profiles[1].UUID != "MODERN-UUID" {
+			t.Fatalf("profiles = %#v, want sorted native macOS profiles from both directories", profiles)
+		}
+		if profiles[0].Type != profileutil.ProfileTypeMacOs || profiles[1].Type != profileutil.ProfileTypeMacOs {
+			t.Fatalf("profile types = %q, %q, want macOS", profiles[0].Type, profiles[1].Type)
+		}
+	})
+
+	t.Run("rejects profile symlink", func(t *testing.T) {
+		directory := t.TempDir()
+		outside := filepath.Join(t.TempDir(), "outside.provisionprofile")
+		if err := os.WriteFile(outside, signedMacProvisioningProfile(t, "OUTSIDE-UUID"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(outside, filepath.Join(directory, "linked.provisionprofile")); err != nil {
+			t.Fatal(err)
+		}
+		_, err := readInstalledMacProvisioningProfiles(t.Context(), directory)
+		if err == nil || !strings.Contains(err.Error(), "symlinked") {
+			t.Fatalf("readInstalledMacProvisioningProfiles() error = %v, want symlink rejection", err)
+		}
+	})
+
+	t.Run("rejects oversized profile", func(t *testing.T) {
+		directory := t.TempDir()
+		path := filepath.Join(directory, "oversized.provisionprofile")
+		file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0o600)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := file.Truncate(macEmbeddedProfileMaxBytes + 1); err != nil {
+			_ = file.Close()
+			t.Fatal(err)
+		}
+		if err := file.Close(); err != nil {
+			t.Fatal(err)
+		}
+		_, err = readInstalledMacProvisioningProfiles(t.Context(), directory)
+		if err == nil || !strings.Contains(err.Error(), "size limit") {
+			t.Fatalf("readInstalledMacProvisioningProfiles() error = %v, want size limit", err)
+		}
+	})
+
+	t.Run("honors canceled context", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		_, err := readInstalledMacProvisioningProfiles(ctx, t.TempDir())
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("readInstalledMacProvisioningProfiles() error = %v, want context.Canceled", err)
+		}
+	})
+}
+
+func TestResolveMacManualExportOptionsFiltersProfilesAndRequiresSharedCertificate(t *testing.T) {
+	now := time.Now()
+	archiveInfo := macArchiveExportInfo{
+		ArchiveInfo: exportoptionsgenerator.ArchiveInfo{
+			AppBundleID: "com.example.demo",
+			EntitlementsByBundleID: map[string]plistutil.PlistData{
+				"com.example.demo":       {"com.apple.developer.team-identifier": "TEAM123"},
+				"com.example.demo.share": {"com.apple.developer.team-identifier": "TEAM123"},
+			},
+		},
+		EmbeddedProfiles: map[string]profileutil.ProvisioningProfileInfoModel{
+			"com.example.demo":       {UUID: "embedded-main"},
+			"com.example.demo.share": {UUID: "embedded-share"},
+		},
+	}
+	profile := func(uuid, bundleID, teamID string, profileType profileutil.ProfileType, method legacyexportoptions.Method, expiry time.Time, serial string) profileutil.ProvisioningProfileInfoModel {
+		return profileutil.ProvisioningProfileInfoModel{
+			UUID: uuid, Name: uuid, BundleID: bundleID, TeamID: teamID, Type: profileType, ExportType: method,
+			ExpirationDate: expiry, DeveloperCertificates: []certificateutil.CertificateInfoModel{{Serial: serial}},
+			Entitlements: plistutil.PlistData{"com.apple.developer.team-identifier": "TEAM123"},
+		}
+	}
+	profiles := []profileutil.ProvisioningProfileInfoModel{
+		profile("ios", "com.example.demo", "TEAM123", profileutil.ProfileTypeIos, legacyexportoptions.MethodAppStoreConnect, now.Add(time.Hour), "SHARED"),
+		profile("dev", "com.example.demo", "TEAM123", profileutil.ProfileTypeMacOs, legacyexportoptions.MethodDevelopment, now.Add(time.Hour), "SHARED"),
+		profile("wrong-team", "com.example.demo", "OTHER", profileutil.ProfileTypeMacOs, legacyexportoptions.MethodAppStoreConnect, now.Add(time.Hour), "SHARED"),
+		profile("expired", "com.example.demo", "TEAM123", profileutil.ProfileTypeMacOs, legacyexportoptions.MethodAppStoreConnect, now.Add(-time.Hour), "SHARED"),
+		profile("main", "com.example.demo", "TEAM123", profileutil.ProfileTypeMacOs, legacyexportoptions.MethodAppStoreConnect, now.Add(time.Hour), "SHARED"),
+		profile("share-a", "com.example.demo.share", "TEAM123", profileutil.ProfileTypeMacOs, legacyexportoptions.MethodAppStoreConnect, now.Add(time.Hour), "SHARED"),
+	}
+	certificates := []certificateutil.CertificateInfoModel{{CommonName: "Mac App Distribution", TeamID: "TEAM123", Serial: "SHARED"}}
+	certificates[0].CommonName = "Mac App Distribution: Example (TEAM123)"
+	installers := []certificateutil.CertificateInfoModel{{CommonName: "Mac Installer Distribution: Example (TEAM123)", TeamID: "TEAM123", Serial: "INSTALLER"}}
+	manual, err := resolveMacManualExportOptions(archiveInfo, profiles, certificates, installers, "TEAM123")
+	if err != nil {
+		t.Fatalf("resolveMacManualExportOptions() error: %v", err)
+	}
+	if manual.ProvisioningProfiles["com.example.demo"] != "main" || manual.ProvisioningProfiles["com.example.demo.share"] != "share-a" {
+		t.Fatalf("profile mapping = %#v", manual.ProvisioningProfiles)
+	}
+
+	profiles[len(profiles)-1].DeveloperCertificates = []certificateutil.CertificateInfoModel{{Serial: "OTHER"}}
+	if _, err := resolveMacManualExportOptions(archiveInfo, profiles, certificates, installers, "TEAM123"); err == nil || !strings.Contains(err.Error(), "could not find one installed macOS distribution certificate") {
+		t.Fatalf("expected shared certificate failure, got %v", err)
+	}
+}
+
+func TestResolveMacManualExportOptionsAllowsArchiveWithoutEmbeddedProfiles(t *testing.T) {
+	archiveInfo := macArchiveExportInfo{ArchiveInfo: exportoptionsgenerator.ArchiveInfo{
+		AppBundleID: "com.example.demo",
+		EntitlementsByBundleID: map[string]plistutil.PlistData{
+			"com.example.demo": {"com.apple.security.app-sandbox": true},
+		},
+	}}
+	certificates := []certificateutil.CertificateInfoModel{{
+		CommonName: "Apple Distribution: Example (TEAM123)", TeamID: "TEAM123", Serial: "APP",
+	}}
+	installers := []certificateutil.CertificateInfoModel{{
+		CommonName: "Mac Installer Distribution: Example (TEAM123)", TeamID: "TEAM123", Serial: "INSTALLER",
+	}}
+
+	manual, err := resolveMacManualExportOptions(archiveInfo, nil, certificates, installers, "TEAM123")
+	if err != nil {
+		t.Fatalf("resolveMacManualExportOptions() error: %v", err)
+	}
+	if len(manual.ProvisioningProfiles) != 0 {
+		t.Fatalf("profile mapping = %#v, want no profiles for an archive without embedded profiles", manual.ProvisioningProfiles)
+	}
+	if manual.SigningCertificate != certificates[0].CommonName || manual.InstallerSigningCertificate != installers[0].CommonName {
+		t.Fatalf("manual signing identities = %#v", manual)
+	}
+}
+
+func TestResolveMacManualExportOptionsRequiresProfileForRestrictedEntitlement(t *testing.T) {
+	archiveInfo := macArchiveExportInfo{ArchiveInfo: exportoptionsgenerator.ArchiveInfo{
+		AppBundleID: "com.example.demo",
+		EntitlementsByBundleID: map[string]plistutil.PlistData{
+			"com.example.demo": {"keychain-access-groups": []string{"TEAM123.com.example.shared"}},
+		},
+	}}
+	certificates := []certificateutil.CertificateInfoModel{{
+		CommonName: "Apple Distribution: Example (TEAM123)", TeamID: "TEAM123", Serial: "APP",
+	}}
+	installers := []certificateutil.CertificateInfoModel{{
+		CommonName: "Mac Installer Distribution: Example (TEAM123)", TeamID: "TEAM123", Serial: "INSTALLER",
+	}}
+
+	_, err := resolveMacManualExportOptions(archiveInfo, nil, certificates, installers, "TEAM123")
+	if err == nil || !strings.Contains(err.Error(), "required App Store provisioning profile set") {
+		t.Fatalf("expected restricted-entitlement profile error, got %v", err)
+	}
+}
+
+func TestMacBundleRequiresProvisioningProfileForApplicationGroups(t *testing.T) {
+	if !macBundleRequiresProvisioningProfile(plistutil.PlistData{
+		"com.apple.security.application-groups": []string{"TEAM123.com.example.shared"},
+	}, false) {
+		t.Fatal("application groups must require a macOS provisioning profile")
+	}
+}
+
+func TestSelectMacProvisioningProfileMatchesEntitlementValues(t *testing.T) {
+	now := time.Now()
+	profile := func(uuid string, entitlements plistutil.PlistData) profileutil.ProvisioningProfileInfoModel {
+		return profileutil.ProvisioningProfileInfoModel{
+			UUID: uuid, Name: uuid, BundleID: "com.example.demo", TeamID: "TEAM123",
+			Type: profileutil.ProfileTypeMacOs, ExportType: legacyexportoptions.MethodAppStoreConnect,
+			ExpirationDate: now.Add(time.Hour), DeveloperCertificates: []certificateutil.CertificateInfoModel{{Serial: "CERT"}},
+			Entitlements: entitlements,
+		}
+	}
+
+	tests := []struct {
+		name         string
+		target       any
+		wrong        any
+		matching     any
+		matchingUUID string
+	}{
+		{
+			name:         "keychain access groups",
+			target:       []string{"TEAM123.com.example.shared"},
+			wrong:        []string{"TEAM123.com.example.other"},
+			matching:     []string{"TEAM123.com.example.shared"},
+			matchingUUID: "matching-keychain",
+		},
+		{
+			name:         "application groups",
+			target:       []string{"TEAM123.com.example.shared"},
+			wrong:        []string{"TEAM123.com.example.other"},
+			matching:     []string{"TEAM123.com.example.shared"},
+			matchingUUID: "matching-groups",
+		},
+		{
+			name:         "iCloud containers",
+			target:       []string{"iCloud.com.example.demo"},
+			wrong:        []string{"iCloud.com.example.other"},
+			matching:     []string{"iCloud.com.example.demo"},
+			matchingUUID: "matching-icloud",
+		},
+	}
+	keys := []string{
+		"keychain-access-groups",
+		"com.apple.security.application-groups",
+		"com.apple.developer.icloud-container-identifiers",
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			targetEntitlements := plistutil.PlistData{keys[i]: tt.target}
+			profiles := []profileutil.ProvisioningProfileInfoModel{
+				profile("aaa-wrong", plistutil.PlistData{keys[i]: tt.wrong}),
+				profile(tt.matchingUUID, plistutil.PlistData{keys[i]: tt.matching}),
+			}
+
+			selected, ok := selectMacProvisioningProfile("com.example.demo", nil, profiles, "CERT", "TEAM123", targetEntitlements)
+			if !ok || selected.UUID != tt.matchingUUID {
+				t.Fatalf("selected profile = %#v, %t; want %q", selected, ok, tt.matchingUUID)
+			}
+
+			if selected, ok := selectMacProvisioningProfile("com.example.demo", nil, profiles[:1], "CERT", "TEAM123", targetEntitlements); ok {
+				t.Fatalf("selected mismatching profile %#v", selected)
+			}
+		})
+	}
+}
+
+func TestSelectMacProvisioningProfileAllowsWildcardEntitlementValues(t *testing.T) {
+	now := time.Now()
+	profiles := []profileutil.ProvisioningProfileInfoModel{{
+		UUID: "wildcard", Name: "wildcard", BundleID: "com.example.*", TeamID: "TEAM123",
+		Type: profileutil.ProfileTypeMacOs, ExportType: legacyexportoptions.MethodAppStoreConnect,
+		ExpirationDate: now.Add(time.Hour), DeveloperCertificates: []certificateutil.CertificateInfoModel{{Serial: "CERT"}},
+		Entitlements: plistutil.PlistData{
+			"keychain-access-groups": []string{"TEAM123.*"},
+		},
+	}}
+	targetEntitlements := plistutil.PlistData{
+		"keychain-access-groups": []string{"TEAM123.com.example.shared"},
+	}
+
+	selected, ok := selectMacProvisioningProfile("com.example.demo", nil, profiles, "CERT", "TEAM123", targetEntitlements)
+	if !ok || selected.UUID != "wildcard" {
+		t.Fatalf("selected profile = %#v, %t; want wildcard profile", selected, ok)
+	}
+}
+
+func TestMacProfileEntitlementValueRejectsUnsafeWildcardsAndLists(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile any
+		target  any
+	}{
+		{name: "bare wildcard", profile: "*", target: "TEAM123.com.example.shared"},
+		{name: "partial suffix wildcard", profile: "TEAM123*", target: "TEAM123.com.example.shared"},
+		{name: "middle wildcard", profile: "TEAM*.shared", target: "TEAM123.com.example.shared"},
+		{name: "mixed profile list", profile: []any{"TEAM123.*", 42}, target: []string{"TEAM123.com.example.shared"}},
+		{name: "wildcard target", profile: []string{"TEAM123.*"}, target: []string{"TEAM123.*"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if macProfileEntitlementValuePermits(tt.profile, tt.target) {
+				t.Fatalf("profile value %#v permitted target %#v", tt.profile, tt.target)
+			}
+		})
+	}
+}
+
+func TestResolveMacManualExportOptionsUsesSelectedCertificateFingerprints(t *testing.T) {
+	archiveInfo := macArchiveExportInfo{ArchiveInfo: exportoptionsgenerator.ArchiveInfo{
+		AppBundleID: "com.example.demo",
+		EntitlementsByBundleID: map[string]plistutil.PlistData{
+			"com.example.demo": {"keychain-access-groups": []string{"TEAM123.com.example.shared"}},
+		},
+	}}
+	profiles := []profileutil.ProvisioningProfileInfoModel{{
+		UUID: "matching", Name: "matching", BundleID: "com.example.demo", TeamID: "TEAM123",
+		Type: profileutil.ProfileTypeMacOs, ExportType: legacyexportoptions.MethodAppStoreConnect,
+		ExpirationDate: time.Now().Add(time.Hour), DeveloperCertificates: []certificateutil.CertificateInfoModel{{Serial: "BBB"}},
+		Entitlements: plistutil.PlistData{"keychain-access-groups": []string{"TEAM123.com.example.shared"}},
+	}}
+	certificates := []certificateutil.CertificateInfoModel{
+		{CommonName: "Mac App Distribution: Example (TEAM123)", TeamID: "TEAM123", Serial: "AAA", SHA1Fingerprint: "APP-WRONG"},
+		{CommonName: "Mac App Distribution: Example (TEAM123)", TeamID: "TEAM123", Serial: "BBB", SHA1Fingerprint: "APP-MATCHING"},
+	}
+	installers := []certificateutil.CertificateInfoModel{{
+		CommonName: "Mac Installer Distribution: Example (TEAM123)", TeamID: "TEAM123", Serial: "INSTALLER", SHA1Fingerprint: "INSTALLER-SHA1",
+	}}
+
+	manual, err := resolveMacManualExportOptions(archiveInfo, profiles, certificates, installers, "TEAM123")
+	if err != nil {
+		t.Fatalf("resolveMacManualExportOptions() error: %v", err)
+	}
+	if manual.SigningCertificate != "APP-MATCHING" {
+		t.Fatalf("signing certificate = %q, want selected certificate fingerprint", manual.SigningCertificate)
+	}
+	if manual.InstallerSigningCertificate != "INSTALLER-SHA1" {
+		t.Fatalf("installer signing certificate = %q, want selected certificate fingerprint", manual.InstallerSigningCertificate)
+	}
+}
+
+func TestInstalledIdentityInfosPreservesExactPrivateKeyIdentities(t *testing.T) {
+	const (
+		firstIdentity   = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+		secondIdentity  = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+		certificateOnly = "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"
+	)
+	for _, policy := range []string{"codesigning", "macappstore"} {
+		t.Run(policy, func(t *testing.T) {
+			originalCommand := macSecurityCommandContextFn
+			macSecurityCommandContextFn = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+				if name != "/usr/bin/security" {
+					t.Fatalf("security path = %q", name)
+				}
+				if got := strings.Join(args, " "); got != "find-identity -v -p "+policy {
+					t.Fatalf("security arguments = %q", got)
+				}
+				output := fmt.Sprintf("  1) %s \"Shared Name\"\n  2) %s \"Shared Name\"\n     2 valid identities found\n", firstIdentity, secondIdentity)
+				return exec.CommandContext(ctx, "/usr/bin/printf", "%s", output)
+			}
+			t.Cleanup(func() { macSecurityCommandContextFn = originalCommand })
+
+			certificates := []certificateutil.CertificateInfoModel{
+				{CommonName: "Shared Name", SHA1Fingerprint: certificateOnly},
+				{CommonName: "Shared Name", SHA1Fingerprint: strings.ToLower(secondIdentity)},
+				{CommonName: "Shared Name", SHA1Fingerprint: firstIdentity},
+			}
+			identities, err := installedIdentityInfos(t.Context(), policy, func(context.Context) ([]certificateutil.CertificateInfoModel, error) {
+				return certificates, nil
+			})
+			if err != nil {
+				t.Fatalf("installedIdentityInfos() error: %v", err)
+			}
+			if len(identities) != 2 || !strings.EqualFold(identities[0].SHA1Fingerprint, firstIdentity) || !strings.EqualFold(identities[1].SHA1Fingerprint, secondIdentity) {
+				t.Fatalf("identities = %#v, want exact private-key-backed fingerprints in security order", identities)
+			}
+		})
+	}
+}
+
+func TestInstalledIdentityInfosRejectsUnmatchedIdentityFingerprint(t *testing.T) {
+	const identity = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+	originalCommand := macSecurityCommandContextFn
+	macSecurityCommandContextFn = func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, "/usr/bin/printf", "%s", "1) "+identity+" \"Identity\"\n")
+	}
+	t.Cleanup(func() { macSecurityCommandContextFn = originalCommand })
+
+	_, err := installedIdentityInfos(t.Context(), "codesigning", func(context.Context) ([]certificateutil.CertificateInfoModel, error) {
+		return []certificateutil.CertificateInfoModel{{CommonName: "Identity", SHA1Fingerprint: "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"}}, nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "did not match an accessible certificate") {
+		t.Fatalf("installedIdentityInfos() error = %v, want unmatched identity rejection", err)
+	}
+}
+
+func TestInstalledCodesignIdentityInfosReadsCertificateMetadataWithContext(t *testing.T) {
+	certificate, certificatePEM := testInstalledIdentityCertificate(t, "Mac App Distribution: Example (TEAM123)")
+	originalCommand := macSecurityCommandContextFn
+	macSecurityCommandContextFn = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		if name != "/usr/bin/security" {
+			t.Fatalf("security path = %q", name)
+		}
+		switch got := strings.Join(args, " "); got {
+		case "find-identity -v -p codesigning":
+			return exec.CommandContext(ctx, "/usr/bin/printf", "%s", "1) "+certificate.SHA1Fingerprint+" \""+certificate.CommonName+"\"\n")
+		case "find-certificate -a -p":
+			return exec.CommandContext(ctx, "/usr/bin/printf", "%s", string(certificatePEM))
+		default:
+			t.Fatalf("security arguments = %q", got)
+			return nil
+		}
+	}
+	t.Cleanup(func() { macSecurityCommandContextFn = originalCommand })
+
+	identities, err := installedCodesignIdentityInfos(t.Context())
+	if err != nil {
+		t.Fatalf("installedCodesignIdentityInfos() error: %v", err)
+	}
+	if len(identities) != 1 || !strings.EqualFold(identities[0].SHA1Fingerprint, certificate.SHA1Fingerprint) || identities[0].CommonName != certificate.CommonName {
+		t.Fatalf("identities = %#v, want certificate metadata for exact identity", identities)
+	}
+}
+
+func TestInstalledCodesignIdentityInfosCancelsCertificateMetadataEnumeration(t *testing.T) {
+	const identity = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+	originalCommand := macSecurityCommandContextFn
+	macSecurityCommandContextFn = func(ctx context.Context, _ string, args ...string) *exec.Cmd {
+		switch got := strings.Join(args, " "); got {
+		case "find-identity -v -p codesigning":
+			return exec.CommandContext(ctx, "/usr/bin/printf", "%s", "1) "+identity+" \"Identity\"\n")
+		case "find-certificate -a -p":
+			return exec.CommandContext(ctx, "/bin/sh", "-c", "sleep 10")
+		default:
+			t.Fatalf("security arguments = %q", got)
+			return nil
+		}
+	}
+	t.Cleanup(func() { macSecurityCommandContextFn = originalCommand })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	_, err := installedCodesignIdentityInfos(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("installedCodesignIdentityInfos() error = %v, want context deadline exceeded", err)
+	}
+}
+
+func TestInstalledIdentityFingerprintsRejectsMalformedAndOversizedOutput(t *testing.T) {
+	if _, err := parseInstalledIdentityFingerprints([]byte("1) NOT-A-SHA1 \"Identity\"\n")); err == nil {
+		t.Fatal("expected malformed identity fingerprint rejection")
+	}
+
+	originalCommand := macSecurityCommandContextFn
+	originalRun := macSecurityRunCommandFn
+	macSecurityCommandContextFn = func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, "/usr/bin/true")
+	}
+	macSecurityRunCommandFn = func(command *exec.Cmd) error {
+		_, err := command.Stdout.Write(make([]byte, macSecurityOutputMaxBytes+1))
+		return err
+	}
+	t.Cleanup(func() {
+		macSecurityCommandContextFn = originalCommand
+		macSecurityRunCommandFn = originalRun
+	})
+	if _, err := installedIdentityFingerprints(t.Context(), "codesigning"); err == nil || !strings.Contains(err.Error(), "output exceeded") {
+		t.Fatalf("installedIdentityFingerprints() error = %v, want bounded-output rejection", err)
+	}
+}
+
+func TestInstalledIdentityFingerprintsPreservesCancellation(t *testing.T) {
+	originalCommand := macSecurityCommandContextFn
+	macSecurityCommandContextFn = func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, "/bin/sh", "-c", "sleep 10")
+	}
+	t.Cleanup(func() { macSecurityCommandContextFn = originalCommand })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	_, err := installedIdentityFingerprints(ctx, "macappstore")
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("installedIdentityFingerprints() error = %v, want context deadline exceeded", err)
+	}
+}
+
+func TestResolveMacManualExportOptionsPairsInstallerWithInferredApplicationTeam(t *testing.T) {
+	archiveInfo := macArchiveExportInfo{ArchiveInfo: exportoptionsgenerator.ArchiveInfo{
+		AppBundleID: "com.example.demo",
+		EntitlementsByBundleID: map[string]plistutil.PlistData{
+			"com.example.demo": {"com.apple.security.app-sandbox": true},
+		},
+	}}
+	certificates := []certificateutil.CertificateInfoModel{
+		{CommonName: "Apple Distribution: A", TeamID: "TEAMA", Serial: "APP-A"},
+		{CommonName: "Apple Distribution: B", TeamID: "TEAMB", Serial: "APP-B"},
+	}
+	installers := []certificateutil.CertificateInfoModel{
+		{CommonName: "3rd Party Mac Developer Installer: A", TeamID: "TEAMB", Serial: "INSTALLER-B"},
+		{CommonName: "3rd Party Mac Developer Installer: Z", TeamID: "TEAMA", Serial: "INSTALLER-A"},
+	}
+
+	manual, err := resolveMacManualExportOptions(archiveInfo, nil, certificates, installers, "")
+	if err != nil {
+		t.Fatalf("resolveMacManualExportOptions() error: %v", err)
+	}
+	if manual.TeamID != "TEAMA" || manual.SigningCertificate != "Apple Distribution: A" || manual.InstallerSigningCertificate != "3rd Party Mac Developer Installer: Z" {
+		t.Fatalf("manual identities were not paired by inferred team: %#v", manual)
+	}
+}
+
+func TestResolveMacManualExportOptionsRequiresInstallerIdentity(t *testing.T) {
+	archiveInfo := macArchiveExportInfo{ArchiveInfo: exportoptionsgenerator.ArchiveInfo{
+		AppBundleID: "com.example.demo",
+		EntitlementsByBundleID: map[string]plistutil.PlistData{
+			"com.example.demo": {},
+		},
+	}}
+	certificates := []certificateutil.CertificateInfoModel{{CommonName: "Mac App Distribution: Example (TEAM123)", TeamID: "TEAM123"}}
+
+	_, err := resolveMacManualExportOptions(archiveInfo, nil, certificates, nil, "TEAM123")
+	if err == nil || !strings.Contains(err.Error(), "installer certificate") {
+		t.Fatalf("expected installer identity error, got %v", err)
+	}
+	wrongTeam := []certificateutil.CertificateInfoModel{{CommonName: "Mac Installer Distribution: Other", TeamID: "OTHER"}}
+	_, err = resolveMacManualExportOptions(archiveInfo, nil, certificates, wrongTeam, "TEAM123")
+	if err == nil || !strings.Contains(err.Error(), "installer certificate") {
+		t.Fatalf("expected wrong-team installer identity error, got %v", err)
 	}
 }
 
 func TestManualExportOptionsFromHashPreservesCloudKitEnvironment(t *testing.T) {
 	manual, err := manualExportOptionsFromHash(map[string]interface{}{
-		"teamID":                     "TEAM123",
-		"signingCertificate":         "Apple Distribution: Example (TEAM123)",
-		"provisioningProfiles":       map[string]string{"com.example.demo": "profile-uuid"},
-		"iCloudContainerEnvironment": "Production",
+		"teamID":                      "TEAM123",
+		"signingCertificate":          "Apple Distribution: Example (TEAM123)",
+		"installerSigningCertificate": "Mac Installer Distribution",
+		"provisioningProfiles":        map[string]string{"com.example.demo": "profile-uuid"},
+		"iCloudContainerEnvironment":  "Production",
 	})
 	if err != nil {
 		t.Fatalf("manualExportOptionsFromHash() error: %v", err)
@@ -111,4 +953,210 @@ func TestManualExportOptionsFromHashPreservesCloudKitEnvironment(t *testing.T) {
 	if fmt.Sprint(payload["iCloudContainerEnvironment"]) != "Production" {
 		t.Fatalf("iCloudContainerEnvironment = %#v, want Production", payload["iCloudContainerEnvironment"])
 	}
+	if fmt.Sprint(payload["installerSigningCertificate"]) != "Mac Installer Distribution" {
+		t.Fatalf("installerSigningCertificate = %#v, want Mac Installer Distribution", payload["installerSigningCertificate"])
+	}
+}
+
+func writeMacExportOptionsTestArchive(t *testing.T) string {
+	t.Helper()
+	const teamID = "TEAM123"
+
+	archivePath := filepath.Join(t.TempDir(), "Demo.xcarchive")
+	appPath := filepath.Join(archivePath, "Products", "Applications", "Demo.app")
+	if err := os.MkdirAll(filepath.Join(archivePath, "Products", "Applications", "AAA-Decoy.app"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(appPath, "Contents", "MacOS"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(appPath, "Contents", "PlugIns", "Share.appex", "Contents", "MacOS"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(appPath, "Contents", "XPCServices", "Helper.xpc", "Contents", "MacOS"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(appPath, "Contents", "Library", "LoginItems", "Login.app", "Contents", "MacOS"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(appPath, "Contents", "Library", "SystemExtensions", "Network.systemextension", "Contents", "MacOS"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(appPath, "Contents", "Library", "SystemExtensions", "Driver.dext", "Contents", "MacOS"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	archiveData, err := plist.Marshal(map[string]any{
+		"ApplicationProperties": map[string]any{
+			"ApplicationPath":    "Applications/Demo.app",
+			"CFBundleIdentifier": "com.example.demo",
+			"Team":               teamID,
+		},
+	}, plist.XMLFormat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(archivePath, "Info.plist"), archiveData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	appData, err := plist.Marshal(map[string]any{
+		"CFBundleIdentifier":         "com.example.demo",
+		"CFBundleExecutable":         "Demo",
+		"DTPlatformName":             "macosx",
+		"CFBundleSupportedPlatforms": []string{"macosx"},
+	}, plist.XMLFormat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(appPath, "Contents", "Info.plist"), appData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(appPath, "Contents", "MacOS", "Demo"), []byte("binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	extensionData, err := plist.Marshal(map[string]any{
+		"CFBundleIdentifier": "com.example.demo.share",
+		"CFBundleExecutable": "Share",
+		"DTPlatformName":     "macosx",
+	}, plist.XMLFormat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(appPath, "Contents", "PlugIns", "Share.appex", "Contents", "Info.plist"), extensionData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(appPath, "Contents", "PlugIns", "Share.appex", "Contents", "MacOS", "Share"), []byte("binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	helperData, err := plist.Marshal(map[string]any{
+		"CFBundleIdentifier": "com.example.demo.helper",
+		"CFBundleExecutable": "Helper",
+		"DTPlatformName":     "macosx",
+	}, plist.XMLFormat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(appPath, "Contents", "XPCServices", "Helper.xpc", "Contents", "Info.plist"), helperData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(appPath, "Contents", "XPCServices", "Helper.xpc", "Contents", "MacOS", "Helper"), []byte("binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, nested := range []struct {
+		path       string
+		bundleID   string
+		executable string
+	}{
+		{path: filepath.Join("Contents", "Library", "LoginItems", "Login.app"), bundleID: "com.example.demo.login", executable: "Login"},
+		{path: filepath.Join("Contents", "Library", "SystemExtensions", "Network.systemextension"), bundleID: "com.example.demo.network-extension", executable: "Network"},
+		{path: filepath.Join("Contents", "Library", "SystemExtensions", "Driver.dext"), bundleID: "com.example.demo.driver-extension", executable: "Driver"},
+		{path: filepath.Join("Contents", "PlugIns", "Support.bundle"), bundleID: "com.example.demo.bundle", executable: "Support"},
+		{path: filepath.Join("Contents", "PlugIns", "Importer.plugin"), bundleID: "com.example.demo.plugin", executable: "Importer"},
+		{path: filepath.Join("Contents", "Library", "QuickLook", "Preview.qlgenerator"), bundleID: "com.example.demo.quicklook", executable: "Preview"},
+		{path: filepath.Join("Contents", "Library", "Spotlight", "Metadata.mdimporter"), bundleID: "com.example.demo.metadata-importer", executable: "Metadata"},
+	} {
+		data, err := plist.Marshal(map[string]any{
+			"CFBundleIdentifier": nested.bundleID,
+			"CFBundleExecutable": nested.executable,
+			"DTPlatformName":     "macosx",
+		}, plist.XMLFormat)
+		if err != nil {
+			t.Fatal(err)
+		}
+		bundlePath := filepath.Join(appPath, nested.path)
+		if err := os.MkdirAll(filepath.Join(bundlePath, "Contents", "MacOS"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(bundlePath, "Contents", "Info.plist"), data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(bundlePath, "Contents", "MacOS", nested.executable), []byte("binary"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return archivePath
+}
+
+func signedMacProvisioningProfile(t *testing.T, uuid string) []byte {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().Add(-time.Hour)
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		NotBefore:    now,
+		NotAfter:     now.Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certificate, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	profilePlist, err := plist.Marshal(map[string]any{
+		"UUID":                        uuid,
+		"Name":                        "Mac Profile " + uuid,
+		"TeamName":                    "Example Team",
+		"TeamIdentifier":              []string{"TEAM123"},
+		"ApplicationIdentifierPrefix": []string{"TEAM123"},
+		"Platform":                    []string{"osx"},
+		"CreationDate":                now,
+		"ExpirationDate":              now.Add(24 * time.Hour),
+		"DeveloperCertificates":       [][]byte{der},
+		"Entitlements": map[string]any{
+			"application-identifier":              "TEAM123.com.example.demo",
+			"com.apple.developer.team-identifier": "TEAM123",
+			"get-task-allow":                      false,
+		},
+	}, plist.XMLFormat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signed, err := pkcs7.NewSignedData(profilePlist)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := signed.AddSigner(certificate, key, pkcs7.SignerInfoConfig{}); err != nil {
+		t.Fatal(err)
+	}
+	data, err := signed.Finish()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func testInstalledIdentityCertificate(t *testing.T, commonName string) (certificateutil.CertificateInfoModel, []byte) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().Add(-time.Hour)
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(42),
+		Subject: pkix.Name{
+			CommonName:         commonName,
+			Organization:       []string{"Example Team"},
+			OrganizationalUnit: []string{"TEAM123"},
+		},
+		NotBefore: now,
+		NotAfter:  now.Add(24 * time.Hour),
+		KeyUsage:  x509.KeyUsageDigitalSignature,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certificate, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return certificateutil.NewCertificateInfo(*certificate, nil), pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
 }

--- a/internal/xcode/export_options_macos.go
+++ b/internal/xcode/export_options_macos.go
@@ -991,7 +991,7 @@ func macBundleRequiresProvisioningProfile(entitlements plistutil.PlistData, hasE
 // and ordinary sandbox/hardened-runtime claims. Unknown capability entitlements
 // fail closed unless the archive carried an embedded profile.
 func macEntitlementDoesNotRequireProfile(key string) bool {
-	if key == "com.apple.developer.team-identifier" || key == "com.apple.security.app-sandbox" || key == "com.apple.security.inherit" || key == "com.apple.security.get-task-allow" || key == "com.apple.security.print" {
+	if key == "com.apple.developer.team-identifier" || key == "com.apple.security.app-sandbox" || key == "com.apple.security.inherit" || key == "com.apple.security.get-task-allow" || key == "com.apple.security.print" || key == "com.apple.security.scripting-targets" {
 		return true
 	}
 	for _, prefix := range []string{

--- a/internal/xcode/export_options_macos.go
+++ b/internal/xcode/export_options_macos.go
@@ -1111,25 +1111,112 @@ func macProfileEntitlementsPermitTarget(profileEntitlements, targetEntitlements 
 }
 
 func macProfileEntitlementValuePermitsForExport(key string, profileValue, targetValue any) bool {
-	if macProfileEntitlementValuePermits(profileValue, targetValue) {
-		return true
+	switch key {
+	case "com.apple.developer.icloud-container-environment":
+		return macICloudEnvironmentPermits(profileValue, targetValue)
+	case "com.apple.developer.icloud-services":
+		return macICloudServicesPermit(profileValue, targetValue)
+	case "com.apple.developer.aps-environment",
+		"com.apple.developer.devicecheck.appattest-environment":
+		return macLowercaseEnvironmentPermits(profileValue, targetValue)
+	default:
+		return macProfileEntitlementValuePermits(profileValue, targetValue)
+	}
+}
+
+func macICloudEnvironmentPermits(profileValue, targetValue any) bool {
+	target, ok := targetValue.(string)
+	if !ok || (target != "Development" && target != "Production") {
+		return false
 	}
 
-	profileString, profileIsString := profileValue.(string)
-	targetString, targetIsString := targetValue.(string)
+	if profile, ok := profileValue.(string); ok {
+		return macCanonicalEnvironmentPermits(profile, target, "Development", "Production")
+	}
+	profiles, ok := macStringArray(profileValue)
+	if !ok || len(profiles) == 0 {
+		return false
+	}
+	permitted := false
+	for _, profile := range profiles {
+		if profile != "Development" && profile != "Production" {
+			return false
+		}
+		if macCanonicalEnvironmentPermits(profile, target, "Development", "Production") {
+			permitted = true
+		}
+	}
+	return permitted
+}
+
+func macLowercaseEnvironmentPermits(profileValue, targetValue any) bool {
+	profile, profileIsString := profileValue.(string)
+	target, targetIsString := targetValue.(string)
 	if !profileIsString || !targetIsString {
 		return false
 	}
+	return macCanonicalEnvironmentPermits(profile, target, "development", "production")
+}
 
-	switch key {
-	case "com.apple.developer.icloud-container-environment":
-		return profileString == "Production" && targetString == "Development"
-	case "com.apple.developer.aps-environment",
-		"com.apple.developer.devicecheck.appattest-environment":
-		return profileString == "production" && targetString == "development"
-	default:
+func macCanonicalEnvironmentPermits(profile, target, development, production string) bool {
+	if (profile != development && profile != production) || (target != development && target != production) {
 		return false
 	}
+	return profile == target || (profile == production && target == development)
+}
+
+func macICloudServicesPermit(profileValue, targetValue any) bool {
+	targetServices, ok := macStringArray(targetValue)
+	if !ok || len(targetServices) == 0 || !macICloudServicesAreCanonical(targetServices) {
+		return false
+	}
+	if profile, ok := profileValue.(string); ok {
+		return profile == "*"
+	}
+	profileServices, ok := macStringArray(profileValue)
+	if !ok || len(profileServices) == 0 || !macICloudServicesAreCanonical(profileServices) {
+		return false
+	}
+	for _, target := range targetServices {
+		matched := false
+		for _, profile := range profileServices {
+			if profile == target {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	return true
+}
+
+func macStringArray(value any) ([]string, bool) {
+	array := reflect.ValueOf(value)
+	if !array.IsValid() || (array.Kind() != reflect.Slice && array.Kind() != reflect.Array) {
+		return nil, false
+	}
+	values := make([]string, 0, array.Len())
+	for index := 0; index < array.Len(); index++ {
+		value, ok := array.Index(index).Interface().(string)
+		if !ok {
+			return nil, false
+		}
+		values = append(values, value)
+	}
+	return values, true
+}
+
+func macICloudServicesAreCanonical(services []string) bool {
+	for _, service := range services {
+		switch service {
+		case "CloudDocuments", "CloudKit":
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func macProfileEntitlementValuePermits(profileValue, targetValue any) bool {

--- a/internal/xcode/export_options_macos.go
+++ b/internal/xcode/export_options_macos.go
@@ -1103,11 +1103,33 @@ func macProfileEntitlementsPermitTarget(profileEntitlements, targetEntitlements 
 			continue
 		}
 		profileValue, ok := profileEntitlements[key]
-		if !ok || !macProfileEntitlementValuePermits(profileValue, targetValue) {
+		if !ok || !macProfileEntitlementValuePermitsForExport(key, profileValue, targetValue) {
 			return false
 		}
 	}
 	return true
+}
+
+func macProfileEntitlementValuePermitsForExport(key string, profileValue, targetValue any) bool {
+	if macProfileEntitlementValuePermits(profileValue, targetValue) {
+		return true
+	}
+
+	profileString, profileIsString := profileValue.(string)
+	targetString, targetIsString := targetValue.(string)
+	if !profileIsString || !targetIsString {
+		return false
+	}
+
+	switch key {
+	case "com.apple.developer.icloud-container-environment":
+		return profileString == "Production" && targetString == "Development"
+	case "com.apple.developer.aps-environment",
+		"com.apple.developer.devicecheck.appattest-environment":
+		return profileString == "production" && targetString == "development"
+	default:
+		return false
+	}
 }
 
 func macProfileEntitlementValuePermits(profileValue, targetValue any) bool {

--- a/internal/xcode/export_options_macos.go
+++ b/internal/xcode/export_options_macos.go
@@ -1,0 +1,1219 @@
+//go:build darwin
+
+package xcode
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bitrise-io/go-xcode/certificateutil"
+	legacyexportoptions "github.com/bitrise-io/go-xcode/exportoptions"
+	"github.com/bitrise-io/go-xcode/v2/exportoptionsgenerator"
+	"github.com/bitrise-io/go-xcode/v2/plistutil"
+	"github.com/bitrise-io/go-xcode/v2/profileutil"
+	"github.com/fullsailor/pkcs7"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/infoplist"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/rootfs"
+	"github.com/rudrankriyam/App-Store-Connect-CLI/internal/secureopen"
+	"github.com/ryanuber/go-glob"
+	"howett.net/plist"
+)
+
+const (
+	macEmbeddedProfileMaxBytes     int64 = 16 << 20
+	macExecutableMaxBytes          int64 = 4 << 30
+	macProfileInventoryMaxEntries        = 100_000
+	macArchiveMaxEntries                 = 100_000
+	macArchiveMaxDepth                   = 128
+	macCodesignOutputMaxBytes            = infoplist.MaxBytes + 64<<10
+	macSecurityOutputMaxBytes            = 1 << 20
+	macSecurityCertificateMaxBytes       = 16 << 20
+)
+
+type macArchiveExportInfo struct {
+	exportoptionsgenerator.ArchiveInfo
+	EmbeddedProfiles map[string]profileutil.ProvisioningProfileInfoModel
+	SigningIdentity  string
+}
+
+var (
+	readMacArchiveExportInfoFn             = readMacArchiveExportInfo
+	installedMacProvisioningProfileInfosFn = installedMacProvisioningProfileInfos
+	installedCodesignIdentityInfosFn       = installedCodesignIdentityInfos
+	installedInstallerIdentityInfosFn      = installedInstallerIdentityInfos
+	macCodesignCommandContextFn            = exec.CommandContext
+	macSecurityCommandContextFn            = exec.CommandContext
+	macSecurityRunCommandFn                = func(command *exec.Cmd) error { return command.Run() }
+	macUserHomeDirFn                       = os.UserHomeDir
+	afterMacArchiveInitialLstatFn          func()
+)
+
+func generateMacManualExportOptions(ctx context.Context, archivePath, teamID string) (manualExportOptions, error) {
+	if err := contextError(ctx); err != nil {
+		return manualExportOptions{}, err
+	}
+
+	var manual manualExportOptions
+	if _, err := captureBitriseStdout(func() error {
+		archiveInfo, err := readMacArchiveExportInfoFn(ctx, archivePath)
+		if err != nil {
+			return err
+		}
+		profiles, err := installedMacProvisioningProfileInfosFn(ctx)
+		if err != nil {
+			return fmt.Errorf("read installed macOS provisioning profiles: %w", err)
+		}
+		certificates, err := installedCodesignIdentityInfosFn(ctx)
+		if err != nil {
+			return fmt.Errorf("read installed code-signing identities: %w", err)
+		}
+		installerCertificates, err := installedInstallerIdentityInfosFn(ctx)
+		if err != nil {
+			return fmt.Errorf("read installed installer-signing identities: %w", err)
+		}
+		manual, err = resolveMacManualExportOptions(archiveInfo, profiles, certificates, installerCertificates, teamID)
+		return err
+	}); err != nil {
+		return manualExportOptions{}, err
+	}
+	return manual, nil
+}
+
+func readMacArchiveExportInfo(ctx context.Context, archivePath string) (macArchiveExportInfo, error) {
+	if err := contextError(ctx); err != nil {
+		return macArchiveExportInfo{}, err
+	}
+	archivePath = filepath.Clean(strings.TrimSpace(archivePath))
+	info, err := os.Lstat(archivePath)
+	if err != nil {
+		return macArchiveExportInfo{}, fmt.Errorf("inspect macOS archive: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return macArchiveExportInfo{}, fmt.Errorf("macOS archive path must be a non-symlinked directory")
+	}
+	if afterMacArchiveInitialLstatFn != nil {
+		afterMacArchiveInitialLstatFn()
+	}
+	archiveRoot, err := rootfs.New(archivePath)
+	if err != nil {
+		return macArchiveExportInfo{}, fmt.Errorf("open macOS archive: %w", err)
+	}
+	defer archiveRoot.Close()
+	openedArchiveRoot, err := openNonSymlinkedSelectedRoot(archiveRoot, archivePath, info)
+	if err != nil {
+		return macArchiveExportInfo{}, fmt.Errorf("verify macOS archive root: %w", err)
+	}
+	if err := openedArchiveRoot.Close(); err != nil {
+		return macArchiveExportInfo{}, fmt.Errorf("close verified macOS archive root: %w", err)
+	}
+
+	applicationProperties, applicationPath, err := readMacArchiveApplicationProperties(archiveRoot)
+	if err != nil {
+		return macArchiveExportInfo{}, err
+	}
+	application, ok, err := readMacBundleExportInfo(ctx, archiveRoot, applicationPath, true)
+	if err != nil {
+		return macArchiveExportInfo{}, fmt.Errorf("read macOS archived application: %w", err)
+	}
+	if !ok {
+		return macArchiveExportInfo{}, fmt.Errorf("macOS archived application is missing executable bundle metadata")
+	}
+	expectedBundleID := strings.TrimSpace(coercePlistValueToString(applicationProperties["CFBundleIdentifier"]))
+	if application.BundleID == "" || expectedBundleID == "" || application.BundleID != expectedBundleID {
+		return macArchiveExportInfo{}, fmt.Errorf("macOS archived application bundle identifier %q does not match archive bundle identifier %q", application.BundleID, expectedBundleID)
+	}
+
+	result := macArchiveExportInfo{
+		ArchiveInfo: exportoptionsgenerator.ArchiveInfo{
+			AppBundleID: application.BundleID,
+			EntitlementsByBundleID: map[string]plistutil.PlistData{
+				application.BundleID: application.Entitlements,
+			},
+		},
+		EmbeddedProfiles: make(map[string]profileutil.ProvisioningProfileInfoModel),
+		SigningIdentity:  strings.TrimSpace(coercePlistValueToString(applicationProperties["SigningIdentity"])),
+	}
+	if application.Profile != nil {
+		result.EmbeddedProfiles[application.BundleID] = *application.Profile
+	}
+	nestedPaths, err := discoverNestedMacBundlePaths(ctx, archiveRoot, applicationPath)
+	if err != nil {
+		return macArchiveExportInfo{}, err
+	}
+	for _, nestedPath := range nestedPaths {
+		bundle, executable, err := readMacBundleExportInfo(ctx, archiveRoot, nestedPath, false)
+		if err != nil {
+			return macArchiveExportInfo{}, fmt.Errorf("read nested macOS executable bundle %q: %w", nestedPath, err)
+		}
+		if !executable {
+			continue
+		}
+		if _, duplicate := result.EntitlementsByBundleID[bundle.BundleID]; duplicate {
+			return macArchiveExportInfo{}, fmt.Errorf("duplicate macOS executable bundle identifier %q", bundle.BundleID)
+		}
+		result.EntitlementsByBundleID[bundle.BundleID] = bundle.Entitlements
+		if bundle.Profile != nil {
+			result.EmbeddedProfiles[bundle.BundleID] = *bundle.Profile
+		}
+	}
+	return result, nil
+}
+
+type macBundleExportInfo struct {
+	BundleID     string
+	Entitlements plistutil.PlistData
+	Profile      *profileutil.ProvisioningProfileInfoModel
+}
+
+func readMacArchiveApplicationProperties(archiveRoot rootfs.Root) (map[string]any, string, error) {
+	payload, err := readMacArchivePlist(archiveRoot, "Info.plist")
+	if err != nil {
+		return nil, "", fmt.Errorf("read macOS archive Info.plist: %w", err)
+	}
+	applicationProperties, ok := payload["ApplicationProperties"].(map[string]any)
+	if !ok {
+		return nil, "", fmt.Errorf("macOS archive Info.plist missing ApplicationProperties")
+	}
+	applicationRelativePath := strings.TrimSpace(coercePlistValueToString(applicationProperties["ApplicationPath"]))
+	cleanPath := filepath.Clean(filepath.FromSlash(applicationRelativePath))
+	if applicationRelativePath == "" || strings.ContainsRune(applicationRelativePath, 0) || filepath.IsAbs(cleanPath) || filepath.VolumeName(cleanPath) != "" || cleanPath == "." || cleanPath == ".." || strings.HasPrefix(cleanPath, ".."+string(filepath.Separator)) {
+		return nil, "", fmt.Errorf("macOS archive Info.plist contains unsafe ApplicationPath %q", applicationRelativePath)
+	}
+	applicationPath := filepath.ToSlash(filepath.Join("Products", cleanPath))
+	handle, err := archiveRoot.OpenDir(filepath.FromSlash(applicationPath))
+	if err != nil {
+		return nil, "", fmt.Errorf("open macOS archived application: %w", err)
+	}
+	if err := handle.Close(); err != nil {
+		return nil, "", fmt.Errorf("close macOS archived application: %w", err)
+	}
+	return applicationProperties, applicationPath, nil
+}
+
+func readMacBundleExportInfo(ctx context.Context, archiveRoot rootfs.Root, bundlePath string, required bool) (macBundleExportInfo, bool, error) {
+	infoPath := filepath.ToSlash(filepath.Join(bundlePath, "Contents", "Info.plist"))
+	payload, err := readMacArchivePlist(archiveRoot, infoPath)
+	if errors.Is(err, os.ErrNotExist) && !required {
+		return macBundleExportInfo{}, false, nil
+	}
+	if err != nil {
+		return macBundleExportInfo{}, false, err
+	}
+	bundleID := strings.TrimSpace(coercePlistValueToString(payload["CFBundleIdentifier"]))
+	if bundleID == "" {
+		return macBundleExportInfo{}, false, fmt.Errorf("info.plist is missing CFBundleIdentifier")
+	}
+	executableName := strings.TrimSpace(coercePlistValueToString(payload["CFBundleExecutable"]))
+	if executableName == "" && !required {
+		return macBundleExportInfo{}, false, nil
+	}
+	if executableName == "" || executableName == "." || executableName == ".." || executableName != filepath.Base(executableName) || strings.ContainsAny(executableName, `/\\`) || strings.ContainsRune(executableName, 0) {
+		return macBundleExportInfo{}, false, fmt.Errorf("info.plist contains unsafe CFBundleExecutable %q", executableName)
+	}
+	executablePath := filepath.ToSlash(filepath.Join(bundlePath, "Contents", "MacOS", executableName))
+	executable, err := archiveRoot.OpenFile(filepath.FromSlash(executablePath))
+	if errors.Is(err, os.ErrNotExist) && !required {
+		return macBundleExportInfo{}, false, nil
+	}
+	if err != nil {
+		return macBundleExportInfo{}, false, fmt.Errorf("open executable: %w", err)
+	}
+	defer executable.Close()
+	entitlements, err := readMacExecutableEntitlements(ctx, executable)
+	if err != nil {
+		return macBundleExportInfo{}, false, fmt.Errorf("read signed entitlements: %w", err)
+	}
+	profile, err := readEmbeddedMacProfile(archiveRoot, filepath.ToSlash(filepath.Join(bundlePath, "Contents", "embedded.provisionprofile")))
+	if err != nil {
+		return macBundleExportInfo{}, false, err
+	}
+	return macBundleExportInfo{BundleID: bundleID, Entitlements: entitlements, Profile: profile}, true, nil
+}
+
+func readMacArchivePlist(archiveRoot rootfs.Root, relativePath string) (map[string]any, error) {
+	data, err := archiveRoot.ReadFileLimited(filepath.FromSlash(relativePath), infoplist.MaxBytes)
+	if err != nil {
+		return nil, err
+	}
+	if err := infoplist.ValidateStructure(data); err != nil {
+		return nil, fmt.Errorf("validate %s: %w", relativePath, err)
+	}
+	var payload map[string]any
+	if _, err := plist.Unmarshal(data, &payload); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", relativePath, err)
+	}
+	if payload == nil {
+		return nil, fmt.Errorf("decode %s: expected a plist dictionary", relativePath)
+	}
+	return payload, nil
+}
+
+func readEmbeddedMacProfile(archiveRoot rootfs.Root, relativePath string) (*profileutil.ProvisioningProfileInfoModel, error) {
+	data, err := archiveRoot.ReadFileLimited(filepath.FromSlash(relativePath), macEmbeddedProfileMaxBytes)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read embedded macOS provisioning profile: %w", err)
+	}
+	profilePKCS7, err := pkcs7.Parse(data)
+	if err != nil {
+		return nil, fmt.Errorf("parse embedded macOS provisioning profile: %w", err)
+	}
+	if err := infoplist.ValidateStructure(profilePKCS7.Content); err != nil {
+		return nil, fmt.Errorf("validate embedded macOS provisioning profile: %w", err)
+	}
+	profile, err := profileutil.NewProvisioningProfileInfo(*profilePKCS7)
+	if err != nil {
+		return nil, fmt.Errorf("decode embedded macOS provisioning profile: %w", err)
+	}
+	return &profile, nil
+}
+
+func discoverNestedMacBundlePaths(ctx context.Context, archiveRoot rootfs.Root, applicationPath string) ([]string, error) {
+	type directory struct {
+		path  string
+		depth int
+	}
+	queue := []directory{{path: applicationPath}}
+	var bundlePaths []string
+	entryCount := 0
+	for len(queue) > 0 {
+		if err := contextError(ctx); err != nil {
+			return nil, err
+		}
+		current := queue[0]
+		queue = queue[1:]
+		if current.depth > macArchiveMaxDepth {
+			return nil, fmt.Errorf("macOS archive directory depth exceeds %d", macArchiveMaxDepth)
+		}
+		directoryHandle, err := archiveRoot.OpenDir(filepath.FromSlash(current.path))
+		if err != nil {
+			return nil, fmt.Errorf("open macOS archive directory %q: %w", current.path, err)
+		}
+		for {
+			if err := contextError(ctx); err != nil {
+				_ = directoryHandle.Close()
+				return nil, err
+			}
+			entries, readErr := directoryHandle.ReadDir(256)
+			if err := contextError(ctx); err != nil {
+				_ = directoryHandle.Close()
+				return nil, err
+			}
+			for _, entry := range entries {
+				if err := contextError(ctx); err != nil {
+					_ = directoryHandle.Close()
+					return nil, err
+				}
+				entryCount++
+				if entryCount > macArchiveMaxEntries {
+					_ = directoryHandle.Close()
+					return nil, fmt.Errorf("macOS archive contains more than %d entries", macArchiveMaxEntries)
+				}
+				entryPath := filepath.ToSlash(filepath.Join(current.path, entry.Name()))
+				if entry.Type()&os.ModeSymlink != 0 {
+					if isMacBundleLikePath(entryPath) {
+						_ = directoryHandle.Close()
+						return nil, fmt.Errorf("refusing symlinked macOS executable bundle %q", entryPath)
+					}
+					continue
+				}
+				if !entry.IsDir() {
+					continue
+				}
+				// Bundle extensions are extensible and custom executable bundles are
+				// valid. Treat every directory as a candidate, then require a safe
+				// Contents/Info.plist and matching Contents/MacOS executable before
+				// including it in the export inventory.
+				bundlePaths = append(bundlePaths, entryPath)
+				queue = append(queue, directory{path: entryPath, depth: current.depth + 1})
+			}
+			if errors.Is(readErr, io.EOF) {
+				break
+			}
+			if readErr != nil {
+				_ = directoryHandle.Close()
+				return nil, fmt.Errorf("read macOS archive directory %q: %w", current.path, readErr)
+			}
+		}
+		if err := directoryHandle.Close(); err != nil {
+			return nil, fmt.Errorf("close macOS archive directory %q: %w", current.path, err)
+		}
+	}
+	sort.Strings(bundlePaths)
+	return bundlePaths, nil
+}
+
+func isMacBundleLikePath(path string) bool {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".app", ".appex", ".bundle", ".dext", ".mdimporter", ".plugin", ".qlgenerator", ".systemextension", ".xpc":
+		return true
+	default:
+		return false
+	}
+}
+
+func readMacExecutableEntitlements(ctx context.Context, executable *os.File) (plistutil.PlistData, error) {
+	snapshotPath, cleanup, err := snapshotMacExecutable(ctx, executable)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	command := macCodesignCommandContextFn(ctx, "/usr/bin/codesign", "-d", "--entitlements", ":-", snapshotPath)
+	stdout := &macBoundedCapture{limit: macCodesignOutputMaxBytes}
+	stderr := &macBoundedCapture{limit: macCodesignOutputMaxBytes}
+	command.Stdout = stdout
+	command.Stderr = stderr
+	if err := command.Run(); err != nil {
+		if contextErr := ctx.Err(); contextErr != nil {
+			return nil, contextErr
+		}
+		return nil, fmt.Errorf("codesign failed: %w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	if stdout.overflow || stderr.overflow {
+		return nil, fmt.Errorf("codesign output exceeded the %d-byte limit", macCodesignOutputMaxBytes)
+	}
+	data := bytes.TrimSpace(stdout.Bytes())
+	if len(data) == 0 {
+		data = extractMacPlistDocument(stderr.Bytes())
+	}
+	if len(data) == 0 {
+		return plistutil.PlistData{}, nil
+	}
+	if len(data) > infoplist.MaxBytes {
+		return nil, fmt.Errorf("signed entitlements exceed %d bytes", infoplist.MaxBytes)
+	}
+	if err := infoplist.ValidateStructure(data); err != nil {
+		return nil, fmt.Errorf("validate signed entitlements: %w", err)
+	}
+	var entitlements plistutil.PlistData
+	if _, err := plist.Unmarshal(data, &entitlements); err != nil {
+		return nil, fmt.Errorf("decode signed entitlements: %w", err)
+	}
+	if entitlements == nil {
+		entitlements = plistutil.PlistData{}
+	}
+	return entitlements, nil
+}
+
+func snapshotMacExecutable(ctx context.Context, executable *os.File) (string, func(), error) {
+	if err := contextError(ctx); err != nil {
+		return "", nil, err
+	}
+	if executable == nil {
+		return "", nil, fmt.Errorf("macOS executable is nil")
+	}
+	before, err := executable.Stat()
+	if err != nil {
+		return "", nil, fmt.Errorf("inspect macOS executable: %w", err)
+	}
+	if !before.Mode().IsRegular() || before.Size() <= 0 || before.Size() > macExecutableMaxBytes {
+		return "", nil, fmt.Errorf("macOS executable size must be between 1 and %d bytes", macExecutableMaxBytes)
+	}
+	if _, err := executable.Seek(0, io.SeekStart); err != nil {
+		return "", nil, fmt.Errorf("seek macOS executable: %w", err)
+	}
+	directory, err := os.MkdirTemp("", ".asc-mac-executable-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("create private macOS executable directory: %w", err)
+	}
+	cleanupDirectory := func() { _ = os.Remove(directory) }
+	temporaryRoot, err := os.OpenRoot(directory)
+	if err != nil {
+		cleanupDirectory()
+		return "", nil, fmt.Errorf("open private macOS executable directory: %w", err)
+	}
+	cleanup := func() {
+		_ = temporaryRoot.Remove("Executable")
+		_ = temporaryRoot.Close()
+		cleanupDirectory()
+	}
+	temporary, err := secureopen.OpenNewPrivateFileNoFollowInRoot(temporaryRoot, "Executable", 0o700)
+	if err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("create private macOS executable snapshot: %w", err)
+	}
+	if err := secureopen.PreparePrivateFile(temporary, 0o700); err != nil {
+		_ = temporary.Close()
+		cleanup()
+		return "", nil, fmt.Errorf("secure private macOS executable snapshot: %w", err)
+	}
+	written, copyErr := copyMacExecutableContext(ctx, temporary, io.LimitReader(executable, before.Size()+1))
+	if copyErr == nil && written != before.Size() {
+		copyErr = fmt.Errorf("copied %d of %d bytes", written, before.Size())
+	}
+	if copyErr == nil {
+		after, statErr := executable.Stat()
+		if statErr != nil {
+			copyErr = statErr
+		} else if before.Size() != after.Size() || before.Mode() != after.Mode() || !before.ModTime().Equal(after.ModTime()) {
+			copyErr = fmt.Errorf("macOS executable changed during snapshot")
+		}
+	}
+	if copyErr == nil {
+		copyErr = temporary.Sync()
+	}
+	closeErr := temporary.Close()
+	if copyErr == nil {
+		copyErr = closeErr
+	}
+	if copyErr != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("snapshot macOS executable: %w", copyErr)
+	}
+	return filepath.Join(directory, "Executable"), cleanup, nil
+}
+
+func copyMacExecutableContext(ctx context.Context, destination io.Writer, source io.Reader) (int64, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	buffer := make([]byte, 64<<10)
+	var written int64
+	for {
+		if err := ctx.Err(); err != nil {
+			return written, err
+		}
+		read, readErr := source.Read(buffer)
+		if read > 0 {
+			if err := ctx.Err(); err != nil {
+				return written, err
+			}
+			count, writeErr := destination.Write(buffer[:read])
+			written += int64(count)
+			if writeErr != nil {
+				return written, writeErr
+			}
+			if count != read {
+				return written, io.ErrShortWrite
+			}
+		}
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				return written, nil
+			}
+			return written, readErr
+		}
+	}
+}
+
+type macBoundedCapture struct {
+	bytes.Buffer
+	limit    int
+	overflow bool
+}
+
+func (capture *macBoundedCapture) Write(data []byte) (int, error) {
+	original := len(data)
+	remaining := capture.limit - capture.Len()
+	if remaining <= 0 {
+		capture.overflow = true
+		return original, nil
+	}
+	if len(data) > remaining {
+		data = data[:remaining]
+		capture.overflow = true
+	}
+	_, _ = capture.Buffer.Write(data)
+	return original, nil
+}
+
+func extractMacPlistDocument(data []byte) []byte {
+	start := bytes.Index(data, []byte("<?xml"))
+	if start < 0 {
+		start = bytes.Index(data, []byte("<plist"))
+	}
+	endMarker := []byte("</plist>")
+	end := bytes.LastIndex(data, endMarker)
+	if start < 0 || end < start {
+		return nil
+	}
+	return bytes.TrimSpace(data[start : end+len(endMarker)])
+}
+
+func installedMacProvisioningProfileInfos(ctx context.Context) ([]profileutil.ProvisioningProfileInfoModel, error) {
+	if err := contextError(ctx); err != nil {
+		return nil, err
+	}
+	home, err := macUserHomeDirFn()
+	if err != nil {
+		return nil, fmt.Errorf("resolve home directory: %w", err)
+	}
+	directories := []string{
+		filepath.Join(home, "Library", "Developer", "Xcode", "UserData", "Provisioning Profiles"),
+		filepath.Join(home, "Library", "MobileDevice", "Provisioning Profiles"),
+	}
+	var profiles []profileutil.ProvisioningProfileInfoModel
+	for _, directory := range directories {
+		if err := contextError(ctx); err != nil {
+			return nil, err
+		}
+		found, err := readInstalledMacProvisioningProfiles(ctx, directory)
+		if err != nil {
+			return nil, err
+		}
+		profiles = append(profiles, found...)
+	}
+	if err := contextError(ctx); err != nil {
+		return nil, err
+	}
+	sort.SliceStable(profiles, func(i, j int) bool {
+		if profiles[i].UUID != profiles[j].UUID {
+			return profiles[i].UUID < profiles[j].UUID
+		}
+		return profiles[i].Name < profiles[j].Name
+	})
+	return profiles, nil
+}
+
+func readInstalledMacProvisioningProfiles(ctx context.Context, directory string) ([]profileutil.ProvisioningProfileInfoModel, error) {
+	if err := contextError(ctx); err != nil {
+		return nil, err
+	}
+	info, err := os.Lstat(directory)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("inspect macOS provisioning profile directory %q: %w", directory, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return nil, fmt.Errorf("macOS provisioning profile directory %q must be a non-symlinked directory", directory)
+	}
+	profileRoot, err := rootfs.New(directory)
+	if err != nil {
+		return nil, fmt.Errorf("open macOS provisioning profile directory %q: %w", directory, err)
+	}
+	defer profileRoot.Close()
+	openedRoot, err := openNonSymlinkedSelectedRoot(profileRoot, directory, info)
+	if err != nil {
+		return nil, fmt.Errorf("verify macOS provisioning profile directory %q: %w", directory, err)
+	}
+	defer openedRoot.Close()
+	directoryHandle, err := openedRoot.Open(".")
+	if err != nil {
+		return nil, fmt.Errorf("read macOS provisioning profile directory %q: %w", directory, err)
+	}
+	var entries []os.DirEntry
+	entryCount := 0
+	for {
+		if err := contextError(ctx); err != nil {
+			_ = directoryHandle.Close()
+			return nil, err
+		}
+		batch, readErr := directoryHandle.ReadDir(256)
+		if err := contextError(ctx); err != nil {
+			_ = directoryHandle.Close()
+			return nil, err
+		}
+		entryCount += len(batch)
+		if entryCount > macProfileInventoryMaxEntries {
+			_ = directoryHandle.Close()
+			return nil, fmt.Errorf("macOS provisioning profile directory %q contains more than %d entries", directory, macProfileInventoryMaxEntries)
+		}
+		entries = append(entries, batch...)
+		if errors.Is(readErr, io.EOF) {
+			break
+		}
+		if readErr != nil {
+			_ = directoryHandle.Close()
+			return nil, fmt.Errorf("read macOS provisioning profile directory %q: %w", directory, readErr)
+		}
+	}
+	if err := directoryHandle.Close(); err != nil {
+		return nil, fmt.Errorf("close macOS provisioning profile directory %q: %w", directory, err)
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+
+	profiles := make([]profileutil.ProvisioningProfileInfoModel, 0, len(entries))
+	for _, entry := range entries {
+		if err := contextError(ctx); err != nil {
+			return nil, err
+		}
+		extension := strings.ToLower(filepath.Ext(entry.Name()))
+		if extension != profileutil.MacExtension && extension != profileutil.IOSExtension {
+			continue
+		}
+		path := filepath.Join(directory, entry.Name())
+		if entry.Type()&os.ModeSymlink != 0 {
+			return nil, fmt.Errorf("refusing symlinked macOS provisioning profile %q", path)
+		}
+		file, err := secureopen.OpenExistingNoFollowInRoot(openedRoot, entry.Name())
+		if err != nil {
+			return nil, fmt.Errorf("open macOS provisioning profile %q: %w", path, err)
+		}
+		openedInfo, statErr := file.Stat()
+		if statErr != nil {
+			_ = file.Close()
+			return nil, fmt.Errorf("inspect macOS provisioning profile %q: %w", path, statErr)
+		}
+		if !openedInfo.Mode().IsRegular() {
+			_ = file.Close()
+			return nil, fmt.Errorf("macOS provisioning profile %q must be a regular file", path)
+		}
+		data, readErr := io.ReadAll(io.LimitReader(file, macEmbeddedProfileMaxBytes+1))
+		closeErr := file.Close()
+		if readErr != nil {
+			return nil, fmt.Errorf("read macOS provisioning profile %q: %w", path, readErr)
+		}
+		if closeErr != nil {
+			return nil, fmt.Errorf("close macOS provisioning profile %q: %w", path, closeErr)
+		}
+		if int64(len(data)) > macEmbeddedProfileMaxBytes {
+			return nil, fmt.Errorf("macOS provisioning profile %q exceeds the %d-byte size limit", path, macEmbeddedProfileMaxBytes)
+		}
+		if err := contextError(ctx); err != nil {
+			return nil, err
+		}
+		profilePKCS7, err := pkcs7.Parse(data)
+		if err != nil {
+			return nil, fmt.Errorf("parse macOS provisioning profile %q: %w", path, err)
+		}
+		if err := infoplist.ValidateStructure(profilePKCS7.Content); err != nil {
+			return nil, fmt.Errorf("validate macOS provisioning profile %q: %w", path, err)
+		}
+		profile, err := profileutil.NewProvisioningProfileInfo(*profilePKCS7)
+		if err != nil {
+			return nil, fmt.Errorf("decode macOS provisioning profile %q: %w", path, err)
+		}
+		if profile.Type != profileutil.ProfileTypeMacOs {
+			continue
+		}
+		profiles = append(profiles, profile)
+	}
+	return profiles, nil
+}
+
+func openNonSymlinkedSelectedRoot(root rootfs.Root, path string, expected os.FileInfo) (*os.Root, error) {
+	opened, err := root.OpenRoot()
+	if err != nil {
+		return nil, err
+	}
+	openedInfo, err := opened.Stat(".")
+	if err != nil {
+		_ = opened.Close()
+		return nil, err
+	}
+	selectedInfo, err := os.Lstat(path)
+	if err != nil {
+		_ = opened.Close()
+		return nil, err
+	}
+	if expected == nil || expected.Mode()&os.ModeSymlink != 0 || !expected.IsDir() || selectedInfo.Mode()&os.ModeSymlink != 0 || !selectedInfo.IsDir() || !os.SameFile(expected, openedInfo) || !os.SameFile(expected, selectedInfo) {
+		_ = opened.Close()
+		return nil, fmt.Errorf("selected path is no longer the same non-symlinked directory")
+	}
+	return opened, nil
+}
+
+func installedCodesignIdentityInfos(ctx context.Context) ([]certificateutil.CertificateInfoModel, error) {
+	return installedIdentityInfos(ctx, "codesigning", installedCertificateInfos)
+}
+
+func installedInstallerIdentityInfos(ctx context.Context) ([]certificateutil.CertificateInfoModel, error) {
+	return installedIdentityInfos(ctx, "macappstore", installedCertificateInfos)
+}
+
+func installedIdentityInfos(
+	ctx context.Context,
+	policy string,
+	readCertificates func(context.Context) ([]certificateutil.CertificateInfoModel, error),
+) ([]certificateutil.CertificateInfoModel, error) {
+	fingerprints, err := installedIdentityFingerprints(ctx, policy)
+	if err != nil {
+		return nil, err
+	}
+	if len(fingerprints) == 0 {
+		return []certificateutil.CertificateInfoModel{}, nil
+	}
+	if err := contextError(ctx); err != nil {
+		return nil, err
+	}
+	certificates, err := readCertificates(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := contextError(ctx); err != nil {
+		return nil, err
+	}
+	byFingerprint := make(map[string]certificateutil.CertificateInfoModel, len(certificates))
+	for _, certificate := range certificates {
+		fingerprint := strings.ToUpper(strings.TrimSpace(certificate.SHA1Fingerprint))
+		if sha1IdentitySelectorPattern.MatchString(fingerprint) {
+			byFingerprint[fingerprint] = certificate
+		}
+	}
+	identities := make([]certificateutil.CertificateInfoModel, 0, len(fingerprints))
+	for _, fingerprint := range fingerprints {
+		certificate, ok := byFingerprint[fingerprint]
+		if !ok {
+			return nil, fmt.Errorf("installed %s identity %s did not match an accessible certificate", policy, fingerprint)
+		}
+		identities = append(identities, certificate)
+	}
+	return identities, nil
+}
+
+func installedCertificateInfos(ctx context.Context) ([]certificateutil.CertificateInfoModel, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := contextError(ctx); err != nil {
+		return nil, err
+	}
+	command := macSecurityCommandContextFn(ctx, "/usr/bin/security", "find-certificate", "-a", "-p")
+	stdout := &macBoundedCapture{limit: macSecurityCertificateMaxBytes}
+	stderr := &macBoundedCapture{limit: macSecurityOutputMaxBytes}
+	command.Stdout = stdout
+	command.Stderr = stderr
+	if err := macSecurityRunCommandFn(command); err != nil {
+		if contextErr := ctx.Err(); contextErr != nil {
+			return nil, contextErr
+		}
+		return nil, fmt.Errorf("security find-certificate failed: %w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	if stdout.overflow || stderr.overflow {
+		return nil, fmt.Errorf("security find-certificate output exceeded its size limit")
+	}
+	return parseInstalledCertificateInfos(ctx, stdout.Bytes())
+}
+
+func parseInstalledCertificateInfos(ctx context.Context, data []byte) ([]certificateutil.CertificateInfoModel, error) {
+	remaining := bytes.TrimSpace(data)
+	certificates := make([]certificateutil.CertificateInfoModel, 0)
+	for len(remaining) > 0 {
+		if err := contextError(ctx); err != nil {
+			return nil, err
+		}
+		block, rest := pem.Decode(remaining)
+		if block == nil {
+			return nil, fmt.Errorf("security returned malformed certificate data")
+		}
+		if block.Type != "CERTIFICATE" {
+			return nil, fmt.Errorf("security returned unexpected PEM block %q", block.Type)
+		}
+		certificate, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("parse installed certificate: %w", err)
+		}
+		certificates = append(certificates, certificateutil.NewCertificateInfo(*certificate, nil))
+		remaining = bytes.TrimSpace(rest)
+	}
+	return certificates, nil
+}
+
+func installedIdentityFingerprints(ctx context.Context, policy string) ([]string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := contextError(ctx); err != nil {
+		return nil, err
+	}
+	switch policy {
+	case "codesigning", "macappstore":
+	default:
+		return nil, fmt.Errorf("unsupported security identity policy %q", policy)
+	}
+	command := macSecurityCommandContextFn(ctx, "/usr/bin/security", "find-identity", "-v", "-p", policy)
+	stdout := &macBoundedCapture{limit: macSecurityOutputMaxBytes}
+	stderr := &macBoundedCapture{limit: macSecurityOutputMaxBytes}
+	command.Stdout = stdout
+	command.Stderr = stderr
+	if err := macSecurityRunCommandFn(command); err != nil {
+		if contextErr := ctx.Err(); contextErr != nil {
+			return nil, contextErr
+		}
+		return nil, fmt.Errorf("security find-identity -p %s failed: %w: %s", policy, err, strings.TrimSpace(stderr.String()))
+	}
+	if stdout.overflow || stderr.overflow {
+		return nil, fmt.Errorf("security find-identity -p %s output exceeded the %d-byte limit", policy, macSecurityOutputMaxBytes)
+	}
+	return parseInstalledIdentityFingerprints(stdout.Bytes())
+}
+
+func parseInstalledIdentityFingerprints(data []byte) ([]string, error) {
+	lines := strings.Split(string(data), "\n")
+	seen := make(map[string]struct{})
+	fingerprints := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		closeParen := strings.IndexByte(line, ')')
+		if closeParen <= 0 {
+			continue
+		}
+		if _, err := strconv.Atoi(strings.TrimSpace(line[:closeParen])); err != nil {
+			continue
+		}
+		fields := strings.Fields(line[closeParen+1:])
+		if len(fields) == 0 || !sha1IdentitySelectorPattern.MatchString(fields[0]) {
+			return nil, fmt.Errorf("security returned a malformed identity fingerprint")
+		}
+		fingerprint := strings.ToUpper(fields[0])
+		if _, ok := seen[fingerprint]; ok {
+			continue
+		}
+		seen[fingerprint] = struct{}{}
+		fingerprints = append(fingerprints, fingerprint)
+	}
+	return fingerprints, nil
+}
+
+func resolveMacManualExportOptions(
+	archiveInfo macArchiveExportInfo,
+	profiles []profileutil.ProvisioningProfileInfoModel,
+	certificates []certificateutil.CertificateInfoModel,
+	installerCertificates []certificateutil.CertificateInfoModel,
+	teamID string,
+) (manualExportOptions, error) {
+	if strings.TrimSpace(archiveInfo.AppBundleID) == "" {
+		return manualExportOptions{}, fmt.Errorf("macOS archive is missing the application bundle identifier")
+	}
+	if len(archiveInfo.EntitlementsByBundleID) == 0 {
+		return manualExportOptions{}, fmt.Errorf("macOS archive is missing application entitlements")
+	}
+
+	bundleIDs := make([]string, 0, len(archiveInfo.EntitlementsByBundleID))
+	for bundleID := range archiveInfo.EntitlementsByBundleID {
+		if strings.TrimSpace(bundleID) != "" {
+			bundleIDs = append(bundleIDs, bundleID)
+		}
+	}
+	sort.Strings(bundleIDs)
+	if len(bundleIDs) == 0 {
+		return manualExportOptions{}, fmt.Errorf("macOS archive is missing executable bundle identifiers")
+	}
+
+	sort.SliceStable(certificates, func(i, j int) bool {
+		if certificates[i].CommonName != certificates[j].CommonName {
+			return certificates[i].CommonName < certificates[j].CommonName
+		}
+		return certificates[i].Serial < certificates[j].Serial
+	})
+	matchedApplicationIdentity := false
+	matchedInstallerIdentity := false
+	for _, certificate := range certificates {
+		if !isMacAppDistributionCertificate(certificate.CommonName) {
+			continue
+		}
+		effectiveTeamID := strings.TrimSpace(teamID)
+		if effectiveTeamID == "" {
+			effectiveTeamID = strings.TrimSpace(certificate.TeamID)
+		}
+		if effectiveTeamID == "" || certificate.TeamID != effectiveTeamID {
+			continue
+		}
+		matchedApplicationIdentity = true
+		installerCertificate, ok := selectMacInstallerCertificate(installerCertificates, effectiveTeamID)
+		if !ok {
+			continue
+		}
+		matchedInstallerIdentity = true
+		mapping := make(map[string]string, len(bundleIDs))
+		allMatched := true
+		for _, bundleID := range bundleIDs {
+			targetEntitlements := archiveInfo.EntitlementsByBundleID[bundleID]
+			_, hasEmbeddedProfile := archiveInfo.EmbeddedProfiles[bundleID]
+			if !macBundleRequiresProvisioningProfile(targetEntitlements, hasEmbeddedProfile) {
+				continue
+			}
+			profile, ok := selectMacProvisioningProfile(bundleID, archiveInfo.EmbeddedProfiles, profiles, certificate.Serial, effectiveTeamID, targetEntitlements)
+			if !ok {
+				allMatched = false
+				break
+			}
+			value := strings.TrimSpace(profile.UUID)
+			if value == "" {
+				value = strings.TrimSpace(profile.Name)
+			}
+			if value == "" {
+				allMatched = false
+				break
+			}
+			mapping[bundleID] = value
+		}
+		if allMatched {
+			return manualExportOptions{
+				TeamID:                       effectiveTeamID,
+				SigningCertificate:           macCertificateSpecifier(certificate),
+				InstallerSigningCertificate:  macCertificateSpecifier(installerCertificate),
+				ProvisioningProfiles:         mapping,
+				ICloudContainerEnvironment:   macICloudContainerEnvironment(archiveInfo.EntitlementsByBundleID),
+				ProvisioningProfilesOptional: len(mapping) == 0,
+			}, nil
+		}
+	}
+
+	if matchedApplicationIdentity && !matchedInstallerIdentity {
+		return manualExportOptions{}, fmt.Errorf("could not find an installed Mac App Store installer certificate matching an installed macOS distribution identity for team %q", teamID)
+	}
+	return manualExportOptions{}, fmt.Errorf("could not find one installed macOS distribution certificate and required App Store provisioning profile set for team %q covering bundle identifiers %s", teamID, strings.Join(bundleIDs, ", "))
+}
+
+func macCertificateSpecifier(certificate certificateutil.CertificateInfoModel) string {
+	if fingerprint := strings.TrimSpace(certificate.SHA1Fingerprint); fingerprint != "" {
+		return fingerprint
+	}
+	return strings.TrimSpace(certificate.CommonName)
+}
+
+func macBundleRequiresProvisioningProfile(entitlements plistutil.PlistData, hasEmbeddedProfile bool) bool {
+	if hasEmbeddedProfile {
+		return true
+	}
+	for key := range entitlements {
+		key = strings.TrimSpace(key)
+		if key == "" || macEntitlementDoesNotRequireProfile(key) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// macEntitlementDoesNotRequireProfile intentionally recognizes only identity
+// and ordinary sandbox/hardened-runtime claims. Unknown capability entitlements
+// fail closed unless the archive carried an embedded profile.
+func macEntitlementDoesNotRequireProfile(key string) bool {
+	if key == "com.apple.developer.team-identifier" || key == "com.apple.security.app-sandbox" || key == "com.apple.security.inherit" || key == "com.apple.security.get-task-allow" || key == "com.apple.security.print" {
+		return true
+	}
+	for _, prefix := range []string{
+		"com.apple.security.assets.",
+		"com.apple.security.automation.",
+		"com.apple.security.cs.",
+		"com.apple.security.device.",
+		"com.apple.security.files.",
+		"com.apple.security.network.",
+		"com.apple.security.personal-information.",
+		"com.apple.security.temporary-exception.",
+	} {
+		if strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func isMacAppDistributionCertificate(commonName string) bool {
+	name := strings.TrimSpace(commonName)
+	return strings.HasPrefix(name, "Apple Distribution:") ||
+		strings.HasPrefix(name, "Mac App Distribution:") ||
+		strings.HasPrefix(name, "3rd Party Mac Developer Application:")
+}
+
+func selectMacInstallerCertificate(certificates []certificateutil.CertificateInfoModel, teamID string) (certificateutil.CertificateInfoModel, bool) {
+	sort.SliceStable(certificates, func(i, j int) bool {
+		if certificates[i].CommonName != certificates[j].CommonName {
+			return certificates[i].CommonName < certificates[j].CommonName
+		}
+		return certificates[i].Serial < certificates[j].Serial
+	})
+	for _, certificate := range certificates {
+		if teamID != "" && certificate.TeamID != teamID {
+			continue
+		}
+		name := strings.TrimSpace(certificate.CommonName)
+		if strings.HasPrefix(name, "Mac Installer Distribution:") || strings.HasPrefix(name, "3rd Party Mac Developer Installer:") {
+			return certificate, true
+		}
+	}
+	return certificateutil.CertificateInfoModel{}, false
+}
+
+func selectMacProvisioningProfile(
+	bundleID string,
+	embeddedProfiles map[string]profileutil.ProvisioningProfileInfoModel,
+	profiles []profileutil.ProvisioningProfileInfoModel,
+	certificateSerial string,
+	teamID string,
+	targetEntitlements plistutil.PlistData,
+) (profileutil.ProvisioningProfileInfoModel, bool) {
+	candidates := make([]profileutil.ProvisioningProfileInfoModel, 0)
+	now := time.Now()
+	for _, profile := range profiles {
+		if profile.Type != profileutil.ProfileTypeMacOs || !macProfileIsAppStore(profile.ExportType) {
+			continue
+		}
+		if teamID != "" && profile.TeamID != teamID {
+			continue
+		}
+		if !profile.ExpirationDate.IsZero() && !now.Before(profile.ExpirationDate) {
+			continue
+		}
+		if !glob.Glob(profile.BundleID, bundleID) || !macProfileContainsCertificate(profile, certificateSerial) {
+			continue
+		}
+		if len(profileutil.MatchTargetAndProfileEntitlements(targetEntitlements, profile.Entitlements, profile.Type)) > 0 {
+			continue
+		}
+		if !macProfileEntitlementsPermitTarget(profile.Entitlements, targetEntitlements) {
+			continue
+		}
+		candidates = append(candidates, profile)
+	}
+	if len(candidates) == 0 {
+		return profileutil.ProvisioningProfileInfoModel{}, false
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		iExact := candidates[i].BundleID == bundleID
+		jExact := candidates[j].BundleID == bundleID
+		if iExact != jExact {
+			return iExact
+		}
+		iEmbedded := embeddedProfiles[bundleID].UUID != "" && embeddedProfiles[bundleID].UUID == candidates[i].UUID
+		jEmbedded := embeddedProfiles[bundleID].UUID != "" && embeddedProfiles[bundleID].UUID == candidates[j].UUID
+		if iEmbedded != jEmbedded {
+			return iEmbedded
+		}
+		if len(candidates[i].BundleID) != len(candidates[j].BundleID) {
+			return len(candidates[i].BundleID) > len(candidates[j].BundleID)
+		}
+		if !candidates[i].ExpirationDate.Equal(candidates[j].ExpirationDate) {
+			return candidates[i].ExpirationDate.After(candidates[j].ExpirationDate)
+		}
+		if candidates[i].UUID != candidates[j].UUID {
+			return candidates[i].UUID < candidates[j].UUID
+		}
+		return candidates[i].Name < candidates[j].Name
+	})
+	return candidates[0], true
+}
+
+func macProfileEntitlementsPermitTarget(profileEntitlements, targetEntitlements plistutil.PlistData) bool {
+	for key, targetValue := range targetEntitlements {
+		key = strings.TrimSpace(key)
+		if key == "" || macEntitlementDoesNotRequireProfile(key) {
+			continue
+		}
+		profileValue, ok := profileEntitlements[key]
+		if !ok || !macProfileEntitlementValuePermits(profileValue, targetValue) {
+			return false
+		}
+	}
+	return true
+}
+
+func macProfileEntitlementValuePermits(profileValue, targetValue any) bool {
+	profile := reflect.ValueOf(profileValue)
+	target := reflect.ValueOf(targetValue)
+	if !profile.IsValid() || !target.IsValid() {
+		return !profile.IsValid() && !target.IsValid()
+	}
+
+	if profile.Kind() != target.Kind() {
+		return false
+	}
+	switch profile.Kind() {
+	case reflect.String:
+		return macProfileStringEntitlementPermits(profile.String(), target.String())
+	case reflect.Slice, reflect.Array:
+		for profileIndex := 0; profileIndex < profile.Len(); profileIndex++ {
+			value, ok := profile.Index(profileIndex).Interface().(string)
+			if !ok || !macProfileEntitlementPatternIsSafe(value) {
+				return false
+			}
+		}
+		for targetIndex := 0; targetIndex < target.Len(); targetIndex++ {
+			value, ok := target.Index(targetIndex).Interface().(string)
+			if !ok || strings.Contains(value, "*") {
+				return false
+			}
+			permitted := false
+			for profileIndex := 0; profileIndex < profile.Len(); profileIndex++ {
+				if macProfileEntitlementValuePermits(profile.Index(profileIndex).Interface(), target.Index(targetIndex).Interface()) {
+					permitted = true
+					break
+				}
+			}
+			if !permitted {
+				return false
+			}
+		}
+		return true
+	case reflect.Map:
+		if profile.Type().Key().Kind() != reflect.String || target.Type().Key().Kind() != reflect.String {
+			return false
+		}
+		for _, targetKey := range target.MapKeys() {
+			var profileEntry reflect.Value
+			for _, profileKey := range profile.MapKeys() {
+				if profileKey.String() == targetKey.String() {
+					profileEntry = profile.MapIndex(profileKey)
+					break
+				}
+			}
+			if !profileEntry.IsValid() || !macProfileEntitlementValuePermits(profileEntry.Interface(), target.MapIndex(targetKey).Interface()) {
+				return false
+			}
+		}
+		return true
+	default:
+		return reflect.DeepEqual(profileValue, targetValue)
+	}
+}
+
+func macProfileStringEntitlementPermits(profileValue, targetValue string) bool {
+	if strings.Contains(targetValue, "*") || !macProfileEntitlementPatternIsSafe(profileValue) {
+		return false
+	}
+	return glob.Glob(profileValue, targetValue)
+}
+
+func macProfileEntitlementPatternIsSafe(value string) bool {
+	switch strings.Count(value, "*") {
+	case 0:
+		return true
+	case 1:
+		return strings.HasSuffix(value, ".*") && strings.TrimSuffix(value, ".*") != ""
+	default:
+		return false
+	}
+}
+
+func macProfileIsAppStore(method legacyexportoptions.Method) bool {
+	return method == legacyexportoptions.MethodAppStore || method == legacyexportoptions.MethodAppStoreConnect
+}
+
+func macProfileContainsCertificate(profile profileutil.ProvisioningProfileInfoModel, serial string) bool {
+	if strings.TrimSpace(serial) == "" {
+		return false
+	}
+	for _, certificate := range profile.DeveloperCertificates {
+		if certificate.Serial == serial {
+			return true
+		}
+	}
+	return false
+}
+
+func macICloudContainerEnvironment(entitlements map[string]plistutil.PlistData) string {
+	for _, values := range entitlements {
+		services, ok := values.GetStringArray("com.apple.developer.icloud-services")
+		if !ok {
+			continue
+		}
+		for _, service := range services {
+			if service == "CloudKit" || service == "CloudDocuments" {
+				return "Production"
+			}
+		}
+	}
+	return ""
+}

--- a/internal/xcode/export_options_macos.go
+++ b/internal/xcode/export_options_macos.go
@@ -899,6 +899,10 @@ func resolveMacManualExportOptions(
 	if len(bundleIDs) == 0 {
 		return manualExportOptions{}, fmt.Errorf("macOS archive is missing executable bundle identifiers")
 	}
+	effectiveTeamID, err := resolveMacManualExportTeamID(archiveInfo, certificates, teamID)
+	if err != nil {
+		return manualExportOptions{}, err
+	}
 
 	sort.SliceStable(certificates, func(i, j int) bool {
 		if certificates[i].CommonName != certificates[j].CommonName {
@@ -911,10 +915,6 @@ func resolveMacManualExportOptions(
 	for _, certificate := range certificates {
 		if !isMacAppDistributionCertificate(certificate.CommonName) {
 			continue
-		}
-		effectiveTeamID := strings.TrimSpace(teamID)
-		if effectiveTeamID == "" {
-			effectiveTeamID = strings.TrimSpace(certificate.TeamID)
 		}
 		if effectiveTeamID == "" || certificate.TeamID != effectiveTeamID {
 			continue
@@ -961,9 +961,110 @@ func resolveMacManualExportOptions(
 	}
 
 	if matchedApplicationIdentity && !matchedInstallerIdentity {
-		return manualExportOptions{}, fmt.Errorf("could not find an installed Mac App Store installer certificate matching an installed macOS distribution identity for team %q", teamID)
+		return manualExportOptions{}, fmt.Errorf("could not find an installed Mac App Store installer certificate matching an installed macOS distribution identity for team %q", effectiveTeamID)
 	}
-	return manualExportOptions{}, fmt.Errorf("could not find one installed macOS distribution certificate and required App Store provisioning profile set for team %q covering bundle identifiers %s", teamID, strings.Join(bundleIDs, ", "))
+	return manualExportOptions{}, fmt.Errorf("could not find one installed macOS distribution certificate and required App Store provisioning profile set for team %q covering bundle identifiers %s", effectiveTeamID, strings.Join(bundleIDs, ", "))
+}
+
+func resolveMacManualExportTeamID(
+	archiveInfo macArchiveExportInfo,
+	certificates []certificateutil.CertificateInfoModel,
+	requestedTeamID string,
+) (string, error) {
+	if requestedTeamID = strings.TrimSpace(requestedTeamID); requestedTeamID != "" {
+		return requestedTeamID, nil
+	}
+
+	archiveTeamIDs := make(map[string]struct{})
+	for _, profile := range archiveInfo.EmbeddedProfiles {
+		if teamID := strings.TrimSpace(profile.TeamID); teamID != "" {
+			archiveTeamIDs[teamID] = struct{}{}
+		}
+	}
+	for bundleID, entitlements := range archiveInfo.EntitlementsByBundleID {
+		value, ok := entitlements["com.apple.developer.team-identifier"]
+		if !ok {
+			continue
+		}
+		teamID, ok := value.(string)
+		teamID = strings.TrimSpace(teamID)
+		if !ok || teamID == "" {
+			return "", fmt.Errorf("macOS archive bundle %q has an invalid team identifier entitlement", bundleID)
+		}
+		archiveTeamIDs[teamID] = struct{}{}
+	}
+	if signingIdentity := strings.TrimSpace(archiveInfo.SigningIdentity); signingIdentity != "" && signingIdentity != "-" {
+		identityTeamIDs := make(map[string]struct{})
+		fingerprint := strings.ToUpper(signingIdentity)
+		for _, certificate := range certificates {
+			matchesFingerprint := sha1IdentitySelectorPattern.MatchString(fingerprint) && strings.EqualFold(strings.TrimSpace(certificate.SHA1Fingerprint), fingerprint)
+			matchesCommonName := strings.TrimSpace(certificate.CommonName) == signingIdentity
+			if !matchesFingerprint && !matchesCommonName {
+				continue
+			}
+			if teamID := strings.TrimSpace(certificate.TeamID); teamID != "" {
+				identityTeamIDs[teamID] = struct{}{}
+			}
+		}
+		identityTeamID, ok, err := oneMacTeamID(identityTeamIDs, fmt.Sprintf("archived signing identity %q matches multiple installed teams", signingIdentity))
+		if err != nil {
+			return "", err
+		}
+		if !ok {
+			identityTeamID = macSigningIdentityTeamID(signingIdentity)
+		}
+		if identityTeamID != "" {
+			archiveTeamIDs[identityTeamID] = struct{}{}
+		}
+	}
+	if teamID, ok, err := oneMacTeamID(archiveTeamIDs, "macOS archive contains conflicting team identifiers"); ok || err != nil {
+		return teamID, err
+	}
+
+	installedTeamIDs := make(map[string]struct{})
+	for _, certificate := range certificates {
+		if !isMacAppDistributionCertificate(certificate.CommonName) {
+			continue
+		}
+		if teamID := strings.TrimSpace(certificate.TeamID); teamID != "" {
+			installedTeamIDs[teamID] = struct{}{}
+		}
+	}
+	teamID, ok, err := oneMacTeamID(installedTeamIDs, "multiple installed teams provide macOS distribution identities")
+	if err != nil {
+		return "", fmt.Errorf("%w; specify --team-id", err)
+	}
+	if ok {
+		return teamID, nil
+	}
+	return "", nil
+}
+
+func macSigningIdentityTeamID(signingIdentity string) string {
+	openParen := strings.LastIndexByte(signingIdentity, '(')
+	if openParen < 0 || !strings.HasSuffix(signingIdentity, ")") {
+		return ""
+	}
+	teamID := strings.TrimSpace(signingIdentity[openParen+1 : len(signingIdentity)-1])
+	if !signingTeamIDPattern.MatchString(teamID) {
+		return ""
+	}
+	return teamID
+}
+
+func oneMacTeamID(teamIDs map[string]struct{}, conflictMessage string) (string, bool, error) {
+	if len(teamIDs) == 0 {
+		return "", false, nil
+	}
+	teams := make([]string, 0, len(teamIDs))
+	for teamID := range teamIDs {
+		teams = append(teams, teamID)
+	}
+	sort.Strings(teams)
+	if len(teams) > 1 {
+		return "", false, fmt.Errorf("%s: %s", conflictMessage, strings.Join(teams, ", "))
+	}
+	return teams[0], true, nil
 }
 
 func macCertificateSpecifier(certificate certificateutil.CertificateInfoModel) string {


### PR DESCRIPTION
## Summary

- generate manual Mac App Store export options for PKG workflows
- securely inventory executable bundles, macOS profiles, and exact application and installer identities
- support profile-free sandboxed apps, required profile mappings, canonical App Store entitlement transitions, and installed multi-team disambiguation

## Validation

- make build
- make format
- make check-docs
- make lint
- ASC_BYPASS_KEYCHAIN=1 make test
- full-branch Codex review against current main: no actionable findings
- fresh Tuist 4.202.2 project archived with Xcode 27; automatic and manual PKG paths reached their expected local signing boundaries
- adversarial archive symlink, traversal, nested-bundle, method, profile-shape, identity, and cancellation cases passed

No Apple upload, API mutation, keychain write, or user-project mutation was performed.