### PR TITLE
apps wall: add DAWN for Mastodon by Nightfox

### DIFF
--- a/docs/wall-of-apps.json
+++ b/docs/wall-of-apps.json
@@ -379,6 +379,11 @@
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/a2/23/3c/a2233c68-f1ef-e5a4-4574-9ec5fa2a1d4c/AppIcon-0-1x_U007ephone-0-1-sRGB-85-220-0.png/512x512bb.jpg"
   },
   {
+    "app": "DAWN for Mastodon by Nightfox",
+    "link": "https://apps.apple.com/us/app/dawn-for-mastodon-by-nightfox/id1668645019?uo=4",
+    "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/da/40/73/da4073fc-6cdb-a01e-3666-3575f021ff74/AppIcon10-0-0-1x_U007epad-0-0-0-1-0-sRGB-85-220.png/512x512bb.jpg"
+  },
+  {
     "app": "DayBar",
     "link": "https://apps.apple.com/us/app/daybar/id6739052447?mt=12&uo=4",
     "icon": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/79/16/d5/7916d56d-bf7f-37a0-cb0c-bb50f04ed4f3/AppIcon-0-0-85-220-0-5-0-2x.png/512x512bb.png"


### PR DESCRIPTION
## Summary

- add `DAWN for Mastodon by Nightfox` to the Wall of Apps

## Entry

- App ID: 1668645019
- App: DAWN for Mastodon by Nightfox
- Link: https://apps.apple.com/us/app/dawn-for-mastodon-by-nightfox/id1668645019?uo=4

## Notes

- Submitted via `asc apps wall submit`
