### PR TITLE
apps wall: add Dawn: Focus Alarm & Sessions

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -379,6 +379,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/a2/23/3c/a2233c68-f1ef-e5a4-4574-9ec5fa2a1d4c/AppIcon-0-1x_U007ephone-0-1-sRGB-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "Dawn: Focus Alarm & Sessions",
+    "link": "https://apps.apple.com/us/app/dawn-focus-alarm-sessions/id6776340634?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/a0/22/c6/a022c6e9-cb19-caf1-b098-c5777c309134/AppIcon-0-0-1x_U007ephone-0-1-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "DayBar",
     "link": "https://apps.apple.com/us/app/daybar/id6739052447?mt=12&uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/79/16/d5/7916d56d-bf7f-37a0-cb0c-bb50f04ed4f3/AppIcon-0-0-85-220-0-5-0-2x.png/512x512bb.png"


### PR DESCRIPTION
## Summary

- add `Dawn: Focus Alarm & Sessions` to the Wall of Apps

## Entry

- App ID: 6776340634
- App: Dawn: Focus Alarm & Sessions
- Link: https://apps.apple.com/us/app/dawn-focus-alarm-sessions/id6776340634?uo=4

## Notes

- Submitted via `asc apps wall submit`
